### PR TITLE
Move Swift publishing workflow to main repo

### DIFF
--- a/.github/workflows/build-bindings-ios.yml
+++ b/.github/workflows/build-bindings-ios.yml
@@ -97,9 +97,9 @@ jobs:
         mkdir -p ios-universal
         mkdir -p ios-universal-sim
         # build universal lib for arm device and x86 sim
-        lipo -create -output ios-universal/libbreez_sdk_bindings.a aarch64-apple-ios/release/libbreez_sdk_bindings.a x86_64-apple-ios/release/libbreez_sdk_bindings.a
+        lipo -create -output ios-universal/libbreez_sdk_bindings.a aarch64-apple-ios/libbreez_sdk_bindings.a x86_64-apple-ios/libbreez_sdk_bindings.a
         # build universal lib for arm sim and x86 sim
-        lipo -create -output ios-universal-sim/libbreez_sdk_bindings.a aarch64-apple-ios-sim/release/libbreez_sdk_bindings.a x86_64-apple-ios/release/libbreez_sdk_bindings.a
+        lipo -create -output ios-universal-sim/libbreez_sdk_bindings.a aarch64-apple-ios-sim/libbreez_sdk_bindings.a x86_64-apple-ios/libbreez_sdk_bindings.a
 
     - name: Archive release
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build-bindings-ios.yml
+++ b/.github/workflows/build-bindings-ios.yml
@@ -77,17 +77,17 @@ jobs:
     needs: build
     name: build ios-universal
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: sdk-bindings-aarch64-apple-ios
         path: aarch64-apple-ios
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: sdk-bindings-x86_64-apple-ios
         path: x86_64-apple-ios
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: sdk-bindings-aarch64-apple-ios-sim
         path: aarch64-apple-ios-sim
@@ -102,14 +102,14 @@ jobs:
         lipo -create -output ios-universal-sim/libbreez_sdk_bindings.a aarch64-apple-ios-sim/release/libbreez_sdk_bindings.a x86_64-apple-ios/release/libbreez_sdk_bindings.a
 
     - name: Archive release
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: sdk-bindings-ios-universal
         path: |
           ios-universal/libbreez_sdk_bindings.a
 
     - name: Archive release
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: sdk-bindings-ios-universal-sim
         path: |

--- a/.github/workflows/build-bindings-ios.yml
+++ b/.github/workflows/build-bindings-ios.yml
@@ -72,6 +72,49 @@ jobs:
         name: sdk-bindings-${{ matrix.target }}
         path: libs/target/${{ matrix.target }}/release/libbreez_sdk_bindings.a
 
+  merge:
+    runs-on: macOS-latest
+    needs: build
+    name: build ios-universal
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: sdk-bindings-aarch64-apple-ios
+        path: aarch64-apple-ios
+
+    - uses: actions/download-artifact@v3
+      with:
+        name: sdk-bindings-x86_64-apple-ios
+        path: x86_64-apple-ios
+
+    - uses: actions/download-artifact@v3
+      with:
+        name: sdk-bindings-aarch64-apple-ios-sim
+        path: aarch64-apple-ios-sim
+
+    - name: Build iOS universal
+      run: |
+        mkdir -p ios-universal
+        mkdir -p ios-universal-sim
+        # build universal lib for arm device and x86 sim
+        lipo -create -output ios-universal/libbreez_sdk_bindings.a aarch64-apple-ios/release/libbreez_sdk_bindings.a x86_64-apple-ios/release/libbreez_sdk_bindings.a
+        # build universal lib for arm sim and x86 sim
+        lipo -create -output ios-universal-sim/libbreez_sdk_bindings.a aarch64-apple-ios-sim/release/libbreez_sdk_bindings.a x86_64-apple-ios/release/libbreez_sdk_bindings.a
+
+    - name: Archive release
+      uses: actions/upload-artifact@v3
+      with:
+        name: sdk-bindings-ios-universal
+        path: |
+          ios-universal/libbreez_sdk_bindings.a
+
+    - name: Archive release
+      uses: actions/upload-artifact@v3
+      with:
+        name: sdk-bindings-ios-universal-sim
+        path: |
+          ios-universal-sim/libbreez_sdk_bindings.a
+
   build-dummies:
     if: ${{ inputs.use-dummy-binaries }}
     runs-on: ubuntu-latest
@@ -82,6 +125,8 @@ jobs:
           aarch64-apple-ios,
           x86_64-apple-ios,
           aarch64-apple-ios-sim,
+          ios-universal,
+          ios-universal-sim,
         ]
     steps:
       - name: Build dummy ios ${{ matrix.target }}

--- a/.github/workflows/publish-all-platforms.yml
+++ b/.github/workflows/publish-all-platforms.yml
@@ -14,7 +14,7 @@ on:
         description: 'array of packages to publish (remove what you do not want)'
         required: true
         type: string
