### PR TITLE
Remove unnecessary get_info calls

### DIFF
--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -264,7 +264,6 @@ impl BreezServices {
         &self,
         req: SendPaymentRequest,
     ) -> Result<SendPaymentResponse, SendPaymentError> {
-        self.start_node().await?;
         let parsed_invoice = parse_invoice(req.bolt11.as_str())?;
         let invoice_expiration = parsed_invoice.timestamp + parsed_invoice.expiry;
         let current_time = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
@@ -400,7 +399,6 @@ impl BreezServices {
         &self,
         req: SendSpontaneousPaymentRequest,
     ) -> Result<SendPaymentResponse, SendPaymentError> {
-        self.start_node().await?;
         let payment_res = self
             .node_api
             .send_spontaneous_payment(
@@ -712,7 +710,6 @@ impl BreezServices {
         &self,
         req: RedeemOnchainFundsRequest,
     ) -> RedeemOnchainResult<RedeemOnchainFundsResponse> {
-        self.start_node().await?;
         let txid = self
             .node_api
             .redeem_onchain_funds(req.to_address, req.sat_per_vbyte)
@@ -725,7 +722,6 @@ impl BreezServices {
         &self,
         req: PrepareRedeemOnchainFundsRequest,
     ) -> RedeemOnchainResult<PrepareRedeemOnchainFundsResponse> {
-        self.start_node().await?;
         let response = self.node_api.prepare_redeem_onchain_funds(req).await?;
         Ok(response)
     }
@@ -809,7 +805,6 @@ impl BreezServices {
     ///
     /// Should be called  when the user wants to close all the channels.
     pub async fn close_lsp_channels(&self) -> SdkResult<Vec<String>> {
-        self.start_node().await?;
         let lsp = self.lsp_info().await?;
         let tx_ids = self.node_api.close_peer_channels(lsp.pubkey).await?;
         self.sync().await?;
@@ -1195,7 +1190,7 @@ impl BreezServices {
 
     async fn do_sync(&self, match_local_balance: bool) -> Result<()> {
         let start = Instant::now();
-        let node_pubkey = self.node_api.start().await?;
+        let node_pubkey = self.node_api.node_id().await?;
         self.connect_lsp_peer(node_pubkey).await?;
 
         // First query the changes since last sync state.
@@ -1408,11 +1403,6 @@ impl BreezServices {
     /// Convenience method to look up LSP info based on current LSP ID
     pub async fn lsp_info(&self) -> SdkResult<LspInformation> {
         get_lsp(self.persister.clone(), self.lsp_api.clone()).await
-    }
-
-    pub(crate) async fn start_node(&self) -> Result<()> {
-        self.node_api.start().await?;
-        Ok(())
     }
 
     /// Get the recommended fees for onchain transactions
@@ -2545,7 +2535,6 @@ impl Receiver for PaymentReceiver {
         &self,
         req: ReceivePaymentRequest,
     ) -> Result<ReceivePaymentResponse, ReceivePaymentError> {
-        self.node_api.start().await?;
         let lsp_info = get_lsp(self.persister.clone(), self.lsp.clone()).await?;
         let node_state = self
             .persister

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -1438,15 +1438,8 @@ impl NodeAPI for Greenlight {
         payment.try_into()
     }
 
-    async fn start(&self) -> NodeResult<String> {
-        let node_info = self
-            .get_node_client()
-            .await?
-            .getinfo(cln::GetinfoRequest {})
-            .await
-            .map_err(|e| NodeError::ServiceConnectivity(e.to_string()))?
-            .into_inner();
-        Ok(hex::encode(node_info.id))
+    async fn node_id(&self) -> NodeResult<String> {
+        Ok(hex::encode(self.signer.node_id()))
     }
 
     async fn redeem_onchain_funds(

--- a/libs/sdk-core/src/node_api.rs
+++ b/libs/sdk-core/src/node_api.rs
@@ -145,7 +145,7 @@ pub trait NodeAPI: Send + Sync {
         label: Option<String>,
         trampoline_node_id: Vec<u8>,
     ) -> NodeResult<Payment>;
-    async fn start(&self) -> NodeResult<String>;
+    async fn node_id(&self) -> NodeResult<String>;
 
     /// Attempts to find a payment path "manually" and send the htlcs in a way that will drain
     /// Large channels first.

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -404,7 +404,7 @@ impl NodeAPI for MockNodeAPI {
         Ok(payment)
     }
 
-    async fn start(&self) -> NodeResult<String> {
+    async fn node_id(&self) -> NodeResult<String> {
         Ok("".to_string())
     }
 


### PR DESCRIPTION
We don't need anymore to explicitly start the node (call get_info) as geenlight reverse proxy does it automatically. 
Instead of getting the pubkey from get_info, we get it from the signer locally. 
This saves 200-300ms on my desktop (potentially more on mobile) from some sdk functions including sync.