### PR TITLE
Add list_swaps function

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -579,6 +579,14 @@ dictionary SwapInfo {
     u32? confirmed_at;
 };
 
+dictionary ListSwapsRequest {
+    sequence<SwapStatus>? status = null;
+    i64? from_timestamp = null;
+    i64? to_timestamp = null;
+    u32? offset = null;
+    u32? limit = null;
+};
+
 dictionary ReverseSwapPairInfo {
     u64 min;
     u64 max;
@@ -940,6 +948,9 @@ interface BlockingBreezServices {
 
    [Throws=SdkError]
    RefundResponse refund(RefundRequest req);
+
+   [Throws=SdkError]
+   sequence<SwapInfo> list_swaps(ListSwapsRequest req);
 
    [Throws=SdkError]
    ReverseSwapPairInfo fetch_reverse_swap_fees(ReverseSwapFeesRequest req);

--- a/libs/sdk-bindings/src/uniffi_binding.rs
+++ b/libs/sdk-bindings/src/uniffi_binding.rs
@@ -10,9 +10,9 @@ use breez_sdk_core::{
     CheckMessageResponse, ClosedChannelPaymentDetails, Config, ConfigureNodeRequest,
     ConnectRequest, CurrencyInfo, EnvironmentType, EventListener, FeeratePreset, FiatCurrency,
     GreenlightCredentials, GreenlightDeviceCredentials, GreenlightNodeConfig, HealthCheckStatus,
-    InputType, InvoicePaidDetails, LNInvoice, ListPaymentsRequest, LnPaymentDetails,
-    LnUrlAuthError, LnUrlAuthRequestData, LnUrlCallbackStatus, LnUrlErrorData, LnUrlPayError,
-    LnUrlPayErrorData, LnUrlPayRequest, LnUrlPayRequestData, LnUrlWithdrawError,
+    InputType, InvoicePaidDetails, LNInvoice, ListPaymentsRequest, ListSwapsRequest,
+    LnPaymentDetails, LnUrlAuthError, LnUrlAuthRequestData, LnUrlCallbackStatus, LnUrlErrorData,
+    LnUrlPayError, LnUrlPayErrorData, LnUrlPayRequest, LnUrlPayRequestData, LnUrlWithdrawError,
     LnUrlWithdrawRequest, LnUrlWithdrawRequestData, LnUrlWithdrawResult, LnUrlWithdrawSuccessData,
     LocaleOverrides, LocalizedName, LogEntry, LogStream, LspInformation,
     MaxReverseSwapAmountResponse, MessageSuccessActionData, MetadataFilter, MetadataItem, Network,
@@ -303,6 +303,11 @@ impl BlockingBreezServices {
     // construct and broadcast a refund transaction for a faile/expired swap
     pub fn refund(&self, req: RefundRequest) -> SdkResult<RefundResponse> {
         rt().block_on(self.breez_services.refund(req))
+    }
+
+    // list current and historical swaps
+    pub fn list_swaps(&self, req: ListSwapsRequest) -> SdkResult<Vec<SwapInfo>> {
+        rt().block_on(self.breez_services.list_swaps(req))
     }
 
     pub fn fetch_reverse_swap_fees(

--- a/libs/sdk-core/src/backup.rs
+++ b/libs/sdk-core/src/backup.rs
@@ -445,6 +445,7 @@ impl BackupWorker {
 #[cfg(test)]
 mod tests {
     use crate::test_utils::get_test_ofp_48h;
+    use crate::ListSwapsRequest;
     use crate::{
         backup::BackupRequest,
         persist::db::SqliteStorage,
@@ -752,7 +753,9 @@ mod tests {
             wait_for_backup_success(task_subscription2).await;
         });
         test_expected_backup_events(main_subscription, transport, expected_events, 3, 1).await;
-        let swaps = cloned_persister.list_swaps().unwrap();
+        let swaps = cloned_persister
+            .list_swaps(ListSwapsRequest::default())
+            .unwrap();
         assert!(swaps.len() == 1);
         _ = quit_sender.send(());
         quit_sender.closed().await;

--- a/libs/sdk-core/src/binding.rs
+++ b/libs/sdk-core/src/binding.rs
@@ -38,12 +38,12 @@ use crate::lsp::LspInformation;
 use crate::models::{Config, LogEntry, NodeState, Payment, SwapInfo};
 use crate::{
     BackupStatus, BuyBitcoinRequest, BuyBitcoinResponse, CheckMessageRequest, CheckMessageResponse,
-    ConfigureNodeRequest, ConnectRequest, EnvironmentType, ListPaymentsRequest, LnUrlAuthError,
-    MaxReverseSwapAmountResponse, NodeConfig, NodeCredentials, OnchainPaymentLimitsResponse,
-    OpenChannelFeeRequest, OpenChannelFeeResponse, PayOnchainRequest, PayOnchainResponse,
-    PrepareOnchainPaymentRequest, PrepareOnchainPaymentResponse, PrepareRedeemOnchainFundsRequest,
-    PrepareRedeemOnchainFundsResponse, PrepareRefundRequest, PrepareRefundResponse,
-    ReceiveOnchainRequest, ReceivePaymentRequest, ReceivePaymentResponse,
+    ConfigureNodeRequest, ConnectRequest, EnvironmentType, ListPaymentsRequest, ListSwapsRequest,
+    LnUrlAuthError, MaxReverseSwapAmountResponse, NodeConfig, NodeCredentials,
+    OnchainPaymentLimitsResponse, OpenChannelFeeRequest, OpenChannelFeeResponse, PayOnchainRequest,
+    PayOnchainResponse, PrepareOnchainPaymentRequest, PrepareOnchainPaymentResponse,
+    PrepareRedeemOnchainFundsRequest, PrepareRedeemOnchainFundsResponse, PrepareRefundRequest,
+    PrepareRefundResponse, ReceiveOnchainRequest, ReceivePaymentRequest, ReceivePaymentResponse,
     RedeemOnchainFundsRequest, RedeemOnchainFundsResponse, RefundRequest, RefundResponse,
     ReportIssueRequest, ReverseSwapFeesRequest, ReverseSwapInfo, ReverseSwapPairInfo,
     SendOnchainRequest, SendOnchainResponse, SendPaymentRequest, SendPaymentResponse,
@@ -689,6 +689,12 @@ pub fn redeem_swap(swap_address: String) -> Result<()> {
 /// See [BreezServices::in_progress_swap]
 pub fn in_progress_swap() -> Result<Option<SwapInfo>> {
     block_on(async { get_breez_services().await?.in_progress_swap().await })
+        .map_err(anyhow::Error::new::<SdkError>)
+}
+
+/// See [BreezServices::list_swaps]
+pub fn list_swaps(req: ListSwapsRequest) -> Result<Vec<SwapInfo>> {
+    block_on(async { get_breez_services().await?.list_swaps(req).await })
         .map_err(anyhow::Error::new::<SdkError>)
 }
 

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -880,6 +880,13 @@ impl BreezServices {
         Ok(())
     }
 
+    /// Lists current and historical swaps.
+    ///
+    /// Swaps can be filtered based on creation time and status.
+    pub async fn list_swaps(&self, req: ListSwapsRequest) -> SdkResult<Vec<SwapInfo>> {
+        Ok(self.persister.list_swaps(req)?)
+    }
+
     /// Claims an individual reverse swap.
     ///
     /// To be used only in the context of mobile notifications, where the notification triggers

--- a/libs/sdk-core/src/bridge_generated.io.rs
+++ b/libs/sdk-core/src/bridge_generated.io.rs
@@ -277,6 +277,11 @@ pub extern "C" fn wire_in_progress_swap(port_: i64) {
 }
 
 #[no_mangle]
+pub extern "C" fn wire_list_swaps(port_: i64, req: *mut wire_ListSwapsRequest) {
+    wire_list_swaps_impl(port_, req)
+}
+
+#[no_mangle]
 pub extern "C" fn wire_in_progress_reverse_swaps(port_: i64) {
     wire_in_progress_reverse_swaps_impl(port_)
 }
@@ -374,6 +379,11 @@ pub extern "C" fn new_box_autoadd_i64_0(value: i64) -> *mut i64 {
 #[no_mangle]
 pub extern "C" fn new_box_autoadd_list_payments_request_0() -> *mut wire_ListPaymentsRequest {
     support::new_leak_box_ptr(wire_ListPaymentsRequest::new_with_null_ptr())
+}
+
+#[no_mangle]
+pub extern "C" fn new_box_autoadd_list_swaps_request_0() -> *mut wire_ListSwapsRequest {
+    support::new_leak_box_ptr(wire_ListSwapsRequest::new_with_null_ptr())
 }
 
 #[no_mangle]
@@ -521,6 +531,15 @@ pub extern "C" fn new_list_payment_type_filter_0(len: i32) -> *mut wire_list_pay
 }
 
 #[no_mangle]
+pub extern "C" fn new_list_swap_status_0(len: i32) -> *mut wire_list_swap_status {
+    let wrap = wire_list_swap_status {
+        ptr: support::new_leak_vec_ptr(Default::default(), len),
+        len,
+    };
+    support::new_leak_box_ptr(wrap)
+}
+
+#[no_mangle]
 pub extern "C" fn new_list_tlv_entry_0(len: i32) -> *mut wire_list_tlv_entry {
     let wrap = wire_list_tlv_entry {
         ptr: support::new_leak_vec_ptr(<wire_TlvEntry>::new_with_null_ptr(), len),
@@ -599,6 +618,12 @@ impl Wire2Api<ListPaymentsRequest> for *mut wire_ListPaymentsRequest {
     fn wire2api(self) -> ListPaymentsRequest {
         let wrap = unsafe { support::box_from_leak_ptr(self) };
         Wire2Api::<ListPaymentsRequest>::wire2api(*wrap).into()
+    }
+}
+impl Wire2Api<ListSwapsRequest> for *mut wire_ListSwapsRequest {
+    fn wire2api(self) -> ListSwapsRequest {
+        let wrap = unsafe { support::box_from_leak_ptr(self) };
+        Wire2Api::<ListSwapsRequest>::wire2api(*wrap).into()
     }
 }
 impl Wire2Api<LnUrlAuthRequestData> for *mut wire_LnUrlAuthRequestData {
@@ -839,6 +864,26 @@ impl Wire2Api<ListPaymentsRequest> for wire_ListPaymentsRequest {
             from_timestamp: self.from_timestamp.wire2api(),
             to_timestamp: self.to_timestamp.wire2api(),
             include_failures: self.include_failures.wire2api(),
+            offset: self.offset.wire2api(),
+            limit: self.limit.wire2api(),
+        }
+    }
+}
+impl Wire2Api<Vec<SwapStatus>> for *mut wire_list_swap_status {
+    fn wire2api(self) -> Vec<SwapStatus> {
+        let vec = unsafe {
+            let wrap = support::box_from_leak_ptr(self);
+            support::vec_from_leak_ptr(wrap.ptr, wrap.len)
+        };
+        vec.into_iter().map(Wire2Api::wire2api).collect()
+    }
+}
+impl Wire2Api<ListSwapsRequest> for wire_ListSwapsRequest {
+    fn wire2api(self) -> ListSwapsRequest {
+        ListSwapsRequest {
+            status: self.status.wire2api(),
+            from_timestamp: self.from_timestamp.wire2api(),
+            to_timestamp: self.to_timestamp.wire2api(),
             offset: self.offset.wire2api(),
             limit: self.limit.wire2api(),
         }
@@ -1215,6 +1260,23 @@ pub struct wire_ListPaymentsRequest {
     from_timestamp: *mut i64,
     to_timestamp: *mut i64,
     include_failures: *mut bool,
+    offset: *mut u32,
+    limit: *mut u32,
+}
+
+#[repr(C)]
+#[derive(Clone)]
+pub struct wire_list_swap_status {
+    ptr: *mut i32,
+    len: i32,
+}
+
+#[repr(C)]
+#[derive(Clone)]
+pub struct wire_ListSwapsRequest {
+    status: *mut wire_list_swap_status,
+    from_timestamp: *mut i64,
+    to_timestamp: *mut i64,
     offset: *mut u32,
     limit: *mut u32,
 }
@@ -1624,6 +1686,24 @@ impl NewWithNullPtr for wire_ListPaymentsRequest {
 }
 
 impl Default for wire_ListPaymentsRequest {
+    fn default() -> Self {
+        Self::new_with_null_ptr()
+    }
+}
+
+impl NewWithNullPtr for wire_ListSwapsRequest {
+    fn new_with_null_ptr() -> Self {
+        Self {
+            status: core::ptr::null_mut(),
+            from_timestamp: core::ptr::null_mut(),
+            to_timestamp: core::ptr::null_mut(),
+            offset: core::ptr::null_mut(),
+            limit: core::ptr::null_mut(),
+        }
+    }
+}
+
+impl Default for wire_ListSwapsRequest {
     fn default() -> Self {
         Self::new_with_null_ptr()
     }

--- a/libs/sdk-core/src/persist/sync.rs
+++ b/libs/sdk-core/src/persist/sync.rs
@@ -275,7 +275,7 @@ mod tests {
     use crate::persist::error::PersistResult;
     use crate::persist::test_utils;
     use crate::test_utils::{get_test_ofp_48h, rand_string, rand_vec_u8};
-    use crate::SwapInfo;
+    use crate::{ListSwapsRequest, SwapInfo};
 
     #[test]
     fn test_sync() -> PersistResult<()> {
@@ -303,10 +303,10 @@ mod tests {
         remote_storage.import_remote_changes(&local_storage, false)?;
         local_storage.import_remote_changes(&remote_storage, true)?;
 
-        let mut local_swaps = local_storage.list_swaps()?;
+        let mut local_swaps = local_storage.list_swaps(ListSwapsRequest::default())?;
         local_swaps.sort_by(|s1, s2| s1.bitcoin_address.cmp(&s2.bitcoin_address));
 
-        let mut remote_swaps = local_storage.list_swaps()?;
+        let mut remote_swaps = local_storage.list_swaps(ListSwapsRequest::default())?;
         remote_swaps.sort_by(|s1, s2| s1.bitcoin_address.cmp(&s2.bitcoin_address));
 
         assert_eq!(local_swaps, remote_swaps);
@@ -335,7 +335,7 @@ mod tests {
         let new_fees: crate::OpeningFeeParams = get_test_ofp_48h(10, 10).into();
         local_storage.update_swap_fees(local_swap_info.bitcoin_address, new_fees.clone())?;
 
-        let local_swaps = local_storage.list_swaps()?;
+        let local_swaps = local_storage.list_swaps(ListSwapsRequest::default())?;
         assert_eq!(local_swaps.len(), 1);
         assert_eq!(
             local_swaps
@@ -391,8 +391,8 @@ mod tests {
         // - R2 fee created_at > L2 fee created_at => sync should replace the local version
         // - R3 should be created (mirror of L3) because it doesn't exist on remote
 
-        let local_swaps = local_storage.list_swaps()?;
-        let remote_swaps = remote_storage.list_swaps()?;
+        let local_swaps = local_storage.list_swaps(ListSwapsRequest::default())?;
+        let remote_swaps = remote_storage.list_swaps(ListSwapsRequest::default())?;
         assert_eq!(local_swaps.len(), 3);
         assert_eq!(remote_swaps.len(), 2); // Before the sync, only 2 swaps in remote
 
@@ -400,8 +400,8 @@ mod tests {
         remote_storage.import_remote_changes(&local_storage, false)?;
         local_storage.import_remote_changes(&remote_storage, true)?;
 
-        let local_swaps = local_storage.list_swaps()?;
-        let remote_swaps = remote_storage.list_swaps()?;
+        let local_swaps = local_storage.list_swaps(ListSwapsRequest::default())?;
+        let remote_swaps = remote_storage.list_swaps(ListSwapsRequest::default())?;
         assert_eq!(local_swaps.len(), 3);
         assert_eq!(remote_swaps.len(), 3); // After the sync, all 3 swaps in remote
 

--- a/libs/sdk-flutter/ios/Classes/bridge_generated.h
+++ b/libs/sdk-flutter/ios/Classes/bridge_generated.h
@@ -269,6 +269,19 @@ typedef struct wire_RefundRequest {
   uint32_t sat_per_vbyte;
 } wire_RefundRequest;
 
+typedef struct wire_list_swap_status {
+  int32_t *ptr;
+  int32_t len;
+} wire_list_swap_status;
+
+typedef struct wire_ListSwapsRequest {
+  struct wire_list_swap_status *status;
+  int64_t *from_timestamp;
+  int64_t *to_timestamp;
+  uint32_t *offset;
+  uint32_t *limit;
+} wire_ListSwapsRequest;
+
 typedef struct wire_OpenChannelFeeRequest {
   uint64_t *amount_msat;
   uint32_t *expiry;
@@ -407,6 +420,8 @@ void wire_redeem_swap(int64_t port_, struct wire_uint_8_list *swap_address);
 
 void wire_in_progress_swap(int64_t port_);
 
+void wire_list_swaps(int64_t port_, struct wire_ListSwapsRequest *req);
+
 void wire_in_progress_reverse_swaps(int64_t port_);
 
 void wire_claim_reverse_swap(int64_t port_, struct wire_uint_8_list *lockup_address);
@@ -444,6 +459,8 @@ struct wire_GreenlightNodeConfig *new_box_autoadd_greenlight_node_config_0(void)
 int64_t *new_box_autoadd_i64_0(int64_t value);
 
 struct wire_ListPaymentsRequest *new_box_autoadd_list_payments_request_0(void);
+
+struct wire_ListSwapsRequest *new_box_autoadd_list_swaps_request_0(void);
 
 struct wire_LnUrlAuthRequestData *new_box_autoadd_ln_url_auth_request_data_0(void);
 
@@ -496,6 +513,8 @@ uint64_t *new_box_autoadd_u64_0(uint64_t value);
 struct wire_list_metadata_filter *new_list_metadata_filter_0(int32_t len);
 
 struct wire_list_payment_type_filter *new_list_payment_type_filter_0(int32_t len);
+
+struct wire_list_swap_status *new_list_swap_status_0(int32_t len);
 
 struct wire_list_tlv_entry *new_list_tlv_entry_0(int32_t len);
 
@@ -561,6 +580,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_rescan_swaps);
     dummy_var ^= ((int64_t) (void*) wire_redeem_swap);
     dummy_var ^= ((int64_t) (void*) wire_in_progress_swap);
+    dummy_var ^= ((int64_t) (void*) wire_list_swaps);
     dummy_var ^= ((int64_t) (void*) wire_in_progress_reverse_swaps);
     dummy_var ^= ((int64_t) (void*) wire_claim_reverse_swap);
     dummy_var ^= ((int64_t) (void*) wire_open_channel_fee);
@@ -580,6 +600,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_greenlight_node_config_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_i64_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_list_payments_request_0);
+    dummy_var ^= ((int64_t) (void*) new_box_autoadd_list_swaps_request_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_ln_url_auth_request_data_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_ln_url_pay_request_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_ln_url_withdraw_request_0);
@@ -606,6 +627,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_u64_0);
     dummy_var ^= ((int64_t) (void*) new_list_metadata_filter_0);
     dummy_var ^= ((int64_t) (void*) new_list_payment_type_filter_0);
+    dummy_var ^= ((int64_t) (void*) new_list_swap_status_0);
     dummy_var ^= ((int64_t) (void*) new_list_tlv_entry_0);
     dummy_var ^= ((int64_t) (void*) new_uint_8_list_0);
     dummy_var ^= ((int64_t) (void*) inflate_NodeConfig_Greenlight);

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -277,6 +277,11 @@ abstract class BreezSdkCore {
 
   FlutterRustBridgeTaskConstMeta get kInProgressSwapConstMeta;
 
+  /// See [BreezServices::list_swaps]
+  Future<List<SwapInfo>> listSwaps({required ListSwapsRequest req, dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kListSwapsConstMeta;
+
   /// See [BreezServices::in_progress_reverse_swaps]
   Future<List<ReverseSwapInfo>> inProgressReverseSwaps({dynamic hint});
 
@@ -723,6 +728,26 @@ class ListPaymentsRequest {
     this.fromTimestamp,
     this.toTimestamp,
     this.includeFailures,
+    this.offset,
+    this.limit,
+  });
+}
+
+class ListSwapsRequest {
+  final List<SwapStatus>? status;
+
+  /// Epoch time, in seconds. If set, acts as filter for minimum swap creation time, inclusive.
+  final int? fromTimestamp;
+
+  /// Epoch time, in seconds. If set, acts as filter for maximum swap creation time, exclusive.
+  final int? toTimestamp;
+  final int? offset;
+  final int? limit;
+
+  const ListSwapsRequest({
+    this.status,
+    this.fromTimestamp,
+    this.toTimestamp,
     this.offset,
     this.limit,
   });
@@ -2885,6 +2910,23 @@ class BreezSdkCoreImpl implements BreezSdkCore {
         argNames: [],
       );
 
+  Future<List<SwapInfo>> listSwaps({required ListSwapsRequest req, dynamic hint}) {
+    var arg0 = _platform.api2wire_box_autoadd_list_swaps_request(req);
+    return _platform.executeNormal(FlutterRustBridgeTask(
+      callFfi: (port_) => _platform.inner.wire_list_swaps(port_, arg0),
+      parseSuccessData: _wire2api_list_swap_info,
+      parseErrorData: _wire2api_FrbAnyhowException,
+      constMeta: kListSwapsConstMeta,
+      argValues: [req],
+      hint: hint,
+    ));
+  }
+
+  FlutterRustBridgeTaskConstMeta get kListSwapsConstMeta => const FlutterRustBridgeTaskConstMeta(
+        debugName: "list_swaps",
+        argNames: ["req"],
+      );
+
   Future<List<ReverseSwapInfo>> inProgressReverseSwaps({dynamic hint}) {
     return _platform.executeNormal(FlutterRustBridgeTask(
       callFfi: (port_) => _platform.inner.wire_in_progress_reverse_swaps(port_),
@@ -4266,6 +4308,11 @@ int api2wire_swap_amount_type(SwapAmountType raw) {
 }
 
 @protected
+int api2wire_swap_status(SwapStatus raw) {
+  return api2wire_i32(raw.index);
+}
+
+@protected
 int api2wire_u16(int raw) {
   return raw;
 }
@@ -4351,6 +4398,13 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
   ffi.Pointer<wire_ListPaymentsRequest> api2wire_box_autoadd_list_payments_request(ListPaymentsRequest raw) {
     final ptr = inner.new_box_autoadd_list_payments_request_0();
     _api_fill_to_wire_list_payments_request(raw, ptr.ref);
+    return ptr;
+  }
+
+  @protected
+  ffi.Pointer<wire_ListSwapsRequest> api2wire_box_autoadd_list_swaps_request(ListSwapsRequest raw) {
+    final ptr = inner.new_box_autoadd_list_swaps_request_0();
+    _api_fill_to_wire_list_swaps_request(raw, ptr.ref);
     return ptr;
   }
 
@@ -4554,6 +4608,15 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
   }
 
   @protected
+  ffi.Pointer<wire_list_swap_status> api2wire_list_swap_status(List<SwapStatus> raw) {
+    final ans = inner.new_list_swap_status_0(raw.length);
+    for (var i = 0; i < raw.length; ++i) {
+      ans.ref.ptr[i] = api2wire_swap_status(raw[i]);
+    }
+    return ans;
+  }
+
+  @protected
   ffi.Pointer<wire_list_tlv_entry> api2wire_list_tlv_entry(List<TlvEntry> raw) {
     final ans = inner.new_list_tlv_entry_0(raw.length);
     for (var i = 0; i < raw.length; ++i) {
@@ -4607,6 +4670,11 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
   ffi.Pointer<wire_list_payment_type_filter> api2wire_opt_list_payment_type_filter(
       List<PaymentTypeFilter>? raw) {
     return raw == null ? ffi.nullptr : api2wire_list_payment_type_filter(raw);
+  }
+
+  @protected
+  ffi.Pointer<wire_list_swap_status> api2wire_opt_list_swap_status(List<SwapStatus>? raw) {
+    return raw == null ? ffi.nullptr : api2wire_list_swap_status(raw);
   }
 
   @protected
@@ -4667,6 +4735,11 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
   void _api_fill_to_wire_box_autoadd_list_payments_request(
       ListPaymentsRequest apiObj, ffi.Pointer<wire_ListPaymentsRequest> wireObj) {
     _api_fill_to_wire_list_payments_request(apiObj, wireObj.ref);
+  }
+
+  void _api_fill_to_wire_box_autoadd_list_swaps_request(
+      ListSwapsRequest apiObj, ffi.Pointer<wire_ListSwapsRequest> wireObj) {
+    _api_fill_to_wire_list_swaps_request(apiObj, wireObj.ref);
   }
 
   void _api_fill_to_wire_box_autoadd_ln_url_auth_request_data(
@@ -4833,6 +4906,14 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
     wireObj.from_timestamp = api2wire_opt_box_autoadd_i64(apiObj.fromTimestamp);
     wireObj.to_timestamp = api2wire_opt_box_autoadd_i64(apiObj.toTimestamp);
     wireObj.include_failures = api2wire_opt_box_autoadd_bool(apiObj.includeFailures);
+    wireObj.offset = api2wire_opt_box_autoadd_u32(apiObj.offset);
+    wireObj.limit = api2wire_opt_box_autoadd_u32(apiObj.limit);
+  }
+
+  void _api_fill_to_wire_list_swaps_request(ListSwapsRequest apiObj, wire_ListSwapsRequest wireObj) {
+    wireObj.status = api2wire_opt_list_swap_status(apiObj.status);
+    wireObj.from_timestamp = api2wire_opt_box_autoadd_i64(apiObj.fromTimestamp);
+    wireObj.to_timestamp = api2wire_opt_box_autoadd_i64(apiObj.toTimestamp);
     wireObj.offset = api2wire_opt_box_autoadd_u32(apiObj.offset);
     wireObj.limit = api2wire_opt_box_autoadd_u32(apiObj.limit);
   }
@@ -5878,6 +5959,22 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_in_progress_swap');
   late final _wire_in_progress_swap = _wire_in_progress_swapPtr.asFunction<void Function(int)>();
 
+  void wire_list_swaps(
+    int port_,
+    ffi.Pointer<wire_ListSwapsRequest> req,
+  ) {
+    return _wire_list_swaps(
+      port_,
+      req,
+    );
+  }
+
+  late final _wire_list_swapsPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_ListSwapsRequest>)>>(
+          'wire_list_swaps');
+  late final _wire_list_swaps =
+      _wire_list_swapsPtr.asFunction<void Function(int, ffi.Pointer<wire_ListSwapsRequest>)>();
+
   void wire_in_progress_reverse_swaps(
     int port_,
   ) {
@@ -6116,6 +6213,16 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
           'new_box_autoadd_list_payments_request_0');
   late final _new_box_autoadd_list_payments_request_0 = _new_box_autoadd_list_payments_request_0Ptr
       .asFunction<ffi.Pointer<wire_ListPaymentsRequest> Function()>();
+
+  ffi.Pointer<wire_ListSwapsRequest> new_box_autoadd_list_swaps_request_0() {
+    return _new_box_autoadd_list_swaps_request_0();
+  }
+
+  late final _new_box_autoadd_list_swaps_request_0Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_ListSwapsRequest> Function()>>(
+          'new_box_autoadd_list_swaps_request_0');
+  late final _new_box_autoadd_list_swaps_request_0 =
+      _new_box_autoadd_list_swaps_request_0Ptr.asFunction<ffi.Pointer<wire_ListSwapsRequest> Function()>();
 
   ffi.Pointer<wire_LnUrlAuthRequestData> new_box_autoadd_ln_url_auth_request_data_0() {
     return _new_box_autoadd_ln_url_auth_request_data_0();
@@ -6395,6 +6502,20 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
           'new_list_payment_type_filter_0');
   late final _new_list_payment_type_filter_0 = _new_list_payment_type_filter_0Ptr
       .asFunction<ffi.Pointer<wire_list_payment_type_filter> Function(int)>();
+
+  ffi.Pointer<wire_list_swap_status> new_list_swap_status_0(
+    int len,
+  ) {
+    return _new_list_swap_status_0(
+      len,
+    );
+  }
+
+  late final _new_list_swap_status_0Ptr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<wire_list_swap_status> Function(ffi.Int32)>>(
+          'new_list_swap_status_0');
+  late final _new_list_swap_status_0 =
+      _new_list_swap_status_0Ptr.asFunction<ffi.Pointer<wire_list_swap_status> Function(int)>();
 
   ffi.Pointer<wire_list_tlv_entry> new_list_tlv_entry_0(
     int len,
@@ -6831,6 +6952,25 @@ final class wire_RefundRequest extends ffi.Struct {
 
   @ffi.Uint32()
   external int sat_per_vbyte;
+}
+
+final class wire_list_swap_status extends ffi.Struct {
+  external ffi.Pointer<ffi.Int32> ptr;
+
+  @ffi.Int32()
+  external int len;
+}
+
+final class wire_ListSwapsRequest extends ffi.Struct {
+  external ffi.Pointer<wire_list_swap_status> status;
+
+  external ffi.Pointer<ffi.Int64> from_timestamp;
+
+  external ffi.Pointer<ffi.Int64> to_timestamp;
+
+  external ffi.Pointer<ffi.Uint32> offset;
+
+  external ffi.Pointer<ffi.Uint32> limit;
 }
 
 final class wire_OpenChannelFeeRequest extends ffi.Struct {

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -910,6 +910,48 @@ fun asListPaymentsRequestList(arr: ReadableArray): List<ListPaymentsRequest> {
     return list
 }
 
+fun asListSwapsRequest(listSwapsRequest: ReadableMap): ListSwapsRequest? {
+    if (!validateMandatoryFields(
+            listSwapsRequest,
+            arrayOf(),
+        )
+    ) {
+        return null
+    }
+    val status = if (hasNonNullKey(listSwapsRequest, "status")) listSwapsRequest.getArray("status")?.let { asSwapStatusList(it) } else null
+    val fromTimestamp = if (hasNonNullKey(listSwapsRequest, "fromTimestamp")) listSwapsRequest.getDouble("fromTimestamp").toLong() else null
+    val toTimestamp = if (hasNonNullKey(listSwapsRequest, "toTimestamp")) listSwapsRequest.getDouble("toTimestamp").toLong() else null
+    val offset = if (hasNonNullKey(listSwapsRequest, "offset")) listSwapsRequest.getInt("offset").toUInt() else null
+    val limit = if (hasNonNullKey(listSwapsRequest, "limit")) listSwapsRequest.getInt("limit").toUInt() else null
+    return ListSwapsRequest(
+        status,
+        fromTimestamp,
+        toTimestamp,
+        offset,
+        limit,
+    )
+}
+
+fun readableMapOf(listSwapsRequest: ListSwapsRequest): ReadableMap =
+    readableMapOf(
+        "status" to listSwapsRequest.status?.let { readableArrayOf(it) },
+        "fromTimestamp" to listSwapsRequest.fromTimestamp,
+        "toTimestamp" to listSwapsRequest.toTimestamp,
+        "offset" to listSwapsRequest.offset,
+        "limit" to listSwapsRequest.limit,
+    )
+
+fun asListSwapsRequestList(arr: ReadableArray): List<ListSwapsRequest> {
+    val list = ArrayList<ListSwapsRequest>()
+    for (value in arr.toArrayList()) {
+        when (value) {
+            is ReadableMap -> list.add(asListSwapsRequest(value)!!)
+            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
+        }
+    }
+    return list
+}
+
 fun asLnPaymentDetails(lnPaymentDetails: ReadableMap): LnPaymentDetails? {
     if (!validateMandatoryFields(
             lnPaymentDetails,
@@ -4496,6 +4538,7 @@ fun pushToArray(
         is RouteHintHop -> array.pushMap(readableMapOf(value))
         is String -> array.pushString(value)
         is SwapInfo -> array.pushMap(readableMapOf(value))
+        is SwapStatus -> array.pushString(value.name.lowercase())
         is TlvEntry -> array.pushMap(readableMapOf(value))
         is UByte -> array.pushInt(value.toInt())
         is UnspentTransactionOutput -> array.pushMap(readableMapOf(value))

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
@@ -753,6 +753,23 @@ class BreezSDKModule(
     }
 
     @ReactMethod
+    fun listSwaps(
+        req: ReadableMap,
+        promise: Promise,
+    ) {
+        executor.execute {
+            try {
+                val listSwapsRequest =
+                    asListSwapsRequest(req) ?: run { throw SdkException.Generic(errMissingMandatoryField("req", "ListSwapsRequest")) }
+                val res = getBreezServices().listSwaps(listSwapsRequest)
+                promise.resolve(readableArrayOf(res))
+            } catch (e: Exception) {
+                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
+            }
+        }
+    }
+
+    @ReactMethod
     fun fetchReverseSwapFees(
         req: ReadableMap,
         promise: Promise,

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -1049,6 +1049,77 @@ enum BreezSDKMapper {
         return listPaymentsRequestList.map { v -> [String: Any?] in return dictionaryOf(listPaymentsRequest: v) }
     }
 
+    static func asListSwapsRequest(listSwapsRequest: [String: Any?]) throws -> ListSwapsRequest {
+        var status: [SwapStatus]?
+        if let statusTmp = listSwapsRequest["status"] as? [String] {
+            status = try asSwapStatusList(arr: statusTmp)
+        }
+
+        var fromTimestamp: Int64?
+        if hasNonNilKey(data: listSwapsRequest, key: "fromTimestamp") {
+            guard let fromTimestampTmp = listSwapsRequest["fromTimestamp"] as? Int64 else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "fromTimestamp"))
+            }
+            fromTimestamp = fromTimestampTmp
+        }
+        var toTimestamp: Int64?
+        if hasNonNilKey(data: listSwapsRequest, key: "toTimestamp") {
+            guard let toTimestampTmp = listSwapsRequest["toTimestamp"] as? Int64 else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "toTimestamp"))
+            }
+            toTimestamp = toTimestampTmp
+        }
+        var offset: UInt32?
+        if hasNonNilKey(data: listSwapsRequest, key: "offset") {
+            guard let offsetTmp = listSwapsRequest["offset"] as? UInt32 else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "offset"))
+            }
+            offset = offsetTmp
+        }
+        var limit: UInt32?
+        if hasNonNilKey(data: listSwapsRequest, key: "limit") {
+            guard let limitTmp = listSwapsRequest["limit"] as? UInt32 else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "limit"))
+            }
+            limit = limitTmp
+        }
+
+        return ListSwapsRequest(
+            status: status,
+            fromTimestamp: fromTimestamp,
+            toTimestamp: toTimestamp,
+            offset: offset,
+            limit: limit
+        )
+    }
+
+    static func dictionaryOf(listSwapsRequest: ListSwapsRequest) -> [String: Any?] {
+        return [
+            "status": listSwapsRequest.status == nil ? nil : arrayOf(swapStatusList: listSwapsRequest.status!),
+            "fromTimestamp": listSwapsRequest.fromTimestamp == nil ? nil : listSwapsRequest.fromTimestamp,
+            "toTimestamp": listSwapsRequest.toTimestamp == nil ? nil : listSwapsRequest.toTimestamp,
+            "offset": listSwapsRequest.offset == nil ? nil : listSwapsRequest.offset,
+            "limit": listSwapsRequest.limit == nil ? nil : listSwapsRequest.limit,
+        ]
+    }
+
+    static func asListSwapsRequestList(arr: [Any]) throws -> [ListSwapsRequest] {
+        var list = [ListSwapsRequest]()
+        for value in arr {
+            if let val = value as? [String: Any?] {
+                var listSwapsRequest = try asListSwapsRequest(listSwapsRequest: val)
+                list.append(listSwapsRequest)
+            } else {
+                throw SdkError.Generic(message: errUnexpectedType(typeName: "ListSwapsRequest"))
+            }
+        }
+        return list
+    }
+
+    static func arrayOf(listSwapsRequestList: [ListSwapsRequest]) -> [Any] {
+        return listSwapsRequestList.map { v -> [String: Any?] in return dictionaryOf(listSwapsRequest: v) }
+    }
+
     static func asLnPaymentDetails(lnPaymentDetails: [String: Any?]) throws -> LnPaymentDetails {
         guard let paymentHash = lnPaymentDetails["paymentHash"] as? String else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "paymentHash", typeName: "LnPaymentDetails"))

--- a/libs/sdk-react-native/ios/RNBreezSDK.m
+++ b/libs/sdk-react-native/ios/RNBreezSDK.m
@@ -262,6 +262,12 @@ RCT_EXTERN_METHOD(
 )
 
 RCT_EXTERN_METHOD(
+    listSwaps: (NSDictionary*)req
+    resolve: (RCTPromiseResolveBlock)resolve
+    reject: (RCTPromiseRejectBlock)reject
+)
+
+RCT_EXTERN_METHOD(
     fetchReverseSwapFees: (NSDictionary*)req
     resolve: (RCTPromiseResolveBlock)resolve
     reject: (RCTPromiseRejectBlock)reject

--- a/libs/sdk-react-native/ios/RNBreezSDK.swift
+++ b/libs/sdk-react-native/ios/RNBreezSDK.swift
@@ -565,6 +565,17 @@ class RNBreezSDK: RCTEventEmitter {
         }
     }
 
+    @objc(listSwaps:resolve:reject:)
+    func listSwaps(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        do {
+            let listSwapsRequest = try BreezSDKMapper.asListSwapsRequest(listSwapsRequest: req)
+            var res = try getBreezServices().listSwaps(req: listSwapsRequest)
+            resolve(BreezSDKMapper.arrayOf(swapInfoList: res))
+        } catch let err {
+            rejectErr(err: err, reject: reject)
+        }
+    }
+
     @objc(fetchReverseSwapFees:resolve:reject:)
     func fetchReverseSwapFees(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         do {

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -153,6 +153,14 @@ export interface ListPaymentsRequest {
     limit?: number
 }
 
+export interface ListSwapsRequest {
+    status?: SwapStatus[]
+    fromTimestamp?: number
+    toTimestamp?: number
+    offset?: number
+    limit?: number
+}
+
 export interface LnPaymentDetails {
     paymentHash: string
     label: string
@@ -1081,6 +1089,11 @@ export const prepareRefund = async (req: PrepareRefundRequest): Promise<PrepareR
 
 export const refund = async (req: RefundRequest): Promise<RefundResponse> => {
     const response = await BreezSDK.refund(req)
+    return response
+}
+
+export const listSwaps = async (req: ListSwapsRequest): Promise<SwapInfo[]> => {
+    const response = await BreezSDK.listSwaps(req)
     return response
 }
 

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -6,7 +6,7 @@ use anyhow::{anyhow, Context, Error, Result};
 use breez_sdk_core::InputType::{LnUrlAuth, LnUrlPay, LnUrlWithdraw};
 use breez_sdk_core::{
     parse, BreezEvent, BreezServices, BuyBitcoinRequest, CheckMessageRequest, ConnectRequest,
-    EventListener, GreenlightCredentials, ListPaymentsRequest, LnUrlPayRequest,
+    EventListener, GreenlightCredentials, ListPaymentsRequest, ListSwapsRequest, LnUrlPayRequest,
     LnUrlWithdrawRequest, MetadataFilter, PayOnchainRequest, PrepareOnchainPaymentRequest,
     PrepareRedeemOnchainFundsRequest, PrepareRefundRequest, ReceiveOnchainRequest,
     ReceivePaymentRequest, RedeemOnchainFundsRequest, RefundRequest, ReportIssueRequest,
@@ -458,6 +458,16 @@ pub(crate) async fn handle_command(
                 })
                 .await?;
             Ok(format!("Refund tx: {}", res.refund_tx_id))
+        }
+        Commands::ListSwaps { offset, limit } => {
+            let res = sdk()?
+                .list_swaps(ListSwapsRequest {
+                    offset,
+                    limit,
+                    ..Default::default()
+                })
+                .await?;
+            Ok(serde_json::to_string_pretty(&res)?)
         }
         Commands::SignMessage { message } => {
             let req = SignMessageRequest { message };

--- a/tools/sdk-cli/src/commands.rs
+++ b/tools/sdk-cli/src/commands.rs
@@ -139,6 +139,14 @@ pub(crate) enum Commands {
         sat_per_vbyte: u32,
     },
 
+    ListSwaps {
+        #[clap(short = 'o', long = "offset")]
+        offset: Option<u32>,
+
+        #[clap(short = 'l', long = "limit")]
+        limit: Option<u32>,
+    },
+
     /// [swap-out] Send on-chain using a reverse swap
     SendOnchain {
         amount_sat: u64,


### PR DESCRIPTION
Adds a `list_swaps` function to the SDK, to query current and historical swaps. Swaps can be filtered by created timestamp and status. They can be paged with `offset` and `limit` fields.

Fixes #1077