-        default: '["csharp", "golang", "maven", "kotlin-mpp", "flutter", "react-native", "python"]'
+        default: '["csharp", "golang", "maven", "kotlin-mpp", "flutter", "react-native", "python", "swift"]'
       csharp-ref:
         description: 'optional commit/tag/branch reference for the C# project. Defaults to ref.'
         required: false
@@ -47,7 +47,7 @@ on:
         description: 'array of packages to publish (remove what you do not want)'
         required: true
         type: string
-        default: '["csharp", "golang", "maven", "kotlin-mpp", "flutter", "react-native", "python"]'
+        default: '["csharp", "golang", "maven", "kotlin-mpp", "flutter", "react-native", "python", "swift"]'
       csharp-ref:
         description: 'optional commit/tag/branch reference for the C# project. Defaults to ref.'
         required: false
@@ -78,6 +78,7 @@ jobs:
       flutter-package-version: ${{ (contains(fromJSON(inputs.packages-to-publish), 'flutter') && inputs.package-version) || '' }}
       react-native-package-version: ${{ (contains(fromJSON(inputs.packages-to-publish), 'react-native') && inputs.package-version) || '' }}
       python-package-version: ${{ (contains(fromJSON(inputs.packages-to-publish), 'python') && inputs.package-version) || '' }}
+      swift-package-version: ${{ (contains(fromJSON(inputs.packages-to-publish), 'swift') && inputs.package-version) || '' }}
       use-dummy-binaries: ${{ inputs.use-dummy-binaries }}
       publish: ${{ inputs.publish }}
     steps:
@@ -95,12 +96,12 @@ jobs:
       # (e.g. bindings-windows: true) if you want to test something.
       repository: ${{ needs.pre-setup.outputs.repository }}
       bindings-windows: ${{ !!needs.pre-setup.outputs.csharp-package-version || !!needs.pre-setup.outputs.golang-package-version || !!needs.pre-setup.outputs.python-package-version }}
-      bindings-darwin: ${{ !!needs.pre-setup.outputs.csharp-package-version || !!needs.pre-setup.outputs.golang-package-version || !!needs.pre-setup.outputs.python-package-version }}
+      bindings-darwin: ${{ !!needs.pre-setup.outputs.csharp-package-version || !!needs.pre-setup.outputs.golang-package-version || !!needs.pre-setup.outputs.python-package-version || !!needs.pre-setup.outputs.swift-package-version }}
       bindings-linux: ${{ !!needs.pre-setup.outputs.csharp-package-version || !!needs.pre-setup.outputs.golang-package-version || !!needs.pre-setup.outputs.python-package-version }}
       bindings-android: ${{ !!needs.pre-setup.outputs.kotlin-mpp-package-version || !!needs.pre-setup.outputs.maven-package-version || !!needs.pre-setup.outputs.golang-package-version }}
-      bindings-ios: ${{ !!needs.pre-setup.outputs.kotlin-mpp-package-version || !!needs.pre-setup.outputs.maven-package-version }}
+      bindings-ios: ${{ !!needs.pre-setup.outputs.kotlin-mpp-package-version || !!needs.pre-setup.outputs.maven-package-version || !!needs.pre-setup.outputs.swift-package-version }}
       kotlin: ${{ !!needs.pre-setup.outputs.kotlin-mpp-package-version || !!needs.pre-setup.outputs.maven-package-version || !!needs.pre-setup.outputs.flutter-package-version }}
-      swift: ${{ !!needs.pre-setup.outputs.flutter-package-version }}
+      swift: ${{ !!needs.pre-setup.outputs.flutter-package-version || !!needs.pre-setup.outputs.swift-package-version }}
       python: ${{ !!needs.pre-setup.outputs.python-package-version }}
       csharp: ${{ !!needs.pre-setup.outputs.csharp-package-version }}
       golang: ${{ !!needs.pre-setup.outputs.golang-package-version }}
@@ -108,6 +109,7 @@ jobs:
       kotlin-mpp: ${{ !!needs.pre-setup.outputs.kotlin-mpp-package-version }}
       flutter: ${{ !!needs.pre-setup.outputs.flutter-package-version }}
       react-native: ${{ !!needs.pre-setup.outputs.react-native-package-version }}
+      spm-cocoapods: ${{ !!needs.pre-setup.outputs.swift-package-version }}
       ref: ${{ needs.pre-setup.outputs.ref }}
       csharp-package-version: ${{ needs.pre-setup.outputs.csharp-package-version || '0.0.2' }}
       csharp-ref: ${{ needs.pre-setup.outputs.csharp-ref }}
@@ -117,6 +119,7 @@ jobs:
       flutter-package-version: ${{ needs.pre-setup.outputs.flutter-package-version || '0.0.2' }}
       react-native-package-version: ${{ needs.pre-setup.outputs.react-native-package-version || '0.0.2' }}
       python-package-version: ${{ needs.pre-setup.outputs.python-package-version || '0.0.2' }}
