### PR TITLE
Fix yielding send_payment handling with timeout

### DIFF
--- a/libs/sdk-core/src/error.rs
+++ b/libs/sdk-core/src/error.rs
@@ -765,6 +765,13 @@ pub enum SendPaymentError {
     #[error("Service connectivity: {err}")]
     ServiceConnectivity { err: String },
 }
+impl SendPaymentError {
+    pub(crate) fn payment_failed(err: &str) -> Self {
+        Self::PaymentFailed {
+            err: err.to_string(),
+        }
+    }
+}
 
 impl From<anyhow::Error> for SendPaymentError {
     fn from(err: anyhow::Error) -> Self {


### PR DESCRIPTION
This PR fixes a bug that was introduced by #954 .

The bug caused `send_payment` to not return when no timeout was specified. Internally, this was caused by different behaviors of `std::sync::mpsc::channel()` than `tokio::sync::oneshot::channel()`. The later terminates and yields back control to the runtime when the spawned thread terminates, as expected.