### PR TITLE
Optimize fetching claim tx by querying the lockup address

### DIFF
--- a/libs/sdk-core/src/swap_out/reverseswap.rs
+++ b/libs/sdk-core/src/swap_out/reverseswap.rs
@@ -652,7 +652,7 @@ impl BTCSendSwap {
 
             if let Some(tx) = &claim_tx {
                 info!(
-                    "Cound claim tx for reverse swap {:?}: {:?}, status: {:?}",
+                    "Found claim tx for reverse swap {:?}: {:?}, status: {:?}",
                     rsi.id, tx.txid, claim_tx_status
                 );
             }


### PR DESCRIPTION
Instead of querying the claim address (final user address) for the claim tx it is better to query the lockup address.
Since the claim is not in our control I have seen a case where it had thousands of transactions resulted in 80m of transactions associated with that address.
The lockup address should have max 2 transactions associated with.