+      swift-package-version: ${{ needs.pre-setup.outputs.swift-package-version || '0.0.2' }}
       publish: ${{ needs.pre-setup.outputs.publish }}
       use-dummy-binaries: ${{ needs.pre-setup.outputs.use-dummy-binaries }}
     steps:
@@ -288,3 +291,21 @@ jobs:
       publish: ${{ needs.setup.outputs.publish == 'true' }}
     secrets:
       PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+
+  publish-swift:
+    needs:
+      - setup
+      - build-bindings-darwin
+      - build-bindings-ios
+      - build-language-bindings
+    if: ${{ needs.setup.outputs.spm-cocoapods == 'true' }}
+    uses: ./.github/workflows/publish-swift.yml
+    with:
+      repository: ${{ needs.setup.outputs.repository }}
+      ref: ${{ needs.setup.outputs.ref }}
+      package-version: ${{ needs.setup.outputs.swift-package-version }}
+      publish: ${{ needs.setup.outputs.publish == 'true' }}
+    secrets:
+      REPO_SSH_KEY: ${{ secrets.REPO_SSH_KEY }}
+      GITHUB_TOKEN_BREEZ_SDK_SWIFT: ${{ secrets.GITHUB_TOKEN_BREEZ_SDK_SWIFT }} # todo: create token
+      COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }} # todo: create token

--- a/.github/workflows/publish-all-platforms.yml
+++ b/.github/workflows/publish-all-platforms.yml
@@ -135,7 +135,7 @@ jobs:
       use-dummy-binaries: ${{ needs.setup.outputs.use-dummy-binaries == 'true' }}
   build-bindings-darwin:
     needs: setup
-    if: always() && !failure() && !cancelled() && ${{ needs.setup.outputs.bindings-darwin == 'true' }}
+    if: ${{ needs.setup.outputs.bindings-darwin == 'true' }}
     uses: ./.github/workflows/build-bindings-darwin.yml
     with:
       repository: ${{ needs.setup.outputs.repository }}
@@ -159,7 +159,7 @@ jobs:
       use-dummy-binaries: ${{ needs.setup.outputs.use-dummy-binaries == 'true' }}
   build-bindings-ios:
     needs: setup
-    if: always() && !failure() && !cancelled() && ${{ needs.setup.outputs.bindings-ios == 'true' }}
+    if: ${{ needs.setup.outputs.bindings-ios == 'true' }}
     uses: ./.github/workflows/build-bindings-ios.yml
     with:
       repository: ${{ needs.setup.outputs.repository }}
@@ -251,11 +251,9 @@ jobs:
       - setup
       - build-language-bindings
       - publish-swift
-    # The flutter package depends on the swift package to be available at runtime.
-    # To make sure this is will be the case, we run the publishing job only if:
-    #   a) its dependencies (mainly publish-swift) succeeded
-    #   b) one of its dependencies, mainly publish-swift, was explicitly skipped (but didn't fail or get cancelled)
-    if: always() && !failure() && !cancelled() && ${{ needs.setup.outputs.flutter == 'true' }}
+      - publish-maven
+    # The flutter package depends on the swift and android packages to be available at runtime.
+    if: ${{ needs.setup.outputs.flutter == 'true' }}
     uses: ./.github/workflows/publish-flutter.yml
     with:
       repository: ${{ needs.setup.outputs.repository }}
@@ -265,17 +263,13 @@ jobs:
     secrets:
       REPO_SSH_KEY: ${{ secrets.REPO_SSH_KEY }}
 
-  # react native version x.y.z will at runtime require
-  # ios and android packages x.y.z being published already.
   publish-react-native:
     needs:
       - setup
       - publish-swift
-    # The react native package depends on the swift cocoapod to be available at runtime.
-    # To make sure this is will be the case, we run the publishing job only if:
-    #   a) its dependencies (mainly publish-swift) succeeded
-    #   b) one of its dependencies, mainly publish-swift, was explicitly skipped (but didn't fail or get cancelled)
-    if: always() && !failure() && !cancelled() && ${{ needs.setup.outputs.react-native == 'true' }}
+      - publish-maven
+    # The react native package depends on the swift and android packages to be available at runtime.
+    if: ${{ needs.setup.outputs.react-native == 'true' }}
     uses: ./.github/workflows/publish-react-native.yml
     with:
       repository: ${{ needs.setup.outputs.repository }}
@@ -308,14 +302,46 @@ jobs:
       - build-bindings-darwin
       - build-bindings-ios
       - build-language-bindings
