### PR TITLE
Clarify `receive_onchain` docs

### DIFF
--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -807,7 +807,8 @@ impl BreezServices {
     /// Onchain receive swap API
     ///
     /// Create and start a new swap. A user-selected [OpeningFeeParams] can be optionally set in the argument.
-    /// If set, and the operation requires a new channel, the SDK will try to use the given fee params.
+    /// If set, and the operation requires a new channel, the SDK will enforce the use the given fee params.
+    /// The provided [OpeningFeeParams] need to be valid at the time of swap redeeming.
     ///
     /// Since we only allow one in-progress swap this method will return error if there is currently
     /// a swap waiting for confirmation to be redeemed and by that complete the swap.


### PR DESCRIPTION
I adjusted the docs according to my understanding of the method. As an SDK user, the word "try" made me think that it would be on a best-effort basis, and redeeming would still work even if the provided params were not valid when the swap is ready to be redeemed.