### PR TITLE
Cache LSP information

### DIFF
--- a/libs/sdk-bindings/src/uniffi_binding.rs
+++ b/libs/sdk-bindings/src/uniffi_binding.rs
@@ -238,7 +238,7 @@ impl BlockingBreezServices {
     }
 
     pub fn lsp_info(&self) -> SdkResult<LspInformation> {
-        rt().block_on(self.breez_services.lsp_info())
+        rt().block_on(self.breez_services.lsp_info(false))
     }
 
     pub fn open_channel_fee(

--- a/libs/sdk-core/src/binding.rs
+++ b/libs/sdk-core/src/binding.rs
@@ -215,7 +215,7 @@ pub fn fetch_lsp_info(id: String) -> Result<Option<LspInformation>> {
 
 /// See [BreezServices::lsp_info]
 pub fn lsp_info() -> Result<LspInformation> {
-    block_on(async { get_breez_services().await?.lsp_info().await })
+    block_on(async { get_breez_services().await?.lsp_info(false).await })
         .map_err(anyhow::Error::new::<SdkError>)
 }
 

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -1213,6 +1213,10 @@ impl OpeningFeeParamsMenu {
         Ok(())
     }
 
+    pub fn is_valid(&self) -> bool {
+        self.validate().is_ok()
+    }
+
     pub fn get_cheapest_opening_fee_params(&self) -> Result<OpeningFeeParams> {
         self.values.first().cloned().ok_or_else(|| {
             anyhow!("The LSP doesn't support opening new channels: Dynamic fees menu contains no values")

--- a/libs/sdk-core/src/persist/cache.rs
+++ b/libs/sdk-core/src/persist/cache.rs
@@ -1,10 +1,11 @@
-use crate::models::NodeState;
+use crate::{models::NodeState, LspInformation};
 
 use super::{db::SqliteStorage, error::PersistResult};
 
 const KEY_GL_CREDENTIALS: &str = "gl_credentials";
 const KEY_LAST_BACKUP_TIME: &str = "last_backup_time";
 const KEY_LAST_SYNC_TIME: &str = "last_sync_time";
+const KEY_LSP_INFORMATION: &str = "lsp_information";
 const KEY_NODE_STATE: &str = "node_state";
 const KEY_STATIC_BACKUP: &str = "static_backup";
 const KEY_WEBHOOK_URL: &str = "webhook_url";
@@ -43,6 +44,23 @@ impl SqliteStorage {
     pub fn get_node_state(&self) -> PersistResult<Option<NodeState>> {
         let state_str = self.get_cached_item(KEY_NODE_STATE)?;
         Ok(match state_str {
+            Some(str) => serde_json::from_str(str.as_str())?,
+            None => None,
+        })
+    }
+
+    pub fn remove_lsp_information(&self) -> PersistResult<()> {
+        self.delete_cached_item(KEY_LSP_INFORMATION)
+    }
+
+    pub fn set_lsp_information(&self, lsp_info: &LspInformation) -> PersistResult<()> {
+        let serialized_lsp_info = serde_json::to_string(lsp_info)?;
+        self.update_cached_item(KEY_LSP_INFORMATION, serialized_lsp_info)
+    }
+
+    pub fn get_lsp_information(&self) -> PersistResult<Option<LspInformation>> {
+        let lsp_info_str = self.get_cached_item(KEY_LSP_INFORMATION)?;
+        Ok(match lsp_info_str {
             Some(str) => serde_json::from_str(str.as_str())?,
             None => None,
         })

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -345,7 +345,7 @@ pub(crate) async fn handle_command(
             serde_json::to_string_pretty(&lsps).map_err(|e| e.into())
         }
         Commands::LspInfo {} => {
-            let lsp_info = sdk()?.lsp_info().await?;
+            let lsp_info = sdk()?.lsp_info(false).await?;
             serde_json::to_string_pretty(&lsp_info).map_err(|e| e.into())
         }
         Commands::ConnectLSP { lsp_id } => {


### PR DESCRIPTION
This PR caches the LspInformation and only refreshes it when a record of the opening fee params expires (hourly) or on reconnect. The aim is to help reduce the requests sent to the Breez server when we already have valid fee param promises.