-    if: always() && !failure() && !cancelled() && ${{ needs.setup.outputs.spm-cocoapods == 'true' }}
-    uses: ./.github/workflows/publish-swift.yml
-    with:
-      repository: ${{ needs.setup.outputs.repository }}
-      ref: ${{ needs.setup.outputs.ref }}
-      package-version: ${{ needs.setup.outputs.swift-package-version }}
-      publish: ${{ needs.setup.outputs.publish == 'true' }}
-    secrets:
-      REPO_SSH_KEY: ${{ secrets.REPO_SSH_KEY }}
-      GITHUB_TOKEN_BREEZ_SDK_SWIFT: ${{ secrets.GITHUB_TOKEN_BREEZ_SDK_SWIFT }} # todo: create token
-      COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }} # todo: create token
+    if: ${{ needs.setup.outputs.spm-cocoapods == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: publish swift (failing)
+        run: exit 1
+    # uses: ./.github/workflows/publish-swift.yml
+    # with:
+    #   repository: ${{ needs.setup.outputs.repository }}
+    #   ref: ${{ needs.setup.outputs.ref }}
+    #   package-version: ${{ needs.setup.outputs.swift-package-version }}
+    #   publish: ${{ needs.setup.outputs.publish == 'true' }}
+    # secrets:
+    #   REPO_SSH_KEY: ${{ secrets.REPO_SSH_KEY }}
+    #   GITHUB_TOKEN_BREEZ_SDK_SWIFT: ${{ secrets.GITHUB_TOKEN_BREEZ_SDK_SWIFT }} # todo: create token
+    #   COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }} # todo: create token
+
+  debug-print:
+    needs:
+      - setup
+      - publish-swift
+      - publish-maven
+    runs-on: ubuntu-latest
+    if: ${{ always() && !failure() && !cancelled() }}
+    steps:
+      - name: check needs results
+        run: |
+          echo ${{ needs.setup.outputs.spm-cocoapods }}
+          echo ${{ needs.setup.outputs.maven }}
+          echo ${{ needs.publish-swift.result }}
+          echo ${{ needs.publish-maven.result }}
+
+  debug-publish:
+    needs:
+      - setup
+      - publish-swift
+      - publish-maven
+    if: ${{ true && always() && !failure() && !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: check needs results
+        run: |
+          echo ${{ needs.publish-swift.result }}
+          echo ${{ needs.publish-maven.result }}

--- a/.github/workflows/publish-all-platforms.yml
+++ b/.github/workflows/publish-all-platforms.yml
@@ -135,7 +135,7 @@ jobs:
       use-dummy-binaries: ${{ needs.setup.outputs.use-dummy-binaries == 'true' }}
   build-bindings-darwin:
     needs: setup
-    if: ${{ needs.setup.outputs.bindings-darwin == 'true' }}
+    if: always() && !failure() && !cancelled() && ${{ needs.setup.outputs.bindings-darwin == 'true' }}
     uses: ./.github/workflows/build-bindings-darwin.yml
     with:
       repository: ${{ needs.setup.outputs.repository }}
@@ -159,7 +159,7 @@ jobs:
       use-dummy-binaries: ${{ needs.setup.outputs.use-dummy-binaries == 'true' }}
   build-bindings-ios:
     needs: setup
-    if: ${{ needs.setup.outputs.bindings-ios == 'true' }}
+    if: always() && !failure() && !cancelled() && ${{ needs.setup.outputs.bindings-ios == 'true' }}
     uses: ./.github/workflows/build-bindings-ios.yml
     with:
       repository: ${{ needs.setup.outputs.repository }}
@@ -251,6 +251,10 @@ jobs:
       - setup
       - build-language-bindings
       - publish-swift
+    # The flutter package depends on the swift package to be available at runtime.
+    # To make sure this is will be the case, we run the publishing job only if:
+    #   a) its dependencies (mainly publish-swift) succeeded
+    #   b) one of its dependencies, mainly publish-swift, was explicitly skipped (but didn't fail or get cancelled)
     if: always() && !failure() && !cancelled() && ${{ needs.setup.outputs.flutter == 'true' }}
     uses: ./.github/workflows/publish-flutter.yml
     with:
@@ -267,6 +271,10 @@ jobs:
     needs:
       - setup
       - publish-swift
+    # The react native package depends on the swift cocoapod to be available at runtime.
+    # To make sure this is will be the case, we run the publishing job only if:
+    #   a) its dependencies (mainly publish-swift) succeeded
+    #   b) one of its dependencies, mainly publish-swift, was explicitly skipped (but didn't fail or get cancelled)
     if: always() && !failure() && !cancelled() && ${{ needs.setup.outputs.react-native == 'true' }}
     uses: ./.github/workflows/publish-react-native.yml
     with:
@@ -300,7 +308,7 @@ jobs:
       - build-bindings-darwin
       - build-bindings-ios
       - build-language-bindings
-    if: ${{ needs.setup.outputs.spm-cocoapods == 'true' }}
+    if: always() && !failure() && !cancelled() && ${{ needs.setup.outputs.spm-cocoapods == 'true' }}
     uses: ./.github/workflows/publish-swift.yml
     with:
       repository: ${{ needs.setup.outputs.repository }}

--- a/.github/workflows/publish-all-platforms.yml
+++ b/.github/workflows/publish-all-platforms.yml
@@ -253,7 +253,9 @@ jobs:
       - publish-swift
       - publish-maven
     # The flutter package depends on the swift and android packages to be available at runtime.
-    if: ${{ needs.setup.outputs.flutter == 'true' }}
+    # Therefore, if swift and/or android publishing is turned on, we will run this job only if swift and/or android is successfully published.
+    # If however swift and/or android is skipped, we will run this job nonetheless.
+    if: ${{ needs.setup.outputs.flutter == 'true' && always() && !failure() && !cancelled() }}
     uses: ./.github/workflows/publish-flutter.yml
     with:
       repository: ${{ needs.setup.outputs.repository }}
@@ -269,7 +271,9 @@ jobs:
       - publish-swift
       - publish-maven
     # The react native package depends on the swift and android packages to be available at runtime.
-    if: ${{ needs.setup.outputs.react-native == 'true' }}
+    # Therefore, if swift and/or android publishing is turned on, we will run this job only if swift and/or android is successfully published.
+    # If however swift and/or android is skipped, we will run this job nonetheless.
+    if: ${{ needs.setup.outputs.react-native == 'true' && always() && !failure() && !cancelled() }}
     uses: ./.github/workflows/publish-react-native.yml
     with:
       repository: ${{ needs.setup.outputs.repository }}
@@ -303,45 +307,13 @@ jobs:
       - build-bindings-ios
       - build-language-bindings
     if: ${{ needs.setup.outputs.spm-cocoapods == 'true' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: publish swift (failing)
-        run: exit 1
-    # uses: ./.github/workflows/publish-swift.yml
-    # with:
-    #   repository: ${{ needs.setup.outputs.repository }}
-    #   ref: ${{ needs.setup.outputs.ref }}
-    #   package-version: ${{ needs.setup.outputs.swift-package-version }}
-    #   publish: ${{ needs.setup.outputs.publish == 'true' }}
-    # secrets:
-    #   REPO_SSH_KEY: ${{ secrets.REPO_SSH_KEY }}
-    #   GITHUB_TOKEN_BREEZ_SDK_SWIFT: ${{ secrets.GITHUB_TOKEN_BREEZ_SDK_SWIFT }} # todo: create token
-    #   COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }} # todo: create token
-
-  debug-print:
-    needs:
-      - setup
-      - publish-swift
-      - publish-maven
-    runs-on: ubuntu-latest
-    if: ${{ always() && !failure() && !cancelled() }}
-    steps:
-      - name: check needs results
-        run: |
-          echo ${{ needs.setup.outputs.spm-cocoapods }}
-          echo ${{ needs.setup.outputs.maven }}
-          echo ${{ needs.publish-swift.result }}
-          echo ${{ needs.publish-maven.result }}
-
-  debug-publish:
-    needs:
-      - setup
-      - publish-swift
-      - publish-maven
-    if: ${{ true && always() && !failure() && !cancelled() }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: check needs results
-        run: |
-          echo ${{ needs.publish-swift.result }}
-          echo ${{ needs.publish-maven.result }}
+    uses: ./.github/workflows/publish-swift.yml
+    with:
+      repository: ${{ needs.setup.outputs.repository }}
+      ref: ${{ needs.setup.outputs.ref }}
+      package-version: ${{ needs.setup.outputs.swift-package-version }}
+      publish: ${{ needs.setup.outputs.publish == 'true' }}
+    secrets:
+      REPO_SSH_KEY: ${{ secrets.REPO_SSH_KEY }}
+      GITHUB_TOKEN_BREEZ_SDK_SWIFT: ${{ secrets.GITHUB_TOKEN_BREEZ_SDK_SWIFT }} # todo: create token
+      COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }} # todo: create token

--- a/.github/workflows/publish-all-platforms.yml
+++ b/.github/workflows/publish-all-platforms.yml
@@ -250,7 +250,8 @@ jobs:
     needs:
       - setup
       - build-language-bindings
-    if: ${{ needs.setup.outputs.flutter == 'true' }}
+      - publish-swift
+    if: always() && !failure() && !cancelled() && ${{ needs.setup.outputs.flutter == 'true' }}
     uses: ./.github/workflows/publish-flutter.yml
     with:
       repository: ${{ needs.setup.outputs.repository }}
@@ -265,7 +266,8 @@ jobs:
   publish-react-native:
     needs:
       - setup
-    if: ${{ needs.setup.outputs.react-native == 'true' }}
+      - publish-swift
+    if: always() && !failure() && !cancelled() && ${{ needs.setup.outputs.react-native == 'true' }}
     uses: ./.github/workflows/publish-react-native.yml
     with:
       repository: ${{ needs.setup.outputs.repository }}

--- a/.github/workflows/publish-all-platforms.yml
+++ b/.github/workflows/publish-all-platforms.yml
@@ -315,5 +315,5 @@ jobs:
       publish: ${{ needs.setup.outputs.publish == 'true' }}
     secrets:
       REPO_SSH_KEY: ${{ secrets.REPO_SSH_KEY }}
-      GITHUB_TOKEN_BREEZ_SDK_SWIFT: ${{ secrets.GITHUB_TOKEN_BREEZ_SDK_SWIFT }} # todo: create token
-      COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }} # todo: create token
+      SWIFT_RELEASE_TOKEN: ${{ secrets. SWIFT_RELEASE_TOKEN }}
+      COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}

--- a/.github/workflows/publish-swift.yml
+++ b/.github/workflows/publish-swift.yml
@@ -1,0 +1,134 @@
+name: Publish Swift Package & CocoaPod
+on:
+  workflow_call:
+    inputs:
+      repository:
+        description: 'sdk repository, defaults to current repository'
+        required: false
+        type: string
+      ref:
+        description: 'commit/tag/branch reference'
+        required: true
+        type: string
+      package-version:
+        description: 'version for the swift package / cocoapod (MAJOR.MINOR.BUILD) (no v prefix)'
+        required: true
+        type: string
+      publish:
+        description: 'value indicating whether to commit/tag a release.'
+        required: true
+        type: boolean
+        default: true
+    secrets:
+      REPO_SSH_KEY:
+        description: 'ssh key to commit to the breez-sdk-swift repository'
+        required: true
+      GITHUB_TOKEN_BREEZ_SDK_SWIFT:
+        description: 'token to create a release to the breez-sdk-swift repository'
+        required: true
+      COCOAPODS_TRUNK_TOKEN:
+        description: 'token to publish to cocoapods'
+        required: true
+
+jobs:
+  build-tag-release:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout breez-sdk-swift repo
+        uses: actions/checkout@v3
+        with:
+          repository: breez/breez-sdk-swift
+          ssh-key: ${{ secrets.REPO_SSH_KEY }}
+          path: breez-sdk-swift
+
+      - name: Checkout breez-sdk repo
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.sha }}
+          path: breez-sdk
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: bindings-swift
+          path: breez-sdk/libs/sdk-bindings/bindings-swift/Sources/BreezSDK/
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: sdk-bindings-aarch64-apple-ios
+          path: breez-sdk/libs/target/aarch64-apple-ios/release/
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: sdk-bindings-ios-universal-sim
+          path: breez-sdk/libs/target/ios-universal-sim/release/
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: sdk-bindings-darwin-universal
+          path: breez-sdk/libs/target/darwin-universal/release/
+
+      - name: Create XCFramework
+        working-directory: breez-sdk/libs/sdk-bindings
+        run: |
+          cp bindings-swift/Sources/BreezSDK/breez_sdkFFI.h bindings-swift/breez_sdkFFI.xcframework/ios-arm64/breez_sdkFFI.framework/Headers
+          cp bindings-swift/Sources/BreezSDK/breez_sdkFFI.h bindings-swift/breez_sdkFFI.xcframework/ios-arm64_x86_64-simulator/breez_sdkFFI.framework/Headers
+          cp bindings-swift/Sources/BreezSDK/breez_sdkFFI.h bindings-swift/breez_sdkFFI.xcframework/macos-arm64_x86_64/breez_sdkFFI.framework/Headers
+          cp ../target/aarch64-apple-ios/release/libbreez_sdk_bindings.a bindings-swift/breez_sdkFFI.xcframework/ios-arm64/breez_sdkFFI.framework/breez_sdkFFI
+          cp ../target/ios-universal-sim/release/libbreez_sdk_bindings.a bindings-swift/breez_sdkFFI.xcframework/ios-arm64_x86_64-simulator/breez_sdkFFI.framework/breez_sdkFFI
+          cp ../target/darwin-universal/release/libbreez_sdk_bindings.a bindings-swift/breez_sdkFFI.xcframework/macos-arm64_x86_64/breez_sdkFFI.framework/breez_sdkFFI
+          rm bindings-swift/Sources/BreezSDK/breez_sdkFFI.h
+          rm bindings-swift/Sources/BreezSDK/breez_sdkFFI.modulemap
+
+      - name: Compress xcframework
+        working-directory: breez-sdk/libs/sdk-bindings/bindings-swift
+        run: |
+          zip -9 -r breez_sdkFFI.xcframework.zip breez_sdkFFI.xcframework
+          echo "XCF_CHECKSUM=`swift package compute-checksum breez_sdkFFI.xcframework.zip`" >> $GITHUB_ENV
+
+      - name: Update swift package
+        working-directory: breez-sdk/libs/sdk-bindings/bindings-swift
+        run: |
+          # Update package definition
+          sed 's#.binaryTarget(name: "breez_sdkFFI", path: "./breez_sdkFFI.xcframework"),#.binaryTarget(name: "breez_sdkFFI", url: "https://github.com/breez/breez-sdk-swift/releases/download/${{ inputs.package-version }}/breez_sdkFFI.xcframework.zip", checksum: "${{ env.XCF_CHECKSUM }}"),#;/.testTarget(name: "BreezSDKTests", dependencies: \["BreezSDK"\]),/d' Package.swift > ../../../../breez-sdk-swift/Package.swift
+          # Update language bindings
+          cp -r Sources ../../../../breez-sdk-swift
+
+      - name: Update cocoapods definitions
+        working-directory: breez-sdk-swift
+        run: |
+          sed -i '' 's#^.\{2\}spec.version.*$#  spec.version                = "${{ inputs.package-version }}"#' breez_sdkFFI.podspec
+          sed -i '' 's#^.\{2\}spec.version.*$#  spec.version                = "${{ inputs.package-version }}"#' BreezSDK.podspec
+
+      - name: Tag swift package
+        working-directory: breez-sdk-swift
+        if: ${{ inputs.publish }}
+        run: |
+          git add Package.swift
+          git add Sources
+          git add breez_sdkFFI.podspec
+          git add BreezSDK.podspec
+          git commit -m "Update Breez SDK Swift bindings to version ${{ inputs.package-version }}"
+          git push
+          git tag ${{ inputs.package-version }} -m "${{ inputs.package-version }}"
+          git push --tags
+
+      - name: Release and attach XCFramework binary artifact
+        if: ${{ inputs.publish }}
+        uses: ncipollo/release-action@v1
+        with:
+          repo: breez/breez-sdk-swift
+          tag: ${{ inputs.package-version }}
+          token: ${{ secrets.GITHUB_TOKEN_BREEZ_SDK_SWIFT }}
+          name: ${{ inputs.package-version }}
+          artifacts: "breez-sdk/libs/sdk-bindings/bindings-swift/breez_sdkFFI.xcframework.zip"
+          prerelease: true
+
+      - name: Push update to Cocoapods trunk
+        working-directory: breez-sdk-swift
+        if: ${{ inputs.publish }}
+        env:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
+        run: |
+          pod trunk push breez_sdkFFI.podspec --allow-warnings
+          pod trunk push BreezSDK.podspec --allow-warnings --synchronous

