### PR TITLE
Trampoline payments

### DIFF
--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -1386,7 +1386,7 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 [[package]]
 name = "gl-client"
 version = "0.2.0"
-source = "git+https://github.com/Blockstream/greenlight.git?rev=b9d1ecb9ea7325b041d08ddc171486fdad646a63#b9d1ecb9ea7325b041d08ddc171486fdad646a63"
+source = "git+https://github.com/Blockstream/greenlight.git?rev=43f02207182e28a4d62e7aa1c79cd098f9b300ba#43f02207182e28a4d62e7aa1c79cd098f9b300ba"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -634,6 +634,7 @@ dictionary LnUrlPayErrorData {
 dictionary LnUrlPayRequest {
     LnUrlPayRequestData data;
     u64 amount_msat;
+    boolean use_trampoline;
     string? comment = null;
     string? payment_label = null;
     boolean? validate_success_action_url = null;
@@ -766,6 +767,7 @@ dictionary RedeemOnchainFundsResponse {
 
 dictionary SendPaymentRequest {
     string bolt11;
+    boolean use_trampoline;
     u64? amount_msat = null;
     string? label = null;
 };

--- a/libs/sdk-common/src/lnurl/specs/pay.rs
+++ b/libs/sdk-common/src/lnurl/specs/pay.rs
@@ -132,6 +132,10 @@ pub mod model {
         pub data: LnUrlPayRequestData,
         /// The amount in millisatoshis for this payment
         pub amount_msat: u64,
+        /// Trampoline payments outsource pathfinding to the LSP. Trampoline payments can improve
+        /// payment performance, but are generally more expensive in terms of fees and they
+        /// compromise on privacy.
+        pub use_trampoline: bool,
         /// An optional comment for this payment
         pub comment: Option<String>,
         /// The external label or identifier of the [Payment]

--- a/libs/sdk-core/Cargo.toml
+++ b/libs/sdk-core/Cargo.toml
@@ -16,7 +16,7 @@ hex = { workspace = true }
 # The switch to 0.2 will happen with https://github.com/breez/breez-sdk/pull/724
 gl-client = { git = "https://github.com/Blockstream/greenlight.git", features = [
     "permissive",
-], rev = "b9d1ecb9ea7325b041d08ddc171486fdad646a63" }
+], rev = "43f02207182e28a4d62e7aa1c79cd098f9b300ba" }
 zbase32 = "0.1.2"
 base64 = { workspace = true }
 chrono = "0.4"

--- a/libs/sdk-core/src/binding.rs
+++ b/libs/sdk-core/src/binding.rs
@@ -123,6 +123,7 @@ pub struct _RouteHintHop {
 pub struct _LnUrlPayRequest {
     pub data: LnUrlPayRequestData,
     pub amount_msat: u64,
+    pub use_trampoline: bool,
     pub comment: Option<String>,
     pub payment_label: Option<String>,
     pub validate_success_action_url: Option<bool>,

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -365,6 +365,7 @@ impl BreezServices {
                 let pay_req = SendPaymentRequest {
                     bolt11: cb.pr.clone(),
                     amount_msat: None,
+                    use_trampoline: req.use_trampoline,
                     label: req.payment_label,
                 };
                 let invoice = parse_invoice(cb.pr.as_str())?;

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -1412,15 +1412,15 @@ impl BreezServices {
             .await;
 
         // Sync node state
-        let sync_breez_services = self.clone();
-        match sync_breez_services.persister.get_node_state()? {
+        match self.persister.get_node_state()? {
             Some(node) => {
-                info!("Starting existing node {}", node.id)
+                info!("Starting existing node {}", node.id);
+                self.connect_lsp_peer(node.id).await?;
             }
             None => {
                 // In case it is a first run we sync in foreground to get the node state.
                 info!("First run, syncing in foreground");
-                sync_breez_services.sync().await?;
+                self.sync().await?;
                 info!("First run, finished running syncing in foreground");
             }
         }

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -755,8 +755,7 @@ impl BreezServices {
             }
         };
 
-        self.persister.set_lsp_id(lsp_id)?;
-        self.persister.set_lsp_pubkey(lsp_pubkey)?;
+        self.persister.set_lsp(lsp_id, Some(lsp_pubkey))?;
         self.sync().await?;
         if let Some(webhook_url) = self.persister.get_webhook_url()? {
             self.register_payment_notifications(webhook_url).await?
@@ -1257,8 +1256,7 @@ impl BreezServices {
             None => return Ok(()),
         };
 
-        self.persister.set_lsp_id(lsp.id)?;
-        self.persister.set_lsp_pubkey(lsp.pubkey.clone())?;
+        self.persister.set_lsp(lsp.id, Some(lsp.pubkey.clone()))?;
         let node_state = match self.node_info() {
             Ok(node_state) => node_state,
             Err(_) => return Ok(()),
@@ -2409,7 +2407,7 @@ impl BreezServicesBuilder {
 
         let current_lsp_id = persister.get_lsp_id()?;
         if current_lsp_id.is_none() && self.config.default_lsp_id.is_some() {
-            persister.set_lsp_id(self.config.default_lsp_id.clone().unwrap())?;
+            persister.set_lsp(self.config.default_lsp_id.clone().unwrap(), None)?;
         }
 
         let payment_receiver = Arc::new(PaymentReceiver {
@@ -3233,7 +3231,7 @@ pub(crate) mod tests {
         let node_api = Arc::new(MockNodeAPI::new(dummy_node_state.clone()));
 
         let breez_server = Arc::new(MockBreezServer {});
-        persister.set_lsp_id(breez_server.lsp_id()).unwrap();
+        persister.set_lsp(breez_server.lsp_id(), None).unwrap();
         persister.set_node_state(&dummy_node_state).unwrap();
 
         let receiver: Arc<dyn Receiver> = Arc::new(PaymentReceiver {
@@ -3340,7 +3338,7 @@ pub(crate) mod tests {
         let persister = Arc::new(create_test_persister(test_config.clone()));
         persister.init()?;
         persister.insert_or_update_payments(&known_payments, false)?;
-        persister.set_lsp_id(MockBreezServer {}.lsp_id())?;
+        persister.set_lsp(MockBreezServer {}.lsp_id(), None)?;
 
         let mut builder = BreezServicesBuilder::new(test_config.clone());
         let breez_services = builder

--- a/libs/sdk-core/src/bridge_generated.io.rs
+++ b/libs/sdk-core/src/bridge_generated.io.rs
@@ -868,6 +868,7 @@ impl Wire2Api<LnUrlPayRequest> for wire_LnUrlPayRequest {
         LnUrlPayRequest {
             data: self.data.wire2api(),
             amount_msat: self.amount_msat.wire2api(),
+            use_trampoline: self.use_trampoline.wire2api(),
             comment: self.comment.wire2api(),
             payment_label: self.payment_label.wire2api(),
             validate_success_action_url: self.validate_success_action_url.wire2api(),
@@ -1082,6 +1083,7 @@ impl Wire2Api<SendPaymentRequest> for wire_SendPaymentRequest {
     fn wire2api(self) -> SendPaymentRequest {
         SendPaymentRequest {
             bolt11: self.bolt11.wire2api(),
+            use_trampoline: self.use_trampoline.wire2api(),
             amount_msat: self.amount_msat.wire2api(),
             label: self.label.wire2api(),
         }
@@ -1238,6 +1240,7 @@ pub struct wire_LnUrlAuthRequestData {
 pub struct wire_LnUrlPayRequest {
     data: wire_LnUrlPayRequestData,
     amount_msat: u64,
+    use_trampoline: bool,
     comment: *mut wire_uint_8_list,
     payment_label: *mut wire_uint_8_list,
     validate_success_action_url: *mut bool,
@@ -1402,6 +1405,7 @@ pub struct wire_SendOnchainRequest {
 #[derive(Clone)]
 pub struct wire_SendPaymentRequest {
     bolt11: *mut wire_uint_8_list,
+    use_trampoline: bool,
     amount_msat: *mut u64,
     label: *mut wire_uint_8_list,
 }
@@ -1647,6 +1651,7 @@ impl NewWithNullPtr for wire_LnUrlPayRequest {
         Self {
             data: Default::default(),
             amount_msat: Default::default(),
+            use_trampoline: Default::default(),
             comment: core::ptr::null_mut(),
             payment_label: core::ptr::null_mut(),
             validate_success_action_url: core::ptr::null_mut(),
@@ -2011,6 +2016,7 @@ impl NewWithNullPtr for wire_SendPaymentRequest {
     fn new_with_null_ptr() -> Self {
         Self {
             bolt11: core::ptr::null_mut(),
+            use_trampoline: Default::default(),
             amount_msat: core::ptr::null_mut(),
             label: core::ptr::null_mut(),
         }

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -2198,7 +2198,7 @@ impl TryFrom<cln::ListpaysPays> for Payment {
                     .as_ref()
                     .map_or(0, |i| i.amount_msat.unwrap_or_default()),
             },
-            fee_msat: payment_amount_sent - payment_amount,
+            fee_msat: payment_amount_sent.saturating_sub(payment_amount),
             status,
             error: None,
             description: ln_invoice.map(|i| i.description).unwrap_or_default(),

--- a/libs/sdk-core/src/lnurl/pay.rs
+++ b/libs/sdk-core/src/lnurl/pay.rs
@@ -402,6 +402,7 @@ pub(crate) mod tests {
             .lnurl_pay(LnUrlPayRequest {
                 data: pay_req,
                 amount_msat: user_amount_msat,
+                use_trampoline: false,
                 comment: Some(comment),
                 payment_label: None,
                 validate_success_action_url: None,
@@ -447,6 +448,7 @@ pub(crate) mod tests {
             .lnurl_pay(LnUrlPayRequest {
                 data: pay_req,
                 amount_msat: user_amount_msat,
+                use_trampoline: false,
                 comment: Some(comment),
                 payment_label: None,
                 validate_success_action_url: None,
@@ -478,6 +480,7 @@ pub(crate) mod tests {
             .lnurl_pay(LnUrlPayRequest {
                 data: pay_req,
                 amount_msat: user_amount_msat,
+                use_trampoline: false,
                 comment: Some(comment),
                 payment_label: None,
                 validate_success_action_url: None,
@@ -512,6 +515,7 @@ pub(crate) mod tests {
             .lnurl_pay(LnUrlPayRequest {
                 data: pay_req,
                 amount_msat: user_amount_msat,
+                use_trampoline: false,
                 comment: Some(comment),
                 payment_label: None,
                 validate_success_action_url: None,
@@ -561,6 +565,7 @@ pub(crate) mod tests {
             .lnurl_pay(LnUrlPayRequest {
                 data: pay_req,
                 amount_msat: user_amount_msat,
+                use_trampoline: false,
                 comment: Some(comment),
                 payment_label: None,
                 validate_success_action_url: None,
@@ -592,6 +597,7 @@ pub(crate) mod tests {
             .lnurl_pay(LnUrlPayRequest {
                 data: pay_req,
                 amount_msat: user_amount_msat,
+                use_trampoline: false,
                 comment: Some(comment),
                 payment_label: None,
                 validate_success_action_url: None,
@@ -633,6 +639,7 @@ pub(crate) mod tests {
             .lnurl_pay(LnUrlPayRequest {
                 data: pay_req,
                 amount_msat: user_amount_msat,
+                use_trampoline: false,
                 comment: Some(comment),
                 payment_label: None,
                 validate_success_action_url: None,
@@ -693,6 +700,7 @@ pub(crate) mod tests {
                 comment: Some(comment),
                 payment_label: None,
                 validate_success_action_url: Some(true),
+                use_trampoline: false,
             })
             .await;
         // An invalid Success Action URL results in an error
@@ -727,6 +735,7 @@ pub(crate) mod tests {
                 comment: Some(comment),
                 payment_label: None,
                 validate_success_action_url: Some(false),
+                use_trampoline: false,
             })
             .await?
         {
@@ -811,6 +820,7 @@ pub(crate) mod tests {
             .lnurl_pay(LnUrlPayRequest {
                 data: pay_req,
                 amount_msat: user_amount_msat,
+                use_trampoline: false,
                 comment: Some(comment),
                 payment_label: None,
                 validate_success_action_url: None,
@@ -896,6 +906,7 @@ pub(crate) mod tests {
             .lnurl_pay(LnUrlPayRequest {
                 data: pay_req,
                 amount_msat: user_amount_msat,
+                use_trampoline: false,
                 comment: Some(comment),
                 payment_label: None,
                 validate_success_action_url: None,

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -847,6 +847,10 @@ pub struct ReceivePaymentResponse {
 pub struct SendPaymentRequest {
     /// The bolt11 invoice
     pub bolt11: String,
+    /// Trampoline payments outsource pathfinding to the LSP. Trampoline payments can improve
+    /// payment performance, but are generally more expensive in terms of fees and they
+    /// compromise on privacy.
+    pub use_trampoline: bool,
     /// The amount to pay in millisatoshis. Should only be set when `bolt11` is a zero-amount invoice.
     pub amount_msat: Option<u64>,
     /// The external label or identifier of the [Payment]

--- a/libs/sdk-core/src/node_api.rs
+++ b/libs/sdk-core/src/node_api.rs
@@ -137,6 +137,13 @@ pub trait NodeAPI: Send + Sync {
         extra_tlvs: Option<Vec<TlvEntry>>,
         label: Option<String>,
     ) -> NodeResult<Payment>;
+    async fn send_trampoline_payment(
+        &self,
+        bolt11: String,
+        amount_msat: u64,
+        label: Option<String>,
+        trampoline_node_id: Vec<u8>,
+    ) -> NodeResult<Payment>;
     async fn start(&self) -> NodeResult<String>;
 
     /// Attempts to find a payment path "manually" and send the htlcs in a way that will drain

--- a/libs/sdk-core/src/persist/settings.rs
+++ b/libs/sdk-core/src/persist/settings.rs
@@ -58,6 +58,15 @@ impl SqliteStorage {
     pub fn get_lsp_id(&self) -> PersistResult<Option<String>> {
         self.get_setting("lsp".to_string())
     }
+
+    pub fn set_lsp_pubkey(&self, pubkey: String) -> PersistResult<()> {
+        self.update_setting("lsp-pubkey".to_string(), pubkey)
+    }
+
+    #[allow(dead_code)]
+    pub fn get_lsp_pubkey(&self) -> PersistResult<Option<String>> {
+        self.get_setting("lsp-pubkey".to_string())
+    }
 }
 
 #[test]

--- a/libs/sdk-core/src/persist/settings.rs
+++ b/libs/sdk-core/src/persist/settings.rs
@@ -51,19 +51,33 @@ impl SqliteStorage {
         Ok(vec)
     }
 
-    pub fn set_lsp_id(&self, lsp_id: String) -> PersistResult<()> {
-        self.update_setting("lsp".to_string(), lsp_id)
+    pub fn set_lsp(&self, lsp_id: String, pubkey: Option<String>) -> PersistResult<()> {
+        if let Some(pubkey) = pubkey {
+            self.update_setting("lsp".to_string(), lsp_id)?;
+            self.update_setting("lsp-pubkey".to_string(), pubkey)?;
+            return Ok(());
+        }
+
+        match self.get_setting("lsp".to_string())? {
+            Some(old_lsp_id) => {
+                if old_lsp_id != lsp_id {
+                    self.update_setting("lsp".to_string(), lsp_id)?;
+                    self.delete_setting("lsp-pubkey".to_string())?;
+                }
+            }
+            None => {
+                self.update_setting("lsp".to_string(), lsp_id)?;
+                self.delete_setting("lsp-pubkey".to_string())?;
+            }
+        };
+
+        Ok(())
     }
 
     pub fn get_lsp_id(&self) -> PersistResult<Option<String>> {
         self.get_setting("lsp".to_string())
     }
 
-    pub fn set_lsp_pubkey(&self, pubkey: String) -> PersistResult<()> {
-        self.update_setting("lsp-pubkey".to_string(), pubkey)
-    }
-
-    #[allow(dead_code)]
     pub fn get_lsp_pubkey(&self) -> PersistResult<Option<String>> {
         self.get_setting("lsp-pubkey".to_string())
     }

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -381,6 +381,17 @@ impl NodeAPI for MockNodeAPI {
         Ok(payment)
     }
 
+    async fn send_trampoline_payment(
+        &self,
+        bolt11: String,
+        _amount_msat: u64,
+        _label: Option<String>,
+        _trampoline_id: Vec<u8>,
+    ) -> NodeResult<Payment> {
+        let payment = self.add_dummy_payment_for(bolt11, None, None).await?;
+        Ok(payment)
+    }
+
     async fn send_spontaneous_payment(
         &self,
         _node_id: String,

--- a/libs/sdk-flutter/ios/Classes/bridge_generated.h
+++ b/libs/sdk-flutter/ios/Classes/bridge_generated.h
@@ -114,6 +114,7 @@ typedef struct wire_ListPaymentsRequest {
 
 typedef struct wire_SendPaymentRequest {
   struct wire_uint_8_list *bolt11;
+  bool use_trampoline;
   uint64_t *amount_msat;
   struct wire_uint_8_list *label;
 } wire_SendPaymentRequest;
@@ -169,6 +170,7 @@ typedef struct wire_LnUrlPayRequestData {
 typedef struct wire_LnUrlPayRequest {
   struct wire_LnUrlPayRequestData data;
   uint64_t amount_msat;
+  bool use_trampoline;
   struct wire_uint_8_list *comment;
   struct wire_uint_8_list *payment_label;
   bool *validate_success_action_url;

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -862,6 +862,7 @@ class LnUrlPayErrorData {
 class LnUrlPayRequest {
   final LnUrlPayRequestData data;
   final int amountMsat;
+  final bool useTrampoline;
   final String? comment;
   final String? paymentLabel;
   final bool? validateSuccessActionUrl;
@@ -869,6 +870,7 @@ class LnUrlPayRequest {
   const LnUrlPayRequest({
     required this.data,
     required this.amountMsat,
+    required this.useTrampoline,
     this.comment,
     this.paymentLabel,
     this.validateSuccessActionUrl,
@@ -1704,6 +1706,11 @@ class SendPaymentRequest {
   /// The bolt11 invoice
   final String bolt11;
 
+  /// Trampoline payments outsource pathfinding to the LSP. Trampoline payments can improve
+  /// payment performance, but are generally more expensive in terms of fees and they
+  /// compromise on privacy.
+  final bool useTrampoline;
+
   /// The amount to pay in millisatoshis. Should only be set when `bolt11` is a zero-amount invoice.
   final int? amountMsat;
 
@@ -1712,6 +1719,7 @@ class SendPaymentRequest {
 
   const SendPaymentRequest({
     required this.bolt11,
+    required this.useTrampoline,
     this.amountMsat,
     this.label,
   });
@@ -4840,6 +4848,7 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
   void _api_fill_to_wire_ln_url_pay_request(LnUrlPayRequest apiObj, wire_LnUrlPayRequest wireObj) {
     _api_fill_to_wire_ln_url_pay_request_data(apiObj.data, wireObj.data);
     wireObj.amount_msat = api2wire_u64(apiObj.amountMsat);
+    wireObj.use_trampoline = api2wire_bool(apiObj.useTrampoline);
     wireObj.comment = api2wire_opt_String(apiObj.comment);
     wireObj.payment_label = api2wire_opt_String(apiObj.paymentLabel);
     wireObj.validate_success_action_url = api2wire_opt_box_autoadd_bool(apiObj.validateSuccessActionUrl);
@@ -4999,6 +5008,7 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
 
   void _api_fill_to_wire_send_payment_request(SendPaymentRequest apiObj, wire_SendPaymentRequest wireObj) {
     wireObj.bolt11 = api2wire_String(apiObj.bolt11);
+    wireObj.use_trampoline = api2wire_bool(apiObj.useTrampoline);
     wireObj.amount_msat = api2wire_opt_box_autoadd_u64(apiObj.amountMsat);
     wireObj.label = api2wire_opt_String(apiObj.label);
   }
@@ -6576,6 +6586,9 @@ final class wire_ListPaymentsRequest extends ffi.Struct {
 final class wire_SendPaymentRequest extends ffi.Struct {
   external ffi.Pointer<wire_uint_8_list> bolt11;
 
+  @ffi.Bool()
+  external bool use_trampoline;
+
   external ffi.Pointer<ffi.Uint64> amount_msat;
 
   external ffi.Pointer<wire_uint_8_list> label;
@@ -6670,6 +6683,9 @@ final class wire_LnUrlPayRequest extends ffi.Struct {
 
   @ffi.Uint64()
   external int amount_msat;
+
+  @ffi.Bool()
+  external bool use_trampoline;
 
   external ffi.Pointer<wire_uint_8_list> comment;
 

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -1150,6 +1150,7 @@ fun asLnUrlPayRequest(lnUrlPayRequest: ReadableMap): LnUrlPayRequest? {
             arrayOf(
                 "data",
                 "amountMsat",
+                "useTrampoline",
             ),
         )
     ) {
@@ -1157,6 +1158,7 @@ fun asLnUrlPayRequest(lnUrlPayRequest: ReadableMap): LnUrlPayRequest? {
     }
     val data = lnUrlPayRequest.getMap("data")?.let { asLnUrlPayRequestData(it) }!!
     val amountMsat = lnUrlPayRequest.getDouble("amountMsat").toULong()
+    val useTrampoline = lnUrlPayRequest.getBoolean("useTrampoline")
     val comment = if (hasNonNullKey(lnUrlPayRequest, "comment")) lnUrlPayRequest.getString("comment") else null
     val paymentLabel = if (hasNonNullKey(lnUrlPayRequest, "paymentLabel")) lnUrlPayRequest.getString("paymentLabel") else null
     val validateSuccessActionUrl =
@@ -1172,6 +1174,7 @@ fun asLnUrlPayRequest(lnUrlPayRequest: ReadableMap): LnUrlPayRequest? {
     return LnUrlPayRequest(
         data,
         amountMsat,
+        useTrampoline,
         comment,
         paymentLabel,
         validateSuccessActionUrl,
@@ -1182,6 +1185,7 @@ fun readableMapOf(lnUrlPayRequest: LnUrlPayRequest): ReadableMap =
     readableMapOf(
         "data" to readableMapOf(lnUrlPayRequest.data),
         "amountMsat" to lnUrlPayRequest.amountMsat,
+        "useTrampoline" to lnUrlPayRequest.useTrampoline,
         "comment" to lnUrlPayRequest.comment,
         "paymentLabel" to lnUrlPayRequest.paymentLabel,
         "validateSuccessActionUrl" to lnUrlPayRequest.validateSuccessActionUrl,
@@ -3199,16 +3203,19 @@ fun asSendPaymentRequest(sendPaymentRequest: ReadableMap): SendPaymentRequest? {
             sendPaymentRequest,
             arrayOf(
                 "bolt11",
+                "useTrampoline",
             ),
         )
     ) {
         return null
     }
     val bolt11 = sendPaymentRequest.getString("bolt11")!!
+    val useTrampoline = sendPaymentRequest.getBoolean("useTrampoline")
     val amountMsat = if (hasNonNullKey(sendPaymentRequest, "amountMsat")) sendPaymentRequest.getDouble("amountMsat").toULong() else null
     val label = if (hasNonNullKey(sendPaymentRequest, "label")) sendPaymentRequest.getString("label") else null
     return SendPaymentRequest(
         bolt11,
+        useTrampoline,
         amountMsat,
         label,
     )
@@ -3217,6 +3224,7 @@ fun asSendPaymentRequest(sendPaymentRequest: ReadableMap): SendPaymentRequest? {
 fun readableMapOf(sendPaymentRequest: SendPaymentRequest): ReadableMap =
     readableMapOf(
         "bolt11" to sendPaymentRequest.bolt11,
+        "useTrampoline" to sendPaymentRequest.useTrampoline,
         "amountMsat" to sendPaymentRequest.amountMsat,
         "label" to sendPaymentRequest.label,
     )

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -1322,6 +1322,9 @@ enum BreezSDKMapper {
         guard let amountMsat = lnUrlPayRequest["amountMsat"] as? UInt64 else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amountMsat", typeName: "LnUrlPayRequest"))
         }
+        guard let useTrampoline = lnUrlPayRequest["useTrampoline"] as? Bool else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "useTrampoline", typeName: "LnUrlPayRequest"))
+        }
         var comment: String?
         if hasNonNilKey(data: lnUrlPayRequest, key: "comment") {
             guard let commentTmp = lnUrlPayRequest["comment"] as? String else {
@@ -1347,6 +1350,7 @@ enum BreezSDKMapper {
         return LnUrlPayRequest(
             data: data,
             amountMsat: amountMsat,
+            useTrampoline: useTrampoline,
             comment: comment,
             paymentLabel: paymentLabel,
             validateSuccessActionUrl: validateSuccessActionUrl
@@ -1357,6 +1361,7 @@ enum BreezSDKMapper {
         return [
             "data": dictionaryOf(lnUrlPayRequestData: lnUrlPayRequest.data),
             "amountMsat": lnUrlPayRequest.amountMsat,
+            "useTrampoline": lnUrlPayRequest.useTrampoline,
             "comment": lnUrlPayRequest.comment == nil ? nil : lnUrlPayRequest.comment,
             "paymentLabel": lnUrlPayRequest.paymentLabel == nil ? nil : lnUrlPayRequest.paymentLabel,
             "validateSuccessActionUrl": lnUrlPayRequest.validateSuccessActionUrl == nil ? nil : lnUrlPayRequest.validateSuccessActionUrl,
@@ -3602,6 +3607,9 @@ enum BreezSDKMapper {
         guard let bolt11 = sendPaymentRequest["bolt11"] as? String else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "bolt11", typeName: "SendPaymentRequest"))
         }
+        guard let useTrampoline = sendPaymentRequest["useTrampoline"] as? Bool else {
+            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "useTrampoline", typeName: "SendPaymentRequest"))
+        }
         var amountMsat: UInt64?
         if hasNonNilKey(data: sendPaymentRequest, key: "amountMsat") {
             guard let amountMsatTmp = sendPaymentRequest["amountMsat"] as? UInt64 else {
@@ -3619,6 +3627,7 @@ enum BreezSDKMapper {
 
         return SendPaymentRequest(
             bolt11: bolt11,
+            useTrampoline: useTrampoline,
             amountMsat: amountMsat,
             label: label
         )
@@ -3627,6 +3636,7 @@ enum BreezSDKMapper {
     static func dictionaryOf(sendPaymentRequest: SendPaymentRequest) -> [String: Any?] {
         return [
             "bolt11": sendPaymentRequest.bolt11,
+            "useTrampoline": sendPaymentRequest.useTrampoline,
             "amountMsat": sendPaymentRequest.amountMsat == nil ? nil : sendPaymentRequest.amountMsat,
             "label": sendPaymentRequest.label == nil ? nil : sendPaymentRequest.label,
         ]

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -191,6 +191,7 @@ export interface LnUrlPayErrorData {
 export interface LnUrlPayRequest {
     data: LnUrlPayRequestData
     amountMsat: number
+    useTrampoline: boolean
     comment?: string
     paymentLabel?: string
     validateSuccessActionUrl?: boolean
@@ -498,6 +499,7 @@ export interface SendOnchainResponse {
 
 export interface SendPaymentRequest {
     bolt11: string
+    useTrampoline: boolean
     amountMsat?: number
     label?: string
 }

--- a/tools/sdk-cli/Cargo.lock
+++ b/tools/sdk-cli/Cargo.lock
@@ -1247,7 +1247,7 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 [[package]]
 name = "gl-client"
 version = "0.2.0"
-source = "git+https://github.com/Blockstream/greenlight.git?rev=b9d1ecb9ea7325b041d08ddc171486fdad646a63#b9d1ecb9ea7325b041d08ddc171486fdad646a63"
+source = "git+https://github.com/Blockstream/greenlight.git?rev=43f02207182e28a4d62e7aa1c79cd098f9b300ba#43f02207182e28a4d62e7aa1c79cd098f9b300ba"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -245,12 +245,14 @@ pub(crate) async fn handle_command(
             bolt11,
             amount_msat,
             label,
+            use_trampoline,
         } => {
             let payment = sdk()?
                 .send_payment(SendPaymentRequest {
                     bolt11,
                     amount_msat,
                     label,
+                    use_trampoline,
                 })
                 .await?;
             serde_json::to_string_pretty(&payment).map_err(|e| e.into())
@@ -470,6 +472,7 @@ pub(crate) async fn handle_command(
             lnurl,
             label,
             validate_success_url,
+            use_trampoline,
         } => match parse(&lnurl).await? {
             LnUrlPay { data: pd } => {
                 let prompt = format!(
@@ -482,6 +485,7 @@ pub(crate) async fn handle_command(
                     .lnurl_pay(LnUrlPayRequest {
                         data: pd,
                         amount_msat: amount_msat.parse::<u64>()?,
+                        use_trampoline,
                         comment: None,
                         payment_label: label,
                         validate_success_action_url: validate_success_url,

--- a/tools/sdk-cli/src/commands.rs
+++ b/tools/sdk-cli/src/commands.rs
@@ -50,6 +50,10 @@ pub(crate) enum Commands {
         /// The external label or identifier of the payment
         #[clap(name = "label", short = 'l', long = "label")]
         label: Option<String>,
+
+        /// If use_trampoline is set, trampoline payments will be attempted.
+        #[clap(long, action)]
+        use_trampoline: bool,
     },
 
     /// [pay] Send a spontaneous (keysend) payment
@@ -97,6 +101,10 @@ pub(crate) enum Commands {
         /// Validates the success action URL
         #[clap(name = "validate_success_url", short = 'v', long = "validate")]
         validate_success_url: Option<bool>,
+
+        /// If use_trampoline is set, trampoline payments will be attempted.
+        #[clap(long, action)]
+        use_trampoline: bool,
     },
 
     /// [lnurl] Withdraw using lnurl withdraw


### PR DESCRIPTION
This PR adds trampoline payment functionality to the SDK. 

If a client sends a payment, normally the greenlight node will find routes through the gossip graph, and attempt to pay over those routes. If a route fails, it tries again. For every attempt there are multiple rounds where the greenlight node has to communicate with the signer. Trampoline payments have the advantage there will be only one outgoing payment attempt, and the LSP will do the retrying, therefore less communication rounds are necessary, hopefully improving payment performance. The tradeoff is the user may pay more fees for the route, and the user loses some privacy in the current setup, because the LSP will learn the payment destination. The initial default trampoline policy will be 0,5%.

This PR leans on the corresponding greenlight PR for trampoline payments, which is still a work in process: https://github.com/Blockstream/greenlight/pull/475

The LSP will need to run this plugin: https://github.com/breez/trampoline

Some notes about this PR:
- Trampoline payments should only be attempted when the LSP is not in the route hint. This is because the LSP side trampoline plugin doesn't cooperate nicely with lspd in it's current state.
- The trampoline payments are automatically fetched with `listpays`. That's nice, because it doesn't require any changes to sync. The payments from `listpays` have the wrong `amount_msat` due to the way trampoline payments work. We solve that by putting the actual amount in a payment label for trampoline payments.

TODO:
- needs update of the greenlight commit id before getting merged, since it's pointing at a PR