### PR TITLE
Yield call to send_payment after a timeout and return a pending payment

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -401,6 +401,7 @@ interface BreezEvent {
     NewBlock(u32 block);
     InvoicePaid(InvoicePaidDetails details);
     Synced();
+    PaymentStarted(Payment details);
     PaymentSucceed(Payment details);
     PaymentFailed(PaymentFailedData details);
     BackupStarted();
@@ -749,6 +750,7 @@ dictionary SendPaymentRequest {
     string bolt11;
     u64? amount_msat = null;
     string? label = null;
+    u64? pending_timeout_sec = null;
 };
 
 dictionary SendSpontaneousPaymentRequest {

--- a/libs/sdk-core/src/bridge_generated.io.rs
+++ b/libs/sdk-core/src/bridge_generated.io.rs
@@ -1072,6 +1072,7 @@ impl Wire2Api<SendPaymentRequest> for wire_SendPaymentRequest {
             bolt11: self.bolt11.wire2api(),
             amount_msat: self.amount_msat.wire2api(),
             label: self.label.wire2api(),
+            pending_timeout_sec: self.pending_timeout_sec.wire2api(),
         }
     }
 }
@@ -1390,6 +1391,7 @@ pub struct wire_SendPaymentRequest {
     bolt11: *mut wire_uint_8_list,
     amount_msat: *mut u64,
     label: *mut wire_uint_8_list,
+    pending_timeout_sec: *mut u64,
 }
 
 #[repr(C)]
@@ -1997,6 +1999,7 @@ impl NewWithNullPtr for wire_SendPaymentRequest {
             bolt11: core::ptr::null_mut(),
             amount_msat: core::ptr::null_mut(),
             label: core::ptr::null_mut(),
+            pending_timeout_sec: core::ptr::null_mut(),
         }
     }
 }

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -1105,19 +1105,22 @@ impl support::IntoDart for BreezEvent {
                 vec![1.into_dart(), details.into_into_dart().into_dart()]
             }
             Self::Synced => vec![2.into_dart()],