--- a/.github/workflows/publish-swift.yml
+++ b/.github/workflows/publish-swift.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Archive xcframework
         uses: actions/upload-artifact@v4
         with:
-          name: breez_sdkFFI-${{ inputs.package-version || intputs.ref }}.xcframework
+          name: breez_sdkFFI-${{ inputs.package-version || inputs.ref }}.xcframework
           path: breez-sdk/libs/sdk-bindings/bindings-swift/breez_sdkFFI.xcframework
 
       - name: Update swift package

--- a/.github/workflows/publish-swift.yml
+++ b/.github/workflows/publish-swift.yml
@@ -23,7 +23,7 @@ on:
       REPO_SSH_KEY:
         description: 'ssh key to commit to the breez-sdk-swift repository'
         required: true
-      GITHUB_TOKEN_BREEZ_SDK_SWIFT:
+      SWIFT_RELEASE_TOKEN:
         description: 'token to create a release to the breez-sdk-swift repository'
         required: true
       COCOAPODS_TRUNK_TOKEN:

--- a/.github/workflows/publish-swift.yml
+++ b/.github/workflows/publish-swift.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Archive xcframework
         uses: actions/upload-artifact@v4
         with:
-          name: breez_sdkFFI-${{ inputs.package-version || intouts.ref }}.xcframework
+          name: breez_sdkFFI-${{ inputs.package-version || intputs.ref }}.xcframework
           path: breez-sdk/libs/sdk-bindings/bindings-swift/breez_sdkFFI.xcframework
 
       - name: Update swift package

