### PR TITLE
Diagnostic data: sanitize swap and reverse swap infos

### DIFF
--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -36,8 +36,8 @@ use crate::greenlight::{GLBackupTransport, Greenlight};
 use crate::lnurl::pay::*;
 use crate::lsp::LspInformation;
 use crate::models::{
-    parse_short_channel_id, ChannelState, ClosedChannelPaymentDetails, Config, EnvironmentType,
-    LspAPI, NodeState, Payment, PaymentDetails, PaymentType, ReverseSwapPairInfo,
+    parse_short_channel_id, sanitize::*, ChannelState, ClosedChannelPaymentDetails, Config,
+    EnvironmentType, LspAPI, NodeState, Payment, PaymentDetails, PaymentType, ReverseSwapPairInfo,
     ReverseSwapServiceAPI, SwapInfo, SwapperAPI, INVOICE_PAYMENT_FEE_EXPIRY_SECONDS,
 };
 use crate::node_api::{CreateInvoiceRequest, NodeAPI};
@@ -2088,8 +2088,14 @@ impl BreezServices {
         )?;
         let channels = serde_json::to_string_pretty(&self.persister.list_channels()?)?;
         let settings = serde_json::to_string_pretty(&self.persister.list_settings()?)?;
-        let reverse_swaps = serde_json::to_string_pretty(&self.persister.list_reverse_swaps()?)?;
-        let swaps = serde_json::to_string_pretty(&self.persister.list_swaps()?)?;
+        let reverse_swaps = self
+            .persister
+            .list_reverse_swaps()
+            .map(sanitize_vec_pretty_print)??;
+        let swaps = self
+            .persister
+            .list_swaps()
+            .map(sanitize_vec_pretty_print)??;
         let lsp_id = serde_json::to_string_pretty(&self.persister.get_lsp_id()?)?;
 
         let res = format!(

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -1590,14 +1590,14 @@ pub(crate) mod sanitize {
 
     use crate::{FullReverseSwapInfo, SwapInfo};
 
-    pub(crate) trait Sanitize<T> {
-        /// Sanitizes a raw struct [T] to a clone of itself where sensitive fields are blanked
-        fn sanitize(self) -> T;
+    pub(crate) trait Sanitize {
+        /// Sanitizes a raw struct to a clone of itself where sensitive fields are blanked
+        fn sanitize(self) -> Self;
     }
 
     pub(crate) fn sanitize_vec<T>(vals: Vec<T>) -> Vec<T>
     where
-        T: Sanitize<T>,
+        T: Sanitize,
     {
         vals.into_iter()
             .map(|val| val.sanitize())
@@ -1606,12 +1606,12 @@ pub(crate) mod sanitize {
 
     pub(crate) fn sanitize_vec_pretty_print<T>(vals: Vec<T>) -> Result<String>
     where
-        T: Sanitize<T> + Serialize,
+        T: Sanitize + Serialize,
     {
         serde_json::to_string_pretty(&sanitize_vec(vals)).map_err(anyhow::Error::new)
     }
 
-    impl Sanitize<FullReverseSwapInfo> for FullReverseSwapInfo {
+    impl Sanitize for FullReverseSwapInfo {
         fn sanitize(self) -> FullReverseSwapInfo {
             FullReverseSwapInfo {
                 preimage: vec![],
@@ -1621,7 +1621,7 @@ pub(crate) mod sanitize {
         }
     }
 
-    impl Sanitize<SwapInfo> for SwapInfo {
+    impl Sanitize for SwapInfo {
         fn sanitize(self) -> SwapInfo {
             SwapInfo {
                 preimage: vec![],


### PR DESCRIPTION
This PR ensures our diagnostic data doesn't include sensitive fields for swaps and reverse swaps.