### PR TITLE
Exclude `use_trampoline` field of `LnUrlPayRequest` on `liquid` feature of `sdk-common`

### DIFF
--- a/libs/sdk-common/src/lnurl/specs/pay.rs
+++ b/libs/sdk-common/src/lnurl/specs/pay.rs
@@ -132,6 +132,7 @@ pub mod model {
         pub data: LnUrlPayRequestData,
         /// The amount in millisatoshis for this payment
         pub amount_msat: u64,
+        #[cfg(not(feature = "liquid"))]
         /// Trampoline payments outsource pathfinding to the LSP. Trampoline payments can improve
         /// payment performance, but are generally more expensive in terms of fees and they
         /// compromise on privacy.

--- a/libs/sdk-common/src/lnurl/specs/pay.rs
+++ b/libs/sdk-common/src/lnurl/specs/pay.rs
@@ -132,7 +132,7 @@ pub mod model {
         pub data: LnUrlPayRequestData,
         /// The amount in millisatoshis for this payment
         pub amount_msat: u64,
-        #[cfg(not(feature = "liquid"))]
+        #[cfg(not(feature = "liquid"))] // Only available for the Greenlight SDK
         /// Trampoline payments outsource pathfinding to the LSP. Trampoline payments can improve
         /// payment performance, but are generally more expensive in terms of fees and they
         /// compromise on privacy.

--- a/libs/sdk-flutter/pubspec.lock
+++ b/libs/sdk-flutter/pubspec.lock
@@ -181,10 +181,10 @@ packages:
     dependency: transitive
     description:
       name: crypto
-      sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
+      sha256: ec30d999af904f33454ba22ed9a86162b35e52b44ac4807d1d93c288041d7d27
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   dart_style:
     dependency: transitive
     description:
@@ -205,10 +205,10 @@ packages:
     dependency: "direct main"
     description:
       name: ffi
-      sha256: "493f37e7df1804778ff3a53bd691d8692ddf69702cf4c1c1096a2e41b4779e21"
+      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   ffigen:
     dependency: "direct dev"
     description:


### PR DESCRIPTION
This PR excludes `use_trampoline` field of `LnUrlPayRequest` on `liquid` feature of `sdk-common`.

### Changelist:
- Exclude use_trampoline field of LnUrlPayRequest from liquid feature 12df2fed5ab63b23e983176fd4f0152d2fc069be
- chore: `flutter pub get` && `flutter pub upgrade` aaa54051c86babadf9cdb1ee001ed1b4fa8ccf41