--- a/.github/workflows/publish-swift.yml
+++ b/.github/workflows/publish-swift.yml
@@ -121,13 +121,14 @@ jobs:
 
       - name: Release and attach XCFramework binary artifact
         if: ${{ inputs.publish }}
-        uses: ncipollo/release-action@v1
+        uses: softprops/action-gh-release@v2
         with:
-          repo: breez/breez-sdk-swift
-          tag: ${{ inputs.package-version }}
+          repository: breez/breez-sdk-swift
+          files: |
+            breez-sdk/libs/sdk-bindings/bindings-swift/breez_sdkFFI.xcframework.zip
+          tag_name: ${{ inputs.package-version }}
+          generate_release_notes: false
           token: ${{ secrets.SWIFT_RELEASE_TOKEN }}
-          name: ${{ inputs.package-version }}
-          artifacts: "breez-sdk/libs/sdk-bindings/bindings-swift/breez_sdkFFI.xcframework.zip"
           prerelease: true
 
       - name: Push update to Cocoapods trunk

--- a/.github/workflows/publish-swift.yml
+++ b/.github/workflows/publish-swift.yml
@@ -86,6 +86,12 @@ jobs:
           zip -9 -r breez_sdkFFI.xcframework.zip breez_sdkFFI.xcframework
           echo "XCF_CHECKSUM=`swift package compute-checksum breez_sdkFFI.xcframework.zip`" >> $GITHUB_ENV
 
