### PR TITLE
Bump `gl-client` to latest commit

### DIFF
--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -1472,7 +1472,7 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 [[package]]
 name = "gl-client"
 version = "0.3.0"
-source = "git+https://github.com/Blockstream/greenlight.git?rev=a0e4faf389484e426fcc197f8726c72a27eef32e#a0e4faf389484e426fcc197f8726c72a27eef32e"
+source = "git+https://github.com/Blockstream/greenlight.git?rev=c09c1be59994b35aadfe4747b78bcdc8fffbe45a#c09c1be59994b35aadfe4747b78bcdc8fffbe45a"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/libs/sdk-core/Cargo.toml
+++ b/libs/sdk-core/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = { workspace = true }
 hex = { workspace = true }
 gl-client = { git = "https://github.com/Blockstream/greenlight.git", features = [
     "permissive",
-], rev = "a0e4faf389484e426fcc197f8726c72a27eef32e" }
+], rev = "c09c1be59994b35aadfe4747b78bcdc8fffbe45a" }
 zbase32 = "0.1.2"
 base64 = { workspace = true }
 chrono = "0.4"

--- a/tools/sdk-cli/Cargo.lock
+++ b/tools/sdk-cli/Cargo.lock
@@ -1333,7 +1333,7 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 [[package]]
 name = "gl-client"
 version = "0.3.0"
-source = "git+https://github.com/Blockstream/greenlight.git?rev=a0e4faf389484e426fcc197f8726c72a27eef32e#a0e4faf389484e426fcc197f8726c72a27eef32e"
+source = "git+https://github.com/Blockstream/greenlight.git?rev=c09c1be59994b35aadfe4747b78bcdc8fffbe45a#c09c1be59994b35aadfe4747b78bcdc8fffbe45a"
 dependencies = [
  "anyhow",
  "async-stream",


### PR DESCRIPTION
This PR bumps `gl-client` to the most recent commit on their `main` branch: https://github.com/Blockstream/greenlight/commits/main/