### PR TITLE
sync: sync all payment updates

### DIFF
--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -12,6 +12,7 @@ use sdk_common::grpc;
 use sdk_common::prelude::Network::*;
 use sdk_common::prelude::*;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use strum_macros::{Display, EnumString};
 
 use crate::bitcoin::blockdata::opcodes;
@@ -639,6 +640,7 @@ pub struct NodeState {
 
 /// Internal response to a [crate::node_api::NodeAPI::pull_changed] call
 pub struct SyncResponse {
+    pub sync_state: Value,
     pub node_state: NodeState,
     pub payments: Vec<crate::models::Payment>,
     pub channels: Vec<crate::models::Channel>,

--- a/libs/sdk-core/src/node_api.rs
+++ b/libs/sdk-core/src/node_api.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::pin::Pin;
 
 use anyhow::Result;
+use serde_json::Value;
 use tokio::sync::{mpsc, watch};
 use tokio_stream::Stream;
 use tonic::Streaming;
@@ -120,7 +121,7 @@ pub trait NodeAPI: Send + Sync {
     async fn fetch_bolt11(&self, payment_hash: Vec<u8>) -> NodeResult<Option<FetchBolt11Result>>;
     async fn pull_changed(
         &self,
-        since_timestamp: u64,
+        sync_state: Option<Value>,
         match_local_balance: bool,
     ) -> NodeResult<SyncResponse>;
     /// As per the `pb::PayRequest` docs, `amount_msat` is only needed when the invoice doesn't specify an amount

--- a/libs/sdk-core/src/persist/cache.rs
+++ b/libs/sdk-core/src/persist/cache.rs
@@ -1,10 +1,12 @@
+use serde_json::Value;
+
 use crate::models::NodeState;
 
 use super::{db::SqliteStorage, error::PersistResult};
 
 const KEY_GL_CREDENTIALS: &str = "gl_credentials";
 const KEY_LAST_BACKUP_TIME: &str = "last_backup_time";
-const KEY_LAST_SYNC_TIME: &str = "last_sync_time";
+const KEY_SYNC_STATE: &str = "sync_state";
 const KEY_NODE_STATE: &str = "node_state";
 const KEY_STATIC_BACKUP: &str = "static_backup";
 const KEY_WEBHOOK_URL: &str = "webhook_url";
@@ -60,14 +62,14 @@ impl SqliteStorage {
         })
     }
 
-    pub fn set_last_sync_time(&self, t: u64) -> PersistResult<()> {
-        self.update_cached_item(KEY_LAST_SYNC_TIME, t.to_string())
+    pub fn set_sync_state(&self, t: &Value) -> PersistResult<()> {
+        self.update_cached_item(KEY_SYNC_STATE, t.to_string())
     }
 
-    pub fn get_last_sync_time(&self) -> PersistResult<Option<u64>> {
-        let state_str = self.get_cached_item(KEY_LAST_SYNC_TIME)?;
+    pub fn get_sync_state(&self) -> PersistResult<Option<Value>> {
+        let state_str = self.get_cached_item(KEY_SYNC_STATE)?;
         Ok(match state_str {
-            Some(str) => str.as_str().parse::<u64>().ok(),
+            Some(str) => serde_json::from_str(&str)?,
             None => None,
         })
     }

--- a/libs/sdk-core/src/persist/migrations.rs
+++ b/libs/sdk-core/src/persist/migrations.rs
@@ -434,7 +434,27 @@ pub(crate) fn current_migrations() -> Vec<&'static str> {
        ",
        "DELETE FROM cached_items WHERE key = 'gl_credentials'",
        "DELETE FROM cached_items WHERE key = 'last_sync_time'",
-       "DELETE FROM cached_items WHERE key = 'node_state'"
+       "DELETE FROM cached_items WHERE key = 'node_state'",
+       "
+       CREATE TABLE IF NOT EXISTS send_pays (
+        created_index INTEGER PRIMARY KEY NOT NULL,
+        updated_index INTEGER,
+        groupid INTEGER NOT NULL,
+        partid INTEGER,
+        payment_hash BLOB NOT NULL,
+        status INTEGER NOT NULL,
+        amount_msat INTEGER,
+        destination BLOB,
+        created_at INTEGER NOT NULL,
+        amount_sent_msat INTEGER,
+        label TEXT,
+        bolt11 TEXT,
+        description TEXT,
+        bolt12 TEXT,
+        payment_preimage BLOB,
+        erroronion BLOB
+       ) STRICT;
+       "
     ]
 }
 

--- a/libs/sdk-core/src/persist/mod.rs
+++ b/libs/sdk-core/src/persist/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod db;
 pub(crate) mod error;
 pub(crate) mod migrations;
 pub(crate) mod reverseswap;
+pub(crate) mod send_pays;
 pub(crate) mod settings;
 pub(crate) mod swap;
 pub(crate) mod sync;

--- a/libs/sdk-core/src/persist/send_pays.rs
+++ b/libs/sdk-core/src/persist/send_pays.rs
@@ -1,0 +1,122 @@
+use rusqlite::named_params;
+use strum_macros::FromRepr;
+
+use super::{db::SqliteStorage, error::PersistResult};
+
+#[derive(FromRepr)]
+#[repr(i32)]
+pub(crate) enum SendPayStatus {
+    Pending = 0,
+    Failed = 1,
+    Complete = 2,
+}
+
+pub(crate) struct SendPay {
+    pub created_index: u64,
+    pub updated_index: Option<u64>,
+    pub groupid: u64,
+    pub partid: Option<u64>,
+    pub payment_hash: Vec<u8>,
+    pub status: SendPayStatus,
+    pub amount_msat: Option<u64>,
+    pub destination: Option<Vec<u8>>,
+    pub created_at: u64,
+    pub amount_sent_msat: Option<u64>,
+    pub label: Option<String>,
+    pub bolt11: Option<String>,
+    pub description: Option<String>,
+    pub bolt12: Option<String>,
+    pub payment_preimage: Option<Vec<u8>>,
+    pub erroronion: Option<Vec<u8>>,
+}
+
+impl SqliteStorage {
+    pub(crate) fn insert_send_pays(&self, send_pays: &[SendPay]) -> PersistResult<()> {
+        let conn = self.get_connection()?;
+        let mut stmt = conn.prepare(
+            r#"INSERT OR REPLACE INTO send_pays (created_index, updated_index, 
+                groupid, partid, payment_hash, status, amount_msat, 
+                destination, created_at, amount_sent_msat, label, bolt11, 
+                description, bolt12, payment_preimage, erroronion) 
+                VALUES (:created_index, :updated_index, 
+                    :groupid, :partid, :payment_hash, :status, :amount_msat, 
+                    :destination, :created_at, :amount_sent_msat, :label, :bolt11, 
+                    :description, :bolt12, :payment_preimage, :erroronion)"#,
+        )?;
+        for send_pay in send_pays {
+            let status: i32 = match send_pay.status {
+                SendPayStatus::Pending => 0,
+                SendPayStatus::Failed => 1,
+                SendPayStatus::Complete => 2,
+            };
+            stmt.execute(named_params! {
+                ":created_index": send_pay.created_index,
+                ":updated_index": send_pay.updated_index,
+                ":groupid": send_pay.groupid,
+                ":partid": send_pay.partid,
+                ":payment_hash": send_pay.payment_hash,
+                ":status": status,
+                ":amount_msat": send_pay.amount_msat,
+                ":destination": send_pay.destination,
+                ":created_at": send_pay.created_at,
+                ":amount_sent_msat": send_pay.amount_sent_msat,
+                ":label": send_pay.label,
+                ":bolt11": send_pay.bolt11,
+                ":description": send_pay.description,
+                ":bolt12": send_pay.bolt12,
+                ":payment_preimage": send_pay.payment_preimage,
+                ":erroronion": send_pay.erroronion,
+            })?;
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn list_send_pays(&self, hashes: &[Vec<u8>]) -> PersistResult<Vec<SendPay>> {
+        let conn = self.get_connection()?;
+        let mut stmt = conn.prepare(
+            r#"SELECT created_index, updated_index, groupid, partid, 
+               payment_hash, status, amount_msat, destination, created_at, 
+               amount_sent_msat, label, bolt11, description, bolt12, 
+               payment_preimage, erroronion
+               FROM send_pays
+               WHERE payment_hash = :payment_hash"#,
+        )?;
+        let mut send_pays = Vec::new();
+        for hash in hashes {
+            let rows: Vec<_> = stmt
+                .query_map(
+                    named_params! {
+                        ":payment_hash": hash
+                    },
+                    |row| {
+                        let status: i32 = row.get("status")?;
+                        Ok(SendPay {
+                            amount_msat: row.get("amount_msat")?,
+                            amount_sent_msat: row.get("amount_sent_msat")?,
+                            created_index: row.get("created_index")?,
+                            updated_index: row.get("updated_index")?,
+                            groupid: row.get("groupid")?,
+                            partid: row.get("partid")?,
+                            payment_hash: row.get("payment_hash")?,
+                            status: SendPayStatus::from_repr(status)
+                                .ok_or(rusqlite::Error::IntegralValueOutOfRange(5, 2))?,
+                            destination: row.get("destination")?,
+                            created_at: row.get("created_at")?,
+                            label: row.get("label")?,
+                            bolt11: row.get("bolt11")?,
+                            description: row.get("description")?,
+                            bolt12: row.get("bolt12")?,
+                            payment_preimage: row.get("payment_preimage")?,
+                            erroronion: row.get("erroronion")?,
+                        })
+                    },
+                )?
+                .collect::<Result<Vec<SendPay>, _>>()?;
+            for row in rows {
+                send_pays.push(row);
+            }
+        }
+        Ok(send_pays)
+    }
+}

--- a/libs/sdk-core/src/persist/transactions.rs
+++ b/libs/sdk-core/src/persist/transactions.rs
@@ -194,14 +194,6 @@ impl SqliteStorage {
         Ok(())
     }
 
-    pub fn last_payment_timestamp(&self) -> PersistResult<u64> {
-        Ok(self.get_connection()?.query_row(
-            "SELECT max(payment_time) FROM payments where status != ?1",
-            params![PaymentStatus::Pending],
-            |row| row.get(0),
-        )?)
-    }
-
     /// Constructs [Payment] by joining data in the `payment` and `payments_external_info` tables
     ///
     /// This queries all payments. To query a single payment, see [Self::get_payment_by_hash]
@@ -875,9 +867,6 @@ fn test_ln_transactions() -> PersistResult<(), Box<dyn std::error::Error>> {
     assert!(
         matches!( &retrieve_txs[1].details, PaymentDetails::Ln {data: LnPaymentDetails {swap_info: swap, ..}} if swap == &Some(swap_info))
     );
-
-    let max_ts = storage.last_payment_timestamp()?;
-    assert_eq!(max_ts, 2000);
 
     storage.insert_or_update_payments(&txs, false)?;
     let retrieve_txs = storage.list_payments(ListPaymentsRequest::default())?;

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -13,6 +13,7 @@ use rand::rngs::OsRng;
 use rand::{random, Rng};
 use sdk_common::grpc;
 use sdk_common::prelude::{FiatAPI, FiatCurrency, Rate};
+use serde_json::Value;
 use tokio::sync::{mpsc, watch, Mutex};
 use tokio::time::sleep;
 use tokio_stream::Stream;
@@ -349,10 +350,11 @@ impl NodeAPI for MockNodeAPI {
 
     async fn pull_changed(
         &self,
-        _since_timestamp: u64,
-        _balance_changed: bool,
+        _sync_state: Option<Value>,
+        _match_local_balance: bool,
     ) -> NodeResult<SyncResponse> {
         Ok(SyncResponse {
+            sync_state: Value::Null,
             node_state: self.node_state.clone(),
             payments: self
                 .cloud_payments


### PR DESCRIPTION
Rather than syncing payments based on the payment time, sync based on the created and updated indices in core lightning. This ensures that all updates are retrieved, also when a payment is updated after the fact. To do this, listsendpays is called, rather than listpays. listsendpays contains a filter based on index. Starting off with the last synced index, fetch all missing newly created payments and updates. It's possible that this particular sync doesn't fetch all payment parts associated to a payment. Therefore, the sendpays are cached into a local database. When a new sync round is done, all known existing parts are fetched from the local database as well, to ensure the resulting sdk payments are 'complete', i.e. they're not missing any parts. This should fix the issue where for closed channels, payments would be marked forever pending.

Should fix https://github.com/breez/breez-sdk-greenlight/issues/1094

Inspiration from https://github.com/ElementsProject/lightning/blob/136244835215ae7fcb48ffcaf3c5bb80c3173348/plugins/pay.c#L415-L533