+      - name: Archive xcframework
+        uses: actions/upload-artifact@v4
+        with:
+          name: breez_sdkFFI-${{ inputs.package-version || intouts.ref }}.xcframework
+          path: breez-sdk/libs/sdk-bindings/bindings-swift/breez_sdkFFI.xcframework
+
       - name: Update swift package
         working-directory: breez-sdk/libs/sdk-bindings/bindings-swift
         run: |

--- a/.github/workflows/publish-swift.yml
+++ b/.github/workflows/publish-swift.yml
@@ -125,7 +125,7 @@ jobs:
         with:
           repo: breez/breez-sdk-swift
           tag: ${{ inputs.package-version }}
-          token: ${{ secrets.GITHUB_TOKEN_BREEZ_SDK_SWIFT }}
+          token: ${{ secrets.SWIFT_RELEASE_TOKEN }}
           name: ${{ inputs.package-version }}
           artifacts: "breez-sdk/libs/sdk-bindings/bindings-swift/breez_sdkFFI.xcframework.zip"
           prerelease: true


### PR DESCRIPTION
## Swift Publishing Workflow Consolidation

This PR relocates the Swift publishing workflow from the [`breez/breez-sdk-swift`](https://github.com/breez/breez-sdk-swift/blob/main/.github/workflows/publish-swift-package.yaml) repository to the main repository. This change simplifies the publishing process by integrating it with the main repo's CI workflow.

### 📖 Overview

Previously, the Swift publishing workflow required separate triggers, unlike other platforms managed centrally in the main repo via the [`publish-all-platforms`](https://github.com/breez/breez-sdk/blob/main/.github/workflows/publish-all-platforms.yml) workflow. This PR enhances the Swift package publishing by:

- Streamlining the publishing process by integrating the Swift package into the main repo's CI workflow.
- Improving build runtime and reliability by reusing the already built binary SDK and language bindings from the main repo's workflows.

One interesting point: Because our Flutter and React Native packages rely on the Swift package at runtime, the PR includes logic to ensure that the Flutter and React Native packages are only published if the Swift package is successfully published too, preventing issues with runtime dependencies. If the Swift package is not set to be published, then the Flutter and React Native packages are published nonetheless allowing us to release updates to those packages that depend on an already published Swift package. Special thanks to @JssDWt for the solution adapted from [this PR](https://github.com/breez/breez-sdk/pull/620).

### ❓ Outstanding Questions

Before merging this PR, we need to address two key points. The first is straightforward, while the second requires some feedback.

1. **Setting CocoaPods Token**  
   We need to set `secrets.COCOAPODS_TRUNK_TOKEN` in the main repo to publish to the CocoaPods trunk. This token is currently only set in the `breez-sdk-swift` repo (I believe we're using @roeierez's token there). The simplest solution is to just move the token from the Swift repo to the main repo.

2. **Publishing `breez_sdkFFI.xcframework`**  
   The Swift package and CocoaPods require a download link to the `breez_sdkFFI.xcframework` binary artifact. Currently, we create a GitHub release in the `breez-sdk-swift` repo and attach the XCFramework as a binary artifact. Moving the workflow to the main repo presents a few challenges for maintaining this setup. I believe options 1 and 3 are the most straightforward, with option 2 being a viable alternative that may need some experimentation.

   - **Option 1**: Use a GitHub Personal Access Token to replicate the current setup. This would involve creating a release in the `breez-sdk-swift` repo from the CI workflow in the main repo. While simple, this requires using user-bound tokens with broad permissions, which isn't ideal.
   - **Option 2**: Use a GitHub app to provide short-lived tokens for the workflow. This option offers better security with non-user-bound tokens but requires more setup.
   - **Option 3**: Create the release in the main `breez-sdk-greenlight` repo instead of the `breez-sdk-swift` repo and attach the artifact there. This option is easy to set up and doesn't require special tokens, but it requires releases to be created on the main repo whenever we want to update or publish the Swift package. Not ideal, imo.
   - **Option 4**: Find an alternative hosting solution outside of GitHub for the artifact, accessible to our users.

### ✋ Feedback Request

I'd appreciate your thoughts on these options, particularly regarding the second point. Looking forward to your feedback. 🙏 