### PR TITLE
Implement lnurl auth signer

### DIFF
--- a/libs/sdk-common/src/lnurl/specs/auth.rs
+++ b/libs/sdk-common/src/lnurl/specs/auth.rs
@@ -6,7 +6,7 @@ use reqwest::Url;
 
 use crate::prelude::*;
 
-pub trait LnurAuthSigner {
+pub trait LnurlAuthSigner {
     fn derive_bip32_pub_key(&self, derivation_path: &[ChildNumber]) -> LnUrlResult<Vec<u8>>;
     fn sign_ecdsa(&self, msg: &[u8], derivation_path: &[ChildNumber]) -> LnUrlResult<Vec<u8>>;
     fn hmac_sha256(
@@ -23,7 +23,7 @@ pub trait LnurAuthSigner {
 /// https://github.com/lnurl/luds/blob/luds/05.md
 ///
 /// See the [parse] docs for more detail on the full workflow.
-pub async fn perform_lnurl_auth<S: LnurAuthSigner>(
+pub async fn perform_lnurl_auth<S: LnurlAuthSigner>(
     req_data: &LnUrlAuthRequestData,
     signer: &S,
 ) -> LnUrlResult<LnUrlCallbackStatus> {
@@ -92,7 +92,7 @@ pub fn validate_request(
     })
 }
 
-pub fn get_derivation_path<S: LnurAuthSigner>(
+pub fn get_derivation_path<S: LnurlAuthSigner>(
     signer: &S,
     url: Url,
 ) -> LnUrlResult<Vec<ChildNumber>> {

--- a/libs/sdk-common/src/lnurl/specs/auth.rs
+++ b/libs/sdk-common/src/lnurl/specs/auth.rs
@@ -29,7 +29,11 @@ pub async fn perform_lnurl_auth<S: LnurAuthSigner>(
 ) -> LnUrlResult<LnUrlCallbackStatus> {
     let url = Url::from_str(&req_data.url).map_err(|e| LnUrlError::InvalidUri(e.to_string()))?;
     let derivation_path = get_derivation_path(signer, url)?;
-    let sig = signer.sign_ecdsa(req_data.k1.as_bytes(), &derivation_path)?;
+    let sig = signer.sign_ecdsa(
+        &hex::decode(&req_data.k1)
+            .map_err(|e| LnUrlError::Generic(format!("Error decoding k1: {e}")))?,
+        &derivation_path,
+    )?;
     let xpub = signer.derive_bip32_pub_key(&derivation_path)?;
 
     // <LNURL_hostname_and_path>?<LNURL_existing_query_parameters>&sig=<hex(sign(utf8ToBytes(k1), linkingPrivKey))>&key=<hex(linkingKey)>

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -32,7 +32,7 @@ use crate::error::{
     RedeemOnchainResult, SdkError, SdkResult, SendOnchainError, SendPaymentError,
 };
 use crate::greenlight::{GLBackupTransport, Greenlight};
-use crate::lnurl::auth::SDKLnurlAuthSigner;
+use crate::lnurl::auth::SdkLnurlAuthSigner;
 use crate::lnurl::pay::*;
 use crate::lsp::LspInformation;
 use crate::models::{
@@ -577,7 +577,7 @@ impl BreezServices {
         &self,
         req_data: LnUrlAuthRequestData,
     ) -> Result<LnUrlCallbackStatus, LnUrlAuthError> {
-        Ok(perform_lnurl_auth(&req_data, &SDKLnurlAuthSigner::new(self.node_api.clone())).await?)
+        Ok(perform_lnurl_auth(&req_data, &SdkLnurlAuthSigner::new(self.node_api.clone())).await?)
     }
 
     /// Creates an bolt11 payment request.

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -11,9 +11,8 @@ use bitcoin::hashes::{sha256, Hash};
 use bitcoin::util::bip32::ChildNumber;
 use chrono::Local;
 use futures::TryFutureExt;
-use gl_client::bitcoin::secp256k1::Secp256k1;
 use log::{LevelFilter, Metadata, Record};
-use reqwest::{header::CONTENT_TYPE, Body, Url};
+use reqwest::{header::CONTENT_TYPE, Body};
 use sdk_common::grpc;
 use sdk_common::prelude::*;
 use serde::Serialize;
@@ -33,6 +32,7 @@ use crate::error::{
     RedeemOnchainResult, SdkError, SdkResult, SendOnchainError, SendPaymentError,
 };
 use crate::greenlight::{GLBackupTransport, Greenlight};
+use crate::lnurl::auth::SDKLnurlAuthSigner;
 use crate::lnurl::pay::*;
 use crate::lsp::LspInformation;
 use crate::models::{
@@ -577,20 +577,7 @@ impl BreezServices {
         &self,
         req_data: LnUrlAuthRequestData,
     ) -> Result<LnUrlCallbackStatus, LnUrlAuthError> {
-        // m/138'/0
-        let hashing_key = self.node_api.derive_bip32_key(vec![
-            ChildNumber::from_hardened_idx(138).map_err(Into::<LnUrlError>::into)?,
-            ChildNumber::from(0),
-        ])?;
-
-        let url =
-            Url::from_str(&req_data.url).map_err(|e| LnUrlError::InvalidUri(e.to_string()))?;
-
-        let derivation_path = get_derivation_path(hashing_key, url)?;
-        let linking_key = self.node_api.derive_bip32_key(derivation_path)?;
-        let linking_keys = linking_key.to_keypair(&Secp256k1::new());
-
-        Ok(perform_lnurl_auth(linking_keys, req_data).await?)
+        Ok(perform_lnurl_auth(&req_data, &SDKLnurlAuthSigner::new(self.node_api.clone())).await?)
     }
 
     /// Creates an bolt11 payment request.

--- a/libs/sdk-core/src/lnurl/auth.rs
+++ b/libs/sdk-core/src/lnurl/auth.rs
@@ -1,12 +1,9 @@
 use std::sync::Arc;
 
-use gl_client::{
-    bitcoin::{
-        hashes::{sha256, Hash, HashEngine, Hmac, HmacEngine},
-        secp256k1::{Message, Secp256k1},
-        util::bip32::ChildNumber,
-    },
-    lightning::util::ser::Writeable,
+use gl_client::bitcoin::{
+    hashes::{sha256, Hash, HashEngine, Hmac, HmacEngine},
+    secp256k1::{Message, Secp256k1},
+    util::bip32::{ChildNumber, ExtendedPubKey},
 };
 use sdk_common::prelude::{LnUrlError, LnUrlResult, LnurlAuthSigner};
 
@@ -24,12 +21,10 @@ impl SdkLnurlAuthSigner {
 
 impl LnurlAuthSigner for SdkLnurlAuthSigner {
     fn derive_bip32_pub_key(&self, derivation_path: &[ChildNumber]) -> LnUrlResult<Vec<u8>> {
-        Ok(self
-            .node_api
-            .derive_bip32_key(derivation_path.to_vec())?
-            .to_keypair(&Secp256k1::new())
-            .public_key()
-            .encode())
+        let xpriv = self.node_api.derive_bip32_key(derivation_path.to_vec())?;
+        Ok(ExtendedPubKey::from_priv(&Secp256k1::new(), &xpriv)
+            .encode()
+            .to_vec())
     }
 
     fn sign_ecdsa(&self, msg: &[u8], derivation_path: &[ChildNumber]) -> LnUrlResult<Vec<u8>> {

--- a/libs/sdk-core/src/lnurl/auth.rs
+++ b/libs/sdk-core/src/lnurl/auth.rs
@@ -1,0 +1,58 @@
+use std::sync::Arc;
+
+use gl_client::{
+    bitcoin::{
+        hashes::{sha256, Hash, HashEngine, Hmac, HmacEngine},
+        secp256k1::{Message, Secp256k1},
+        util::bip32::ChildNumber,
+    },
+    lightning::util::ser::Writeable,
+};
+use sdk_common::prelude::{LnUrlError, LnUrlResult, LnurAuthSigner};
+
+use crate::node_api::NodeAPI;
+
+pub(crate) struct SDKLnurlAuthSigner {
+    node_api: Arc<dyn NodeAPI>,
+}
+
+impl SDKLnurlAuthSigner {
+    pub fn new(node_api: Arc<dyn NodeAPI>) -> Self {
+        Self { node_api }
+    }
+}
+
+impl LnurAuthSigner for SDKLnurlAuthSigner {
+    fn derive_bip32_pub_key(&self, derivation_path: &[ChildNumber]) -> LnUrlResult<Vec<u8>> {
+        Ok(self
+            .node_api
+            .derive_bip32_key(derivation_path.to_vec())?
+            .to_keypair(&Secp256k1::new())
+            .public_key()
+            .encode())
+    }
+
+    fn sign_ecdsa(&self, msg: &[u8], derivation_path: &[ChildNumber]) -> LnUrlResult<Vec<u8>> {
+        let xpriv = self.node_api.derive_bip32_key(derivation_path.to_vec())?;
+        let sig = Secp256k1::new().sign_ecdsa(
+            &Message::from_slice(msg).map_err(|_| LnUrlError::generic("failed to sign"))?,
+            &xpriv.private_key,
+        );
+        Ok(sig.encode())
+    }
+
+    fn hmac_sha256(
+        &self,
+        key_derivation_path: &[ChildNumber],
+        input: &[u8],
+    ) -> LnUrlResult<Vec<u8>> {
+        let priv_key = self
+            .node_api
+            .derive_bip32_key(key_derivation_path.to_vec())?;
+        let mut engine = HmacEngine::<sha256::Hash>::new(priv_key.encode().as_slice());
+        engine.input(input);
+        Ok(Hmac::<sha256::Hash>::from_engine(engine)
+            .as_inner()
+            .to_vec())
+    }
+}

--- a/libs/sdk-core/src/lnurl/auth.rs
+++ b/libs/sdk-core/src/lnurl/auth.rs
@@ -12,17 +12,17 @@ use sdk_common::prelude::{LnUrlError, LnUrlResult, LnurAuthSigner};
 
 use crate::node_api::NodeAPI;
 
-pub(crate) struct SDKLnurlAuthSigner {
+pub(crate) struct SdkLnurlAuthSigner {
     node_api: Arc<dyn NodeAPI>,
 }
 
-impl SDKLnurlAuthSigner {
+impl SdkLnurlAuthSigner {
     pub fn new(node_api: Arc<dyn NodeAPI>) -> Self {
         Self { node_api }
     }
 }
 
-impl LnurAuthSigner for SDKLnurlAuthSigner {
+impl LnurAuthSigner for SdkLnurlAuthSigner {
     fn derive_bip32_pub_key(&self, derivation_path: &[ChildNumber]) -> LnUrlResult<Vec<u8>> {
         Ok(self
             .node_api
@@ -35,7 +35,7 @@ impl LnurAuthSigner for SDKLnurlAuthSigner {
     fn sign_ecdsa(&self, msg: &[u8], derivation_path: &[ChildNumber]) -> LnUrlResult<Vec<u8>> {
         let xpriv = self.node_api.derive_bip32_key(derivation_path.to_vec())?;
         let sig = Secp256k1::new().sign_ecdsa(
-            &Message::from_slice(msg).map_err(|_| LnUrlError::generic("failed to sign"))?,
+            &Message::from_slice(msg).map_err(|_| LnUrlError::generic("Failed to sign"))?,
             &xpriv.private_key,
         );
         Ok(sig.serialize_der().to_vec())

--- a/libs/sdk-core/src/lnurl/auth.rs
+++ b/libs/sdk-core/src/lnurl/auth.rs
@@ -38,7 +38,7 @@ impl LnurAuthSigner for SDKLnurlAuthSigner {
             &Message::from_slice(msg).map_err(|_| LnUrlError::generic("failed to sign"))?,
             &xpriv.private_key,
         );
-        Ok(sig.encode())
+        Ok(sig.serialize_der().to_vec())
     }
 
     fn hmac_sha256(

--- a/libs/sdk-core/src/lnurl/auth.rs
+++ b/libs/sdk-core/src/lnurl/auth.rs
@@ -8,7 +8,7 @@ use gl_client::{
     },
     lightning::util::ser::Writeable,
 };
-use sdk_common::prelude::{LnUrlError, LnUrlResult, LnurAuthSigner};
+use sdk_common::prelude::{LnUrlError, LnUrlResult, LnurlAuthSigner};
 
 use crate::node_api::NodeAPI;
 
@@ -22,7 +22,7 @@ impl SdkLnurlAuthSigner {
     }
 }
 
-impl LnurAuthSigner for SdkLnurlAuthSigner {
+impl LnurlAuthSigner for SdkLnurlAuthSigner {
     fn derive_bip32_pub_key(&self, derivation_path: &[ChildNumber]) -> LnUrlResult<Vec<u8>> {
         Ok(self
             .node_api

--- a/libs/sdk-core/src/lnurl/mod.rs
+++ b/libs/sdk-core/src/lnurl/mod.rs
@@ -1,3 +1,4 @@
+pub mod auth;
 pub mod pay;
 
 #[cfg(test)]


### PR DESCRIPTION
This PR changes the lnurl auth functionality to support signers that don't expose private keys.
Instead of passing the private key (linking key) to the lnurl module for signing the lnurl module expect a signer implementation with some basic building blocks for siginig and deriving public keys.
Also the caller now doesn't need to have a knowledge about the lnurl auth internals (constructing the linking key for example) as the lnurl module takes care of it.
This is needed in order also to support splitting the signer from the sdk implementation in breez-ask-liquid project.