### PR TITLE
drop node state

### DIFF
--- a/libs/sdk-core/src/persist/migrations.rs
+++ b/libs/sdk-core/src/persist/migrations.rs
@@ -433,7 +433,8 @@ pub(crate) fn current_migrations() -> Vec<&'static str> {
         UPDATE channels SET local_balance_msat = spendable_msat;
        ",
        "DELETE FROM cached_items WHERE key = 'gl_credentials'",
-       "DELETE FROM cached_items WHERE key = 'last_sync_time'"
+       "DELETE FROM cached_items WHERE key = 'last_sync_time'",
+       "DELETE FROM cached_items WHERE key = 'node_state'"
     ]
 }
 


### PR DESCRIPTION
merge commit 74a820817bb44dacb1a1193264017877b77156c6 introduced commits c51d2125a9e476a72328d943a718c301921b49ef and
ee25097d55d97c0458c8ed973fadeb3bdfe0afc7, which modify the node state. When the node state is cached, however, deserialization now fails. This commit drops the current node state to ensure deserialization always works.