### PR TITLE
BIP21 parser: add tests that cover rounding errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -195,7 +195,7 @@ jobs:
 
       - name: Run sdk-common tests
         working-directory: libs/sdk-common
-        run: cargo test
+        run: cargo test --features liquid
       
       - name: Check git status
         env: 

--- a/libs/sdk-common/src/input_parser.rs
+++ b/libs/sdk-common/src/input_parser.rs
@@ -785,6 +785,34 @@ pub(crate) mod tests {
         Ok(())
     }
 
+    /// BIP21 amounts which can lead to rounding errors.
+    /// The format is: (sat amount, BIP21 BTC amount)
+    fn get_bip21_rounding_test_vectors() -> Vec<(u64, f64)> {
+        vec![
+            (999, 0.0000_0999),
+            (1_000, 0.0000_1000),
+            (59_810, 0.0005_9810),
+        ]
+    }
+
+    #[tokio::test]
+    async fn test_bitcoin_address_bip21_rounding() -> Result<()> {
+        for (amount_sat, amount_btc) in get_bip21_rounding_test_vectors() {
+            let addr = format!("bitcoin:1andreas3batLhQa2FawWjeyjCqyBzypd?amount={amount_btc}");
+
+            match parse(&addr).await? {
+                InputType::BitcoinAddress {
+                    address: addr_with_amount_parsed,
+                } => {
+                    assert_eq!(addr_with_amount_parsed.amount_sat, Some(amount_sat));
+                }
+                _ => return Err(anyhow!("Invalid type parsed")),
+            }
+        }
+
+        Ok(())
+    }
+
     #[tokio::test]
     #[cfg(feature = "liquid")]
     async fn test_liquid_address() -> Result<()> {
@@ -825,6 +853,25 @@ pub(crate) mod tests {
             );
         } else {
             panic!("Invalid input type received");
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_liquid_address_bip21_rounding() -> Result<()> {
+        let asset_id = elements::issuance::AssetId::LIQUID_BTC.to_string();
+        for (amount_sat, amount_btc) in get_bip21_rounding_test_vectors() {
+            let addr = format!("liquidnetwork:tlq1qqw5ur50rnvcx33vmljjtnez3hrtl6n7vs44tdj2c9fmnxrrgzgwnhw6jtpn8cljkmlr8tgfw9hemrr5y8u2nu024hhak3tpdk?amount={amount_btc}&assetid={asset_id}");
+
+            match parse(&addr).await? {
+                InputType::LiquidAddress {
+                    address: addr_with_amount_parsed,
+                } => {
+                    assert_eq!(addr_with_amount_parsed.amount_sat, Some(amount_sat));
+                }
+                _ => return Err(anyhow!("Invalid type parsed")),
+            }
         }
 
         Ok(())

--- a/libs/sdk-common/src/input_parser.rs
+++ b/libs/sdk-common/src/input_parser.rs
@@ -859,6 +859,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
+    #[cfg(feature = "liquid")]
     async fn test_liquid_address_bip21_rounding() -> Result<()> {
         let asset_id = elements::issuance::AssetId::LIQUID_BTC.to_string();
         for (amount_sat, amount_btc) in get_bip21_rounding_test_vectors() {

--- a/libs/sdk-common/src/input_parser.rs
+++ b/libs/sdk-common/src/input_parser.rs
@@ -787,7 +787,7 @@ pub(crate) mod tests {
 
     /// BIP21 amounts which can lead to rounding errors.
     /// The format is: (sat amount, BIP21 BTC amount)
-    fn get_bip21_rounding_test_vectors() -> Vec<(u64, f64)> {
+    pub(crate) fn get_bip21_rounding_test_vectors() -> Vec<(u64, f64)> {
         vec![
             (999, 0.0000_0999),
             (1_000, 0.0000_1000),
@@ -853,26 +853,6 @@ pub(crate) mod tests {
             );
         } else {
             panic!("Invalid input type received");
-        }
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    #[cfg(feature = "liquid")]
-    async fn test_liquid_address_bip21_rounding() -> Result<()> {
-        let asset_id = elements::issuance::AssetId::LIQUID_BTC.to_string();
-        for (amount_sat, amount_btc) in get_bip21_rounding_test_vectors() {
-            let addr = format!("liquidnetwork:tlq1qqw5ur50rnvcx33vmljjtnez3hrtl6n7vs44tdj2c9fmnxrrgzgwnhw6jtpn8cljkmlr8tgfw9hemrr5y8u2nu024hhak3tpdk?amount={amount_btc}&assetid={asset_id}");
-
-            match parse(&addr).await? {
-                InputType::LiquidAddress {
-                    address: addr_with_amount_parsed,
-                } => {
-                    assert_eq!(addr_with_amount_parsed.amount_sat, Some(amount_sat));
-                }
-                _ => return Err(anyhow!("Invalid type parsed")),
-            }
         }
 
         Ok(())

--- a/libs/sdk-common/src/liquid/mod.rs
+++ b/libs/sdk-common/src/liquid/mod.rs
@@ -1,2 +1,29 @@
 pub mod bip21;
 pub use bip21::*;
+
+#[cfg(test)]
+mod tests {
+    use anyhow::{anyhow, Result};
+
+    use crate::input_parser::tests::get_bip21_rounding_test_vectors;
+    use crate::input_parser::*;
+
+    #[tokio::test]
+    async fn test_liquid_address_bip21_rounding() -> Result<()> {
+        let asset_id = elements::issuance::AssetId::LIQUID_BTC.to_string();
+        for (amount_sat, amount_btc) in get_bip21_rounding_test_vectors() {
+            let addr = format!("liquidnetwork:tlq1qqw5ur50rnvcx33vmljjtnez3hrtl6n7vs44tdj2c9fmnxrrgzgwnhw6jtpn8cljkmlr8tgfw9hemrr5y8u2nu024hhak3tpdk?amount={amount_btc}&assetid={asset_id}");
+
+            match parse(&addr).await? {
+                InputType::LiquidAddress {
+                    address: addr_with_amount_parsed,
+                } => {
+                    assert_eq!(addr_with_amount_parsed.amount_sat, Some(amount_sat));
+                }
+                _ => return Err(anyhow!("Invalid type parsed")),
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/libs/sdk-common/src/liquid/mod.rs
+++ b/libs/sdk-common/src/liquid/mod.rs
@@ -41,7 +41,8 @@ mod tests {
                 message: None,
             };
 
-            let serialized = data.to_uri()
+            let serialized = data
+                .to_uri()
                 .map_err(|e| anyhow!("BIP21 URI serialization error {e:?}"))?;
 
             assert!(serialized.contains(&format!("amount={amount_btc}")));

--- a/libs/sdk-common/src/liquid/mod.rs
+++ b/libs/sdk-common/src/liquid/mod.rs
@@ -4,13 +4,15 @@ pub use bip21::*;
 #[cfg(test)]
 mod tests {
     use anyhow::{anyhow, Result};
+    use elements::AssetId;
 
     use crate::input_parser::tests::get_bip21_rounding_test_vectors;
     use crate::input_parser::*;
+    use crate::liquid::LiquidAddressData;
 
     #[tokio::test]
     async fn test_liquid_address_bip21_rounding() -> Result<()> {
-        let asset_id = elements::issuance::AssetId::LIQUID_BTC.to_string();
+        let asset_id = AssetId::LIQUID_BTC.to_string();
         for (amount_sat, amount_btc) in get_bip21_rounding_test_vectors() {
             let addr = format!("liquidnetwork:tlq1qqw5ur50rnvcx33vmljjtnez3hrtl6n7vs44tdj2c9fmnxrrgzgwnhw6jtpn8cljkmlr8tgfw9hemrr5y8u2nu024hhak3tpdk?amount={amount_btc}&assetid={asset_id}");
 
@@ -22,6 +24,27 @@ mod tests {
                 }
                 _ => return Err(anyhow!("Invalid type parsed")),
             }
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_liquid_address_bip21_rounding_reverse() -> Result<()> {
+        for (amount_sat, amount_btc) in get_bip21_rounding_test_vectors() {
+            let data = LiquidAddressData {
+                address: "tlq1qqw5ur50rnvcx33vmljjtnez3hrtl6n7vs44tdj2c9fmnxrrgzgwnhw6jtpn8cljkmlr8tgfw9hemrr5y8u2nu024hhak3tpdk".to_string(),
+                network: crate::model::Network::Bitcoin,
+                asset_id: Some(AssetId::LIQUID_BTC.to_string()),
+                amount_sat: Some(amount_sat),
+                label: None,
+                message: None,
+            };
+
+            let serialized = data.to_uri()
+                .map_err(|e| anyhow!("BIP21 URI serialization error {e:?}"))?;
+
+            assert!(serialized.contains(&format!("amount={amount_btc}")));
         }
 
         Ok(())


### PR DESCRIPTION
This PR fixes an issue in the parsing of BIP21 Liquid amounts, which may lead to incorrect amounts due to parsing errors.