-            Self::PaymentSucceed { details } => {
+            Self::PaymentStarted { details } => {
                 vec![3.into_dart(), details.into_into_dart().into_dart()]
             }
-            Self::PaymentFailed { details } => {
+            Self::PaymentSucceed { details } => {
                 vec![4.into_dart(), details.into_into_dart().into_dart()]
             }
-            Self::BackupStarted => vec![5.into_dart()],
-            Self::BackupSucceeded => vec![6.into_dart()],
+            Self::PaymentFailed { details } => {
+                vec![5.into_dart(), details.into_into_dart().into_dart()]
+            }
+            Self::BackupStarted => vec![6.into_dart()],
+            Self::BackupSucceeded => vec![7.into_dart()],
             Self::BackupFailed { details } => {
-                vec![7.into_dart(), details.into_into_dart().into_dart()]
+                vec![8.into_dart(), details.into_into_dart().into_dart()]
             }
             Self::SwapUpdated { details } => {
-                vec![8.into_dart(), details.into_into_dart().into_dart()]
+                vec![9.into_dart(), details.into_into_dart().into_dart()]
             }
         }
         .into_dart()

--- a/libs/sdk-core/src/error.rs
+++ b/libs/sdk-core/src/error.rs
@@ -765,6 +765,13 @@ pub enum SendPaymentError {
     #[error("Service connectivity: {err}")]
     ServiceConnectivity { err: String },
 }
+impl SendPaymentError {
+    pub(crate) fn payment_failed(err: &str) -> Self {
+        Self::PaymentFailed {
+            err: err.to_string(),
+        }
+    }
+}
 
 impl From<anyhow::Error> for SendPaymentError {
     fn from(err: anyhow::Error) -> Self {

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -476,6 +476,7 @@ pub struct Config {
     /// the folder should exist before starting the SDK.
     pub working_dir: String,
     pub network: Network,
+    /// Maps to the CLN `retry_for` config when paying invoices (`lightning-pay`)
     pub payment_timeout_sec: u32,
     pub default_lsp_id: Option<String>,
     pub api_key: Option<String>,
@@ -871,7 +872,7 @@ pub struct ReceivePaymentResponse {
 }
 
 /// Represents a send payment request.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct SendPaymentRequest {
     /// The bolt11 invoice
     pub bolt11: String,
@@ -879,6 +880,9 @@ pub struct SendPaymentRequest {
     pub amount_msat: Option<u64>,
     /// The external label or identifier of the [Payment]
     pub label: Option<String>,
+    /// If set, a timeout in seconds, that [crate::BreezServices::send_payment] will return a
+    /// pending payment if not already finished. Otherwise it will return when finished.
+    pub pending_timeout_sec: Option<u64>,
 }
 
 /// Represents a TLV entry for a keysend payment.
@@ -907,6 +911,11 @@ pub struct SendSpontaneousPaymentRequest {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SendPaymentResponse {
     pub payment: Payment,
+}
+impl SendPaymentResponse {
+    pub(crate) fn from_payment(payment: Payment) -> Self {
+        Self { payment }
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/libs/sdk-flutter/ios/Classes/bridge_generated.h
+++ b/libs/sdk-flutter/ios/Classes/bridge_generated.h
@@ -112,6 +112,7 @@ typedef struct wire_SendPaymentRequest {
   struct wire_uint_8_list *bolt11;
   uint64_t *amount_msat;
   struct wire_uint_8_list *label;
+  uint64_t *pending_timeout_sec;
 } wire_SendPaymentRequest;
 
 typedef struct wire_TlvEntry {

--- a/libs/sdk-flutter/lib/bridge_generated.freezed.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.freezed.dart
@@ -354,6 +354,7 @@ mixin _$BreezEvent {
     required TResult Function(int block) newBlock,
     required TResult Function(InvoicePaidDetails details) invoicePaid,
     required TResult Function() synced,
+    required TResult Function(Payment details) paymentStarted,
     required TResult Function(Payment details) paymentSucceed,
     required TResult Function(PaymentFailedData details) paymentFailed,
     required TResult Function() backupStarted,
@@ -367,6 +368,7 @@ mixin _$BreezEvent {
     TResult? Function(int block)? newBlock,
     TResult? Function(InvoicePaidDetails details)? invoicePaid,
     TResult? Function()? synced,
+    TResult? Function(Payment details)? paymentStarted,
     TResult? Function(Payment details)? paymentSucceed,
     TResult? Function(PaymentFailedData details)? paymentFailed,
     TResult? Function()? backupStarted,
@@ -380,6 +382,7 @@ mixin _$BreezEvent {
     TResult Function(int block)? newBlock,
     TResult Function(InvoicePaidDetails details)? invoicePaid,
     TResult Function()? synced,
+    TResult Function(Payment details)? paymentStarted,
     TResult Function(Payment details)? paymentSucceed,
     TResult Function(PaymentFailedData details)? paymentFailed,
     TResult Function()? backupStarted,
@@ -394,6 +397,7 @@ mixin _$BreezEvent {
     required TResult Function(BreezEvent_NewBlock value) newBlock,
     required TResult Function(BreezEvent_InvoicePaid value) invoicePaid,
     required TResult Function(BreezEvent_Synced value) synced,
+    required TResult Function(BreezEvent_PaymentStarted value) paymentStarted,
     required TResult Function(BreezEvent_PaymentSucceed value) paymentSucceed,
     required TResult Function(BreezEvent_PaymentFailed value) paymentFailed,
     required TResult Function(BreezEvent_BackupStarted value) backupStarted,
@@ -407,6 +411,7 @@ mixin _$BreezEvent {
     TResult? Function(BreezEvent_NewBlock value)? newBlock,
     TResult? Function(BreezEvent_InvoicePaid value)? invoicePaid,
     TResult? Function(BreezEvent_Synced value)? synced,
+    TResult? Function(BreezEvent_PaymentStarted value)? paymentStarted,
     TResult? Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
     TResult? Function(BreezEvent_PaymentFailed value)? paymentFailed,
     TResult? Function(BreezEvent_BackupStarted value)? backupStarted,
@@ -420,6 +425,7 @@ mixin _$BreezEvent {
     TResult Function(BreezEvent_NewBlock value)? newBlock,
     TResult Function(BreezEvent_InvoicePaid value)? invoicePaid,
     TResult Function(BreezEvent_Synced value)? synced,
+    TResult Function(BreezEvent_PaymentStarted value)? paymentStarted,
     TResult Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
     TResult Function(BreezEvent_PaymentFailed value)? paymentFailed,
     TResult Function(BreezEvent_BackupStarted value)? backupStarted,
@@ -514,6 +520,7 @@ class _$BreezEvent_NewBlockImpl implements BreezEvent_NewBlock {
     required TResult Function(int block) newBlock,
     required TResult Function(InvoicePaidDetails details) invoicePaid,
     required TResult Function() synced,
+    required TResult Function(Payment details) paymentStarted,
     required TResult Function(Payment details) paymentSucceed,
     required TResult Function(PaymentFailedData details) paymentFailed,
     required TResult Function() backupStarted,
@@ -530,6 +537,7 @@ class _$BreezEvent_NewBlockImpl implements BreezEvent_NewBlock {
     TResult? Function(int block)? newBlock,
     TResult? Function(InvoicePaidDetails details)? invoicePaid,
     TResult? Function()? synced,
+    TResult? Function(Payment details)? paymentStarted,
     TResult? Function(Payment details)? paymentSucceed,
     TResult? Function(PaymentFailedData details)? paymentFailed,
     TResult? Function()? backupStarted,
@@ -546,6 +554,7 @@ class _$BreezEvent_NewBlockImpl implements BreezEvent_NewBlock {
     TResult Function(int block)? newBlock,
     TResult Function(InvoicePaidDetails details)? invoicePaid,
     TResult Function()? synced,
+    TResult Function(Payment details)? paymentStarted,
     TResult Function(Payment details)? paymentSucceed,
     TResult Function(PaymentFailedData details)? paymentFailed,
     TResult Function()? backupStarted,
@@ -566,6 +575,7 @@ class _$BreezEvent_NewBlockImpl implements BreezEvent_NewBlock {
     required TResult Function(BreezEvent_NewBlock value) newBlock,
     required TResult Function(BreezEvent_InvoicePaid value) invoicePaid,
     required TResult Function(BreezEvent_Synced value) synced,
+    required TResult Function(BreezEvent_PaymentStarted value) paymentStarted,
     required TResult Function(BreezEvent_PaymentSucceed value) paymentSucceed,
     required TResult Function(BreezEvent_PaymentFailed value) paymentFailed,
     required TResult Function(BreezEvent_BackupStarted value) backupStarted,
@@ -582,6 +592,7 @@ class _$BreezEvent_NewBlockImpl implements BreezEvent_NewBlock {
     TResult? Function(BreezEvent_NewBlock value)? newBlock,
     TResult? Function(BreezEvent_InvoicePaid value)? invoicePaid,
     TResult? Function(BreezEvent_Synced value)? synced,
+    TResult? Function(BreezEvent_PaymentStarted value)? paymentStarted,
     TResult? Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
     TResult? Function(BreezEvent_PaymentFailed value)? paymentFailed,
     TResult? Function(BreezEvent_BackupStarted value)? backupStarted,
@@ -598,6 +609,7 @@ class _$BreezEvent_NewBlockImpl implements BreezEvent_NewBlock {
     TResult Function(BreezEvent_NewBlock value)? newBlock,
     TResult Function(BreezEvent_InvoicePaid value)? invoicePaid,
     TResult Function(BreezEvent_Synced value)? synced,
+    TResult Function(BreezEvent_PaymentStarted value)? paymentStarted,
     TResult Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
     TResult Function(BreezEvent_PaymentFailed value)? paymentFailed,
     TResult Function(BreezEvent_BackupStarted value)? backupStarted,
@@ -689,6 +701,7 @@ class _$BreezEvent_InvoicePaidImpl implements BreezEvent_InvoicePaid {
     required TResult Function(int block) newBlock,
     required TResult Function(InvoicePaidDetails details) invoicePaid,
     required TResult Function() synced,
+    required TResult Function(Payment details) paymentStarted,
     required TResult Function(Payment details) paymentSucceed,
     required TResult Function(PaymentFailedData details) paymentFailed,
     required TResult Function() backupStarted,
@@ -705,6 +718,7 @@ class _$BreezEvent_InvoicePaidImpl implements BreezEvent_InvoicePaid {
     TResult? Function(int block)? newBlock,
     TResult? Function(InvoicePaidDetails details)? invoicePaid,
     TResult? Function()? synced,
+    TResult? Function(Payment details)? paymentStarted,
     TResult? Function(Payment details)? paymentSucceed,
     TResult? Function(PaymentFailedData details)? paymentFailed,
     TResult? Function()? backupStarted,
@@ -721,6 +735,7 @@ class _$BreezEvent_InvoicePaidImpl implements BreezEvent_InvoicePaid {
     TResult Function(int block)? newBlock,
     TResult Function(InvoicePaidDetails details)? invoicePaid,
     TResult Function()? synced,
+    TResult Function(Payment details)? paymentStarted,
     TResult Function(Payment details)? paymentSucceed,
     TResult Function(PaymentFailedData details)? paymentFailed,
     TResult Function()? backupStarted,
@@ -741,6 +756,7 @@ class _$BreezEvent_InvoicePaidImpl implements BreezEvent_InvoicePaid {
     required TResult Function(BreezEvent_NewBlock value) newBlock,
     required TResult Function(BreezEvent_InvoicePaid value) invoicePaid,
     required TResult Function(BreezEvent_Synced value) synced,
+    required TResult Function(BreezEvent_PaymentStarted value) paymentStarted,
     required TResult Function(BreezEvent_PaymentSucceed value) paymentSucceed,
     required TResult Function(BreezEvent_PaymentFailed value) paymentFailed,
     required TResult Function(BreezEvent_BackupStarted value) backupStarted,
@@ -757,6 +773,7 @@ class _$BreezEvent_InvoicePaidImpl implements BreezEvent_InvoicePaid {
     TResult? Function(BreezEvent_NewBlock value)? newBlock,
     TResult? Function(BreezEvent_InvoicePaid value)? invoicePaid,
     TResult? Function(BreezEvent_Synced value)? synced,
+    TResult? Function(BreezEvent_PaymentStarted value)? paymentStarted,
     TResult? Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
     TResult? Function(BreezEvent_PaymentFailed value)? paymentFailed,
     TResult? Function(BreezEvent_BackupStarted value)? backupStarted,
@@ -773,6 +790,7 @@ class _$BreezEvent_InvoicePaidImpl implements BreezEvent_InvoicePaid {
     TResult Function(BreezEvent_NewBlock value)? newBlock,
     TResult Function(BreezEvent_InvoicePaid value)? invoicePaid,
     TResult Function(BreezEvent_Synced value)? synced,
+    TResult Function(BreezEvent_PaymentStarted value)? paymentStarted,
     TResult Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
     TResult Function(BreezEvent_PaymentFailed value)? paymentFailed,
     TResult Function(BreezEvent_BackupStarted value)? backupStarted,
@@ -838,6 +856,7 @@ class _$BreezEvent_SyncedImpl implements BreezEvent_Synced {
     required TResult Function(int block) newBlock,
     required TResult Function(InvoicePaidDetails details) invoicePaid,
     required TResult Function() synced,
+    required TResult Function(Payment details) paymentStarted,
     required TResult Function(Payment details) paymentSucceed,
     required TResult Function(PaymentFailedData details) paymentFailed,
     required TResult Function() backupStarted,
@@ -854,6 +873,7 @@ class _$BreezEvent_SyncedImpl implements BreezEvent_Synced {
     TResult? Function(int block)? newBlock,
     TResult? Function(InvoicePaidDetails details)? invoicePaid,
     TResult? Function()? synced,
+    TResult? Function(Payment details)? paymentStarted,
     TResult? Function(Payment details)? paymentSucceed,
     TResult? Function(PaymentFailedData details)? paymentFailed,
     TResult? Function()? backupStarted,
@@ -870,6 +890,7 @@ class _$BreezEvent_SyncedImpl implements BreezEvent_Synced {
     TResult Function(int block)? newBlock,
     TResult Function(InvoicePaidDetails details)? invoicePaid,
     TResult Function()? synced,
+    TResult Function(Payment details)? paymentStarted,
     TResult Function(Payment details)? paymentSucceed,
     TResult Function(PaymentFailedData details)? paymentFailed,
     TResult Function()? backupStarted,
@@ -890,6 +911,7 @@ class _$BreezEvent_SyncedImpl implements BreezEvent_Synced {
     required TResult Function(BreezEvent_NewBlock value) newBlock,
     required TResult Function(BreezEvent_InvoicePaid value) invoicePaid,
     required TResult Function(BreezEvent_Synced value) synced,
+    required TResult Function(BreezEvent_PaymentStarted value) paymentStarted,
     required TResult Function(BreezEvent_PaymentSucceed value) paymentSucceed,
     required TResult Function(BreezEvent_PaymentFailed value) paymentFailed,
     required TResult Function(BreezEvent_BackupStarted value) backupStarted,
@@ -906,6 +928,7 @@ class _$BreezEvent_SyncedImpl implements BreezEvent_Synced {
     TResult? Function(BreezEvent_NewBlock value)? newBlock,
     TResult? Function(BreezEvent_InvoicePaid value)? invoicePaid,
     TResult? Function(BreezEvent_Synced value)? synced,
+    TResult? Function(BreezEvent_PaymentStarted value)? paymentStarted,
     TResult? Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
     TResult? Function(BreezEvent_PaymentFailed value)? paymentFailed,
     TResult? Function(BreezEvent_BackupStarted value)? backupStarted,
@@ -922,6 +945,7 @@ class _$BreezEvent_SyncedImpl implements BreezEvent_Synced {
     TResult Function(BreezEvent_NewBlock value)? newBlock,
     TResult Function(BreezEvent_InvoicePaid value)? invoicePaid,
     TResult Function(BreezEvent_Synced value)? synced,
+    TResult Function(BreezEvent_PaymentStarted value)? paymentStarted,
     TResult Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
     TResult Function(BreezEvent_PaymentFailed value)? paymentFailed,
     TResult Function(BreezEvent_BackupStarted value)? backupStarted,
@@ -939,6 +963,187 @@ class _$BreezEvent_SyncedImpl implements BreezEvent_Synced {
 
 abstract class BreezEvent_Synced implements BreezEvent {
   const factory BreezEvent_Synced() = _$BreezEvent_SyncedImpl;
+}
+
+/// @nodoc
+abstract class _$$BreezEvent_PaymentStartedImplCopyWith<$Res> {
+  factory _$$BreezEvent_PaymentStartedImplCopyWith(
+          _$BreezEvent_PaymentStartedImpl value, $Res Function(_$BreezEvent_PaymentStartedImpl) then) =
+      __$$BreezEvent_PaymentStartedImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({Payment details});
+}
+
+/// @nodoc
+class __$$BreezEvent_PaymentStartedImplCopyWithImpl<$Res>
+    extends _$BreezEventCopyWithImpl<$Res, _$BreezEvent_PaymentStartedImpl>
+    implements _$$BreezEvent_PaymentStartedImplCopyWith<$Res> {
+  __$$BreezEvent_PaymentStartedImplCopyWithImpl(
+      _$BreezEvent_PaymentStartedImpl _value, $Res Function(_$BreezEvent_PaymentStartedImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? details = null,
+  }) {
+    return _then(_$BreezEvent_PaymentStartedImpl(
+      details: null == details
+          ? _value.details
+          : details // ignore: cast_nullable_to_non_nullable
+              as Payment,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _$BreezEvent_PaymentStartedImpl implements BreezEvent_PaymentStarted {
+  const _$BreezEvent_PaymentStartedImpl({required this.details});
+
+  @override
+  final Payment details;
+
+  @override
+  String toString() {
+    return 'BreezEvent.paymentStarted(details: $details)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$BreezEvent_PaymentStartedImpl &&
+            (identical(other.details, details) || other.details == details));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, details);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$BreezEvent_PaymentStartedImplCopyWith<_$BreezEvent_PaymentStartedImpl> get copyWith =>
+      __$$BreezEvent_PaymentStartedImplCopyWithImpl<_$BreezEvent_PaymentStartedImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(int block) newBlock,
+    required TResult Function(InvoicePaidDetails details) invoicePaid,
+    required TResult Function() synced,
+    required TResult Function(Payment details) paymentStarted,
+    required TResult Function(Payment details) paymentSucceed,
+    required TResult Function(PaymentFailedData details) paymentFailed,
+    required TResult Function() backupStarted,
+    required TResult Function() backupSucceeded,
+    required TResult Function(BackupFailedData details) backupFailed,
+    required TResult Function(SwapInfo details) swapUpdated,
+  }) {
+    return paymentStarted(details);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(int block)? newBlock,
+    TResult? Function(InvoicePaidDetails details)? invoicePaid,
+    TResult? Function()? synced,
+    TResult? Function(Payment details)? paymentStarted,
+    TResult? Function(Payment details)? paymentSucceed,
+    TResult? Function(PaymentFailedData details)? paymentFailed,
+    TResult? Function()? backupStarted,
+    TResult? Function()? backupSucceeded,
+    TResult? Function(BackupFailedData details)? backupFailed,
+    TResult? Function(SwapInfo details)? swapUpdated,
+  }) {
+    return paymentStarted?.call(details);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(int block)? newBlock,
+    TResult Function(InvoicePaidDetails details)? invoicePaid,
+    TResult Function()? synced,
+    TResult Function(Payment details)? paymentStarted,
+    TResult Function(Payment details)? paymentSucceed,
+    TResult Function(PaymentFailedData details)? paymentFailed,
+    TResult Function()? backupStarted,
+    TResult Function()? backupSucceeded,
+    TResult Function(BackupFailedData details)? backupFailed,
+    TResult Function(SwapInfo details)? swapUpdated,
+    required TResult orElse(),
+  }) {
+    if (paymentStarted != null) {
+      return paymentStarted(details);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(BreezEvent_NewBlock value) newBlock,
+    required TResult Function(BreezEvent_InvoicePaid value) invoicePaid,
+    required TResult Function(BreezEvent_Synced value) synced,
+    required TResult Function(BreezEvent_PaymentStarted value) paymentStarted,
+    required TResult Function(BreezEvent_PaymentSucceed value) paymentSucceed,
+    required TResult Function(BreezEvent_PaymentFailed value) paymentFailed,
+    required TResult Function(BreezEvent_BackupStarted value) backupStarted,
+    required TResult Function(BreezEvent_BackupSucceeded value) backupSucceeded,
+    required TResult Function(BreezEvent_BackupFailed value) backupFailed,
+    required TResult Function(BreezEvent_SwapUpdated value) swapUpdated,
+  }) {
+    return paymentStarted(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(BreezEvent_NewBlock value)? newBlock,
+    TResult? Function(BreezEvent_InvoicePaid value)? invoicePaid,
+    TResult? Function(BreezEvent_Synced value)? synced,
+    TResult? Function(BreezEvent_PaymentStarted value)? paymentStarted,
+    TResult? Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
+    TResult? Function(BreezEvent_PaymentFailed value)? paymentFailed,
+    TResult? Function(BreezEvent_BackupStarted value)? backupStarted,
+    TResult? Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
+    TResult? Function(BreezEvent_BackupFailed value)? backupFailed,
+    TResult? Function(BreezEvent_SwapUpdated value)? swapUpdated,
+  }) {
+    return paymentStarted?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(BreezEvent_NewBlock value)? newBlock,
+    TResult Function(BreezEvent_InvoicePaid value)? invoicePaid,
+    TResult Function(BreezEvent_Synced value)? synced,
+    TResult Function(BreezEvent_PaymentStarted value)? paymentStarted,
+    TResult Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
+    TResult Function(BreezEvent_PaymentFailed value)? paymentFailed,
+    TResult Function(BreezEvent_BackupStarted value)? backupStarted,
+    TResult Function(BreezEvent_BackupSucceeded value)? backupSucceeded,
+    TResult Function(BreezEvent_BackupFailed value)? backupFailed,
+    TResult Function(BreezEvent_SwapUpdated value)? swapUpdated,
+    required TResult orElse(),
+  }) {
+    if (paymentStarted != null) {
+      return paymentStarted(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class BreezEvent_PaymentStarted implements BreezEvent {
+  const factory BreezEvent_PaymentStarted({required final Payment details}) = _$BreezEvent_PaymentStartedImpl;
+
+  Payment get details;
+  @JsonKey(ignore: true)
+  _$$BreezEvent_PaymentStartedImplCopyWith<_$BreezEvent_PaymentStartedImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }
 
 /// @nodoc
@@ -1008,6 +1213,7 @@ class _$BreezEvent_PaymentSucceedImpl implements BreezEvent_PaymentSucceed {
     required TResult Function(int block) newBlock,
     required TResult Function(InvoicePaidDetails details) invoicePaid,
     required TResult Function() synced,
+    required TResult Function(Payment details) paymentStarted,
     required TResult Function(Payment details) paymentSucceed,
     required TResult Function(PaymentFailedData details) paymentFailed,
     required TResult Function() backupStarted,
@@ -1024,6 +1230,7 @@ class _$BreezEvent_PaymentSucceedImpl implements BreezEvent_PaymentSucceed {
     TResult? Function(int block)? newBlock,
     TResult? Function(InvoicePaidDetails details)? invoicePaid,
     TResult? Function()? synced,
+    TResult? Function(Payment details)? paymentStarted,
     TResult? Function(Payment details)? paymentSucceed,
     TResult? Function(PaymentFailedData details)? paymentFailed,
     TResult? Function()? backupStarted,
@@ -1040,6 +1247,7 @@ class _$BreezEvent_PaymentSucceedImpl implements BreezEvent_PaymentSucceed {
     TResult Function(int block)? newBlock,
     TResult Function(InvoicePaidDetails details)? invoicePaid,
     TResult Function()? synced,
+    TResult Function(Payment details)? paymentStarted,
     TResult Function(Payment details)? paymentSucceed,
     TResult Function(PaymentFailedData details)? paymentFailed,
     TResult Function()? backupStarted,
@@ -1060,6 +1268,7 @@ class _$BreezEvent_PaymentSucceedImpl implements BreezEvent_PaymentSucceed {
     required TResult Function(BreezEvent_NewBlock value) newBlock,
     required TResult Function(BreezEvent_InvoicePaid value) invoicePaid,
     required TResult Function(BreezEvent_Synced value) synced,
+    required TResult Function(BreezEvent_PaymentStarted value) paymentStarted,
     required TResult Function(BreezEvent_PaymentSucceed value) paymentSucceed,
     required TResult Function(BreezEvent_PaymentFailed value) paymentFailed,
     required TResult Function(BreezEvent_BackupStarted value) backupStarted,
@@ -1076,6 +1285,7 @@ class _$BreezEvent_PaymentSucceedImpl implements BreezEvent_PaymentSucceed {
     TResult? Function(BreezEvent_NewBlock value)? newBlock,
     TResult? Function(BreezEvent_InvoicePaid value)? invoicePaid,
     TResult? Function(BreezEvent_Synced value)? synced,
+    TResult? Function(BreezEvent_PaymentStarted value)? paymentStarted,
     TResult? Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
     TResult? Function(BreezEvent_PaymentFailed value)? paymentFailed,
     TResult? Function(BreezEvent_BackupStarted value)? backupStarted,
@@ -1092,6 +1302,7 @@ class _$BreezEvent_PaymentSucceedImpl implements BreezEvent_PaymentSucceed {
     TResult Function(BreezEvent_NewBlock value)? newBlock,
     TResult Function(BreezEvent_InvoicePaid value)? invoicePaid,
     TResult Function(BreezEvent_Synced value)? synced,
+    TResult Function(BreezEvent_PaymentStarted value)? paymentStarted,
     TResult Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
     TResult Function(BreezEvent_PaymentFailed value)? paymentFailed,
     TResult Function(BreezEvent_BackupStarted value)? backupStarted,
@@ -1183,6 +1394,7 @@ class _$BreezEvent_PaymentFailedImpl implements BreezEvent_PaymentFailed {
     required TResult Function(int block) newBlock,
     required TResult Function(InvoicePaidDetails details) invoicePaid,
     required TResult Function() synced,
+    required TResult Function(Payment details) paymentStarted,
     required TResult Function(Payment details) paymentSucceed,
     required TResult Function(PaymentFailedData details) paymentFailed,
     required TResult Function() backupStarted,
@@ -1199,6 +1411,7 @@ class _$BreezEvent_PaymentFailedImpl implements BreezEvent_PaymentFailed {
     TResult? Function(int block)? newBlock,
     TResult? Function(InvoicePaidDetails details)? invoicePaid,
     TResult? Function()? synced,
+    TResult? Function(Payment details)? paymentStarted,
     TResult? Function(Payment details)? paymentSucceed,
     TResult? Function(PaymentFailedData details)? paymentFailed,
     TResult? Function()? backupStarted,
@@ -1215,6 +1428,7 @@ class _$BreezEvent_PaymentFailedImpl implements BreezEvent_PaymentFailed {
     TResult Function(int block)? newBlock,
     TResult Function(InvoicePaidDetails details)? invoicePaid,
     TResult Function()? synced,
+    TResult Function(Payment details)? paymentStarted,
     TResult Function(Payment details)? paymentSucceed,
     TResult Function(PaymentFailedData details)? paymentFailed,
     TResult Function()? backupStarted,
@@ -1235,6 +1449,7 @@ class _$BreezEvent_PaymentFailedImpl implements BreezEvent_PaymentFailed {
     required TResult Function(BreezEvent_NewBlock value) newBlock,
     required TResult Function(BreezEvent_InvoicePaid value) invoicePaid,
     required TResult Function(BreezEvent_Synced value) synced,
+    required TResult Function(BreezEvent_PaymentStarted value) paymentStarted,
     required TResult Function(BreezEvent_PaymentSucceed value) paymentSucceed,
     required TResult Function(BreezEvent_PaymentFailed value) paymentFailed,
     required TResult Function(BreezEvent_BackupStarted value) backupStarted,
@@ -1251,6 +1466,7 @@ class _$BreezEvent_PaymentFailedImpl implements BreezEvent_PaymentFailed {
     TResult? Function(BreezEvent_NewBlock value)? newBlock,
     TResult? Function(BreezEvent_InvoicePaid value)? invoicePaid,
     TResult? Function(BreezEvent_Synced value)? synced,
+    TResult? Function(BreezEvent_PaymentStarted value)? paymentStarted,
     TResult? Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
     TResult? Function(BreezEvent_PaymentFailed value)? paymentFailed,
     TResult? Function(BreezEvent_BackupStarted value)? backupStarted,
@@ -1267,6 +1483,7 @@ class _$BreezEvent_PaymentFailedImpl implements BreezEvent_PaymentFailed {
     TResult Function(BreezEvent_NewBlock value)? newBlock,
     TResult Function(BreezEvent_InvoicePaid value)? invoicePaid,
     TResult Function(BreezEvent_Synced value)? synced,
+    TResult Function(BreezEvent_PaymentStarted value)? paymentStarted,
     TResult Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
     TResult Function(BreezEvent_PaymentFailed value)? paymentFailed,
     TResult Function(BreezEvent_BackupStarted value)? backupStarted,
@@ -1333,6 +1550,7 @@ class _$BreezEvent_BackupStartedImpl implements BreezEvent_BackupStarted {
     required TResult Function(int block) newBlock,
     required TResult Function(InvoicePaidDetails details) invoicePaid,
     required TResult Function() synced,
+    required TResult Function(Payment details) paymentStarted,
     required TResult Function(Payment details) paymentSucceed,
     required TResult Function(PaymentFailedData details) paymentFailed,
     required TResult Function() backupStarted,
@@ -1349,6 +1567,7 @@ class _$BreezEvent_BackupStartedImpl implements BreezEvent_BackupStarted {
     TResult? Function(int block)? newBlock,
     TResult? Function(InvoicePaidDetails details)? invoicePaid,
     TResult? Function()? synced,
+    TResult? Function(Payment details)? paymentStarted,
     TResult? Function(Payment details)? paymentSucceed,
     TResult? Function(PaymentFailedData details)? paymentFailed,
     TResult? Function()? backupStarted,
@@ -1365,6 +1584,7 @@ class _$BreezEvent_BackupStartedImpl implements BreezEvent_BackupStarted {
     TResult Function(int block)? newBlock,
     TResult Function(InvoicePaidDetails details)? invoicePaid,
     TResult Function()? synced,
+    TResult Function(Payment details)? paymentStarted,
     TResult Function(Payment details)? paymentSucceed,
     TResult Function(PaymentFailedData details)? paymentFailed,
     TResult Function()? backupStarted,
@@ -1385,6 +1605,7 @@ class _$BreezEvent_BackupStartedImpl implements BreezEvent_BackupStarted {
     required TResult Function(BreezEvent_NewBlock value) newBlock,
     required TResult Function(BreezEvent_InvoicePaid value) invoicePaid,
     required TResult Function(BreezEvent_Synced value) synced,
+    required TResult Function(BreezEvent_PaymentStarted value) paymentStarted,
     required TResult Function(BreezEvent_PaymentSucceed value) paymentSucceed,
     required TResult Function(BreezEvent_PaymentFailed value) paymentFailed,
     required TResult Function(BreezEvent_BackupStarted value) backupStarted,
@@ -1401,6 +1622,7 @@ class _$BreezEvent_BackupStartedImpl implements BreezEvent_BackupStarted {
     TResult? Function(BreezEvent_NewBlock value)? newBlock,
     TResult? Function(BreezEvent_InvoicePaid value)? invoicePaid,
     TResult? Function(BreezEvent_Synced value)? synced,
+    TResult? Function(BreezEvent_PaymentStarted value)? paymentStarted,
     TResult? Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
     TResult? Function(BreezEvent_PaymentFailed value)? paymentFailed,
     TResult? Function(BreezEvent_BackupStarted value)? backupStarted,
@@ -1417,6 +1639,7 @@ class _$BreezEvent_BackupStartedImpl implements BreezEvent_BackupStarted {
     TResult Function(BreezEvent_NewBlock value)? newBlock,
     TResult Function(BreezEvent_InvoicePaid value)? invoicePaid,
     TResult Function(BreezEvent_Synced value)? synced,
+    TResult Function(BreezEvent_PaymentStarted value)? paymentStarted,
     TResult Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
     TResult Function(BreezEvent_PaymentFailed value)? paymentFailed,
     TResult Function(BreezEvent_BackupStarted value)? backupStarted,
@@ -1477,6 +1700,7 @@ class _$BreezEvent_BackupSucceededImpl implements BreezEvent_BackupSucceeded {
     required TResult Function(int block) newBlock,
     required TResult Function(InvoicePaidDetails details) invoicePaid,
     required TResult Function() synced,
+    required TResult Function(Payment details) paymentStarted,
     required TResult Function(Payment details) paymentSucceed,
     required TResult Function(PaymentFailedData details) paymentFailed,
     required TResult Function() backupStarted,
@@ -1493,6 +1717,7 @@ class _$BreezEvent_BackupSucceededImpl implements BreezEvent_BackupSucceeded {
     TResult? Function(int block)? newBlock,
     TResult? Function(InvoicePaidDetails details)? invoicePaid,
     TResult? Function()? synced,
+    TResult? Function(Payment details)? paymentStarted,
     TResult? Function(Payment details)? paymentSucceed,
     TResult? Function(PaymentFailedData details)? paymentFailed,
     TResult? Function()? backupStarted,
@@ -1509,6 +1734,7 @@ class _$BreezEvent_BackupSucceededImpl implements BreezEvent_BackupSucceeded {
     TResult Function(int block)? newBlock,
     TResult Function(InvoicePaidDetails details)? invoicePaid,
     TResult Function()? synced,
+    TResult Function(Payment details)? paymentStarted,
     TResult Function(Payment details)? paymentSucceed,
     TResult Function(PaymentFailedData details)? paymentFailed,
     TResult Function()? backupStarted,
@@ -1529,6 +1755,7 @@ class _$BreezEvent_BackupSucceededImpl implements BreezEvent_BackupSucceeded {
     required TResult Function(BreezEvent_NewBlock value) newBlock,
     required TResult Function(BreezEvent_InvoicePaid value) invoicePaid,
     required TResult Function(BreezEvent_Synced value) synced,
+    required TResult Function(BreezEvent_PaymentStarted value) paymentStarted,
     required TResult Function(BreezEvent_PaymentSucceed value) paymentSucceed,
     required TResult Function(BreezEvent_PaymentFailed value) paymentFailed,
     required TResult Function(BreezEvent_BackupStarted value) backupStarted,
@@ -1545,6 +1772,7 @@ class _$BreezEvent_BackupSucceededImpl implements BreezEvent_BackupSucceeded {
     TResult? Function(BreezEvent_NewBlock value)? newBlock,
     TResult? Function(BreezEvent_InvoicePaid value)? invoicePaid,
     TResult? Function(BreezEvent_Synced value)? synced,
+    TResult? Function(BreezEvent_PaymentStarted value)? paymentStarted,
     TResult? Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
     TResult? Function(BreezEvent_PaymentFailed value)? paymentFailed,
     TResult? Function(BreezEvent_BackupStarted value)? backupStarted,
@@ -1561,6 +1789,7 @@ class _$BreezEvent_BackupSucceededImpl implements BreezEvent_BackupSucceeded {
     TResult Function(BreezEvent_NewBlock value)? newBlock,
     TResult Function(BreezEvent_InvoicePaid value)? invoicePaid,
     TResult Function(BreezEvent_Synced value)? synced,
+    TResult Function(BreezEvent_PaymentStarted value)? paymentStarted,
     TResult Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
     TResult Function(BreezEvent_PaymentFailed value)? paymentFailed,
     TResult Function(BreezEvent_BackupStarted value)? backupStarted,
@@ -1647,6 +1876,7 @@ class _$BreezEvent_BackupFailedImpl implements BreezEvent_BackupFailed {
     required TResult Function(int block) newBlock,
     required TResult Function(InvoicePaidDetails details) invoicePaid,
     required TResult Function() synced,
+    required TResult Function(Payment details) paymentStarted,
     required TResult Function(Payment details) paymentSucceed,
     required TResult Function(PaymentFailedData details) paymentFailed,
     required TResult Function() backupStarted,
@@ -1663,6 +1893,7 @@ class _$BreezEvent_BackupFailedImpl implements BreezEvent_BackupFailed {
     TResult? Function(int block)? newBlock,
     TResult? Function(InvoicePaidDetails details)? invoicePaid,
     TResult? Function()? synced,
+    TResult? Function(Payment details)? paymentStarted,
     TResult? Function(Payment details)? paymentSucceed,
     TResult? Function(PaymentFailedData details)? paymentFailed,
     TResult? Function()? backupStarted,
@@ -1679,6 +1910,7 @@ class _$BreezEvent_BackupFailedImpl implements BreezEvent_BackupFailed {
     TResult Function(int block)? newBlock,
     TResult Function(InvoicePaidDetails details)? invoicePaid,
     TResult Function()? synced,
+    TResult Function(Payment details)? paymentStarted,
     TResult Function(Payment details)? paymentSucceed,
     TResult Function(PaymentFailedData details)? paymentFailed,
     TResult Function()? backupStarted,
@@ -1699,6 +1931,7 @@ class _$BreezEvent_BackupFailedImpl implements BreezEvent_BackupFailed {
     required TResult Function(BreezEvent_NewBlock value) newBlock,
     required TResult Function(BreezEvent_InvoicePaid value) invoicePaid,
     required TResult Function(BreezEvent_Synced value) synced,
+    required TResult Function(BreezEvent_PaymentStarted value) paymentStarted,
     required TResult Function(BreezEvent_PaymentSucceed value) paymentSucceed,
     required TResult Function(BreezEvent_PaymentFailed value) paymentFailed,
     required TResult Function(BreezEvent_BackupStarted value) backupStarted,
@@ -1715,6 +1948,7 @@ class _$BreezEvent_BackupFailedImpl implements BreezEvent_BackupFailed {
     TResult? Function(BreezEvent_NewBlock value)? newBlock,
     TResult? Function(BreezEvent_InvoicePaid value)? invoicePaid,
     TResult? Function(BreezEvent_Synced value)? synced,
+    TResult? Function(BreezEvent_PaymentStarted value)? paymentStarted,
     TResult? Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
     TResult? Function(BreezEvent_PaymentFailed value)? paymentFailed,
     TResult? Function(BreezEvent_BackupStarted value)? backupStarted,
@@ -1731,6 +1965,7 @@ class _$BreezEvent_BackupFailedImpl implements BreezEvent_BackupFailed {
     TResult Function(BreezEvent_NewBlock value)? newBlock,
     TResult Function(BreezEvent_InvoicePaid value)? invoicePaid,
     TResult Function(BreezEvent_Synced value)? synced,
+    TResult Function(BreezEvent_PaymentStarted value)? paymentStarted,
     TResult Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
     TResult Function(BreezEvent_PaymentFailed value)? paymentFailed,
     TResult Function(BreezEvent_BackupStarted value)? backupStarted,
@@ -1823,6 +2058,7 @@ class _$BreezEvent_SwapUpdatedImpl implements BreezEvent_SwapUpdated {
     required TResult Function(int block) newBlock,
     required TResult Function(InvoicePaidDetails details) invoicePaid,
     required TResult Function() synced,
+    required TResult Function(Payment details) paymentStarted,
     required TResult Function(Payment details) paymentSucceed,
     required TResult Function(PaymentFailedData details) paymentFailed,
     required TResult Function() backupStarted,
@@ -1839,6 +2075,7 @@ class _$BreezEvent_SwapUpdatedImpl implements BreezEvent_SwapUpdated {
     TResult? Function(int block)? newBlock,
     TResult? Function(InvoicePaidDetails details)? invoicePaid,
     TResult? Function()? synced,
+    TResult? Function(Payment details)? paymentStarted,
     TResult? Function(Payment details)? paymentSucceed,
     TResult? Function(PaymentFailedData details)? paymentFailed,
     TResult? Function()? backupStarted,
@@ -1855,6 +2092,7 @@ class _$BreezEvent_SwapUpdatedImpl implements BreezEvent_SwapUpdated {
     TResult Function(int block)? newBlock,
     TResult Function(InvoicePaidDetails details)? invoicePaid,
     TResult Function()? synced,
+    TResult Function(Payment details)? paymentStarted,
     TResult Function(Payment details)? paymentSucceed,
     TResult Function(PaymentFailedData details)? paymentFailed,
     TResult Function()? backupStarted,
@@ -1875,6 +2113,7 @@ class _$BreezEvent_SwapUpdatedImpl implements BreezEvent_SwapUpdated {
     required TResult Function(BreezEvent_NewBlock value) newBlock,
     required TResult Function(BreezEvent_InvoicePaid value) invoicePaid,
     required TResult Function(BreezEvent_Synced value) synced,
+    required TResult Function(BreezEvent_PaymentStarted value) paymentStarted,
     required TResult Function(BreezEvent_PaymentSucceed value) paymentSucceed,
     required TResult Function(BreezEvent_PaymentFailed value) paymentFailed,
     required TResult Function(BreezEvent_BackupStarted value) backupStarted,
@@ -1891,6 +2130,7 @@ class _$BreezEvent_SwapUpdatedImpl implements BreezEvent_SwapUpdated {
     TResult? Function(BreezEvent_NewBlock value)? newBlock,
     TResult? Function(BreezEvent_InvoicePaid value)? invoicePaid,
     TResult? Function(BreezEvent_Synced value)? synced,
+    TResult? Function(BreezEvent_PaymentStarted value)? paymentStarted,
     TResult? Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
     TResult? Function(BreezEvent_PaymentFailed value)? paymentFailed,
     TResult? Function(BreezEvent_BackupStarted value)? backupStarted,
@@ -1907,6 +2147,7 @@ class _$BreezEvent_SwapUpdatedImpl implements BreezEvent_SwapUpdated {
     TResult Function(BreezEvent_NewBlock value)? newBlock,
     TResult Function(BreezEvent_InvoicePaid value)? invoicePaid,
     TResult Function(BreezEvent_Synced value)? synced,
+    TResult Function(BreezEvent_PaymentStarted value)? paymentStarted,
     TResult Function(BreezEvent_PaymentSucceed value)? paymentSucceed,
     TResult Function(BreezEvent_PaymentFailed value)? paymentFailed,
     TResult Function(BreezEvent_BackupStarted value)? backupStarted,

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -3231,10 +3231,21 @@ fun asSendPaymentRequest(sendPaymentRequest: ReadableMap): SendPaymentRequest? {
     val bolt11 = sendPaymentRequest.getString("bolt11")!!
     val amountMsat = if (hasNonNullKey(sendPaymentRequest, "amountMsat")) sendPaymentRequest.getDouble("amountMsat").toULong() else null
     val label = if (hasNonNullKey(sendPaymentRequest, "label")) sendPaymentRequest.getString("label") else null
+    val pendingTimeoutSec =
+        if (hasNonNullKey(
+                sendPaymentRequest,
+                "pendingTimeoutSec",
+            )
+        ) {
+            sendPaymentRequest.getDouble("pendingTimeoutSec").toULong()
+        } else {
+            null
+        }
     return SendPaymentRequest(
         bolt11,
         amountMsat,
         label,
+        pendingTimeoutSec,
     )
 }
 
@@ -3243,6 +3254,7 @@ fun readableMapOf(sendPaymentRequest: SendPaymentRequest): ReadableMap {
         "bolt11" to sendPaymentRequest.bolt11,
         "amountMsat" to sendPaymentRequest.amountMsat,
         "label" to sendPaymentRequest.label,
+        "pendingTimeoutSec" to sendPaymentRequest.pendingTimeoutSec,
     )
 }
 
@@ -3859,6 +3871,9 @@ fun asBreezEvent(breezEvent: ReadableMap): BreezEvent? {
     if (type == "synced") {
         return BreezEvent.Synced
     }
+    if (type == "paymentStarted") {
+        return BreezEvent.PaymentStarted(breezEvent.getMap("details")?.let { asPayment(it) }!!)
+    }
     if (type == "paymentSucceed") {
         return BreezEvent.PaymentSucceed(breezEvent.getMap("details")?.let { asPayment(it) }!!)
     }
@@ -3893,6 +3908,10 @@ fun readableMapOf(breezEvent: BreezEvent): ReadableMap? {
         }
         is BreezEvent.Synced -> {
             pushToMap(map, "type", "synced")
+        }
+        is BreezEvent.PaymentStarted -> {
+            pushToMap(map, "type", "paymentStarted")
+            pushToMap(map, "details", readableMapOf(breezEvent.details))
         }
         is BreezEvent.PaymentSucceed -> {
             pushToMap(map, "type", "paymentSucceed")

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -3546,11 +3546,19 @@ enum BreezSDKMapper {
             }
             label = labelTmp
         }
+        var pendingTimeoutSec: UInt64?
+        if hasNonNilKey(data: sendPaymentRequest, key: "pendingTimeoutSec") {
+            guard let pendingTimeoutSecTmp = sendPaymentRequest["pendingTimeoutSec"] as? UInt64 else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "pendingTimeoutSec"))
+            }
+            pendingTimeoutSec = pendingTimeoutSecTmp
+        }
 
         return SendPaymentRequest(
             bolt11: bolt11,
             amountMsat: amountMsat,
-            label: label
+            label: label,
+            pendingTimeoutSec: pendingTimeoutSec
         )
     }
 
@@ -3559,6 +3567,7 @@ enum BreezSDKMapper {
             "bolt11": sendPaymentRequest.bolt11,
             "amountMsat": sendPaymentRequest.amountMsat == nil ? nil : sendPaymentRequest.amountMsat,
             "label": sendPaymentRequest.label == nil ? nil : sendPaymentRequest.label,
+            "pendingTimeoutSec": sendPaymentRequest.pendingTimeoutSec == nil ? nil : sendPaymentRequest.pendingTimeoutSec,
         ]
     }
 
@@ -4264,6 +4273,14 @@ enum BreezSDKMapper {
         if type == "synced" {
             return BreezEvent.synced
         }
+        if type == "paymentStarted" {
+            guard let detailsTmp = breezEvent["details"] as? [String: Any?] else {
+                throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "details", typeName: "BreezEvent"))
+            }
+            let _details = try asPayment(payment: detailsTmp)
+
+            return BreezEvent.paymentStarted(details: _details)
+        }
         if type == "paymentSucceed" {
             guard let detailsTmp = breezEvent["details"] as? [String: Any?] else {
                 throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "details", typeName: "BreezEvent"))
@@ -4327,6 +4344,14 @@ enum BreezSDKMapper {
         case .synced:
             return [
                 "type": "synced",
+            ]
+
+        case let .paymentStarted(
+            details
+        ):
+            return [
+                "type": "paymentStarted",
+                "details": dictionaryOf(payment: details),
             ]
 
         case let .paymentSucceed(

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -491,6 +491,7 @@ export type SendPaymentRequest = {
     bolt11: string
     amountMsat?: number
     label?: string
+    pendingTimeoutSec?: number
 }
 
 export type SendPaymentResponse = {
@@ -593,6 +594,7 @@ export enum BreezEventVariant {
     NEW_BLOCK = "newBlock",
     INVOICE_PAID = "invoicePaid",
     SYNCED = "synced",
+    PAYMENT_STARTED = "paymentStarted",
     PAYMENT_SUCCEED = "paymentSucceed",
     PAYMENT_FAILED = "paymentFailed",
     BACKUP_STARTED = "backupStarted",
@@ -609,6 +611,9 @@ export type BreezEvent = {
     details: InvoicePaidDetails
 } | {
     type: BreezEventVariant.SYNCED
+} | {
+    type: BreezEventVariant.PAYMENT_STARTED,
+    details: Payment
 } | {
     type: BreezEventVariant.PAYMENT_SUCCEED,
     details: Payment

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -243,12 +243,14 @@ pub(crate) async fn handle_command(
             bolt11,
             amount_msat,
             label,
+            pending_timeout_sec,
         } => {
             let payment = sdk()?
                 .send_payment(SendPaymentRequest {
                     bolt11,
                     amount_msat,
                     label,
+                    pending_timeout_sec,
                 })
                 .await?;
             serde_json::to_string_pretty(&payment).map_err(|e| e.into())

--- a/tools/sdk-cli/src/commands.rs
+++ b/tools/sdk-cli/src/commands.rs
@@ -50,6 +50,10 @@ pub(crate) enum Commands {
         /// The external label or identifier of the payment
         #[clap(name = "label", short = 'l', long = "label")]
         label: Option<String>,
+
+        /// The option timeout in which a pending payment is returned if not already finished.
+        #[clap(name = "seconds", short = 't', long = "pending_timeout")]
+        pending_timeout_sec: Option<u64>,
     },
 
     /// [pay] Send a spontaneous (keysend) payment


### PR DESCRIPTION
This adds the following to the SDK:
- [x] A **_PaymentStarted_** event to notify to beginning of a payment.
- [x] Run the `send_payment()` request in a thread with a timeout to prevent the method call hanging too long. If it times out, the pending **_Payment_** is returned and the client can then use the **_PaymentSucceed_** / **_PaymentFailed_** events to handle the completion of the payment.
- [x] Run the `lnurl_pay()` request (which uses `send_payment()`) without a timeout.