### PR TITLE
sdk-common: simplify prelude

### DIFF
--- a/libs/sdk-common/src/input_parser.rs
+++ b/libs/sdk-common/src/input_parser.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
+use ::bip21::Uri;
 use anyhow::{anyhow, Result};
-use bip21::Uri;
 use bitcoin::bech32;
 use bitcoin::bech32::FromBase32;
 use serde::{Deserialize, Serialize};
@@ -9,9 +9,6 @@ use std::collections::HashMap;
 use LnUrlRequestData::*;
 
 use crate::prelude::*;
-
-#[cfg(feature = "liquid")]
-use self::liquid::bip21::LiquidAddressData;
 
 /// Parses generic user input, typically pasted from clipboard or scanned from a QR.
 ///

--- a/libs/sdk-common/src/invoice.rs
+++ b/libs/sdk-common/src/invoice.rs
@@ -11,9 +11,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::prelude::*;
 
-#[cfg(feature = "liquid")]
-use crate::liquid::{bip21::DeserializeError, LiquidAddressData};
-
 pub type InvoiceResult<T, E = InvoiceError> = Result<T, E>;
 
 #[derive(Debug, thiserror::Error)]

--- a/libs/sdk-common/src/lib.rs
+++ b/libs/sdk-common/src/lib.rs
@@ -31,6 +31,8 @@ pub mod prelude {
     pub use crate::buy::moonpay::*;
     pub use crate::input_parser::*;
     pub use crate::invoice::*;
+    #[cfg(feature = "liquid")]
+    pub use crate::liquid::*;
     pub use crate::lnurl::error::*;
     pub use crate::lnurl::model::*;
     pub use crate::lnurl::specs::auth::model::*;

--- a/libs/sdk-common/src/liquid/mod.rs
+++ b/libs/sdk-common/src/liquid/mod.rs
@@ -7,8 +7,7 @@ mod tests {
     use elements::AssetId;
 
     use crate::input_parser::tests::get_bip21_rounding_test_vectors;
-    use crate::input_parser::*;
-    use crate::liquid::LiquidAddressData;
+    use crate::prelude::*;
 
     #[tokio::test]
     async fn test_liquid_address_bip21_rounding() -> Result<()> {


### PR DESCRIPTION
This PR integrates the `liquid` module under `prelude`, so it doesn't need separate imports in callers.