### PR TITLE
Bump gl-client to latest released `v0.3.0`

### DIFF
--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -1470,8 +1470,8 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "gl-client"
-version = "0.2.0"
-source = "git+https://github.com/Blockstream/greenlight.git?rev=7540980dd8f1630b1b148a9eb8b44e2b05ca7e6d#7540980dd8f1630b1b148a9eb8b44e2b05ca7e6d"
+version = "0.3.0"
+source = "git+https://github.com/Blockstream/greenlight.git?rev=a0e4faf389484e426fcc197f8726c72a27eef32e#a0e4faf389484e426fcc197f8726c72a27eef32e"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/libs/sdk-core/Cargo.toml
+++ b/libs/sdk-core/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = { workspace = true }
 hex = { workspace = true }
 gl-client = { git = "https://github.com/Blockstream/greenlight.git", features = [
     "permissive",
-], rev = "7540980dd8f1630b1b148a9eb8b44e2b05ca7e6d" }
+], rev = "a0e4faf389484e426fcc197f8726c72a27eef32e" }
 zbase32 = "0.1.2"
 base64 = { workspace = true }
 chrono = "0.4"

--- a/tools/sdk-cli/Cargo.lock
+++ b/tools/sdk-cli/Cargo.lock
@@ -1331,8 +1331,8 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "gl-client"
-version = "0.2.0"
-source = "git+https://github.com/Blockstream/greenlight.git?rev=7540980dd8f1630b1b148a9eb8b44e2b05ca7e6d#7540980dd8f1630b1b148a9eb8b44e2b05ca7e6d"
+version = "0.3.0"
+source = "git+https://github.com/Blockstream/greenlight.git?rev=a0e4faf389484e426fcc197f8726c72a27eef32e#a0e4faf389484e426fcc197f8726c72a27eef32e"
 dependencies = [
  "anyhow",
  "async-stream",


### PR DESCRIPTION
This PR bumps `gl-client` to the latest publicly released[^2] `v0.3.0`.

According to the changelog[^1] this brings the fix for #1090 among others.

Fixes #1090

[^1]: https://github.com/Blockstream/greenlight/blob/main/CHANGELOG.md
[^2]: https://crates.io/crates/gl-client/versions