### PR TITLE
Persist `SendPay.groupid` as `TEXT` to cover full `u64` range

### DIFF
--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -808,7 +808,7 @@ impl Greenlight {
                 let mut key = hex::encode(&p.payment_hash);
                 key.push('|');
                 key.push_str(&p.groupid.to_string());
-                (key, (p.payment_hash.clone(), p.groupid))
+                (key, (p.payment_hash.clone(), p.groupid.to_string()))
             })
             .collect();
         let hash_group_values: Vec<_> = hash_groups.values().cloned().collect();
@@ -840,7 +840,7 @@ impl Greenlight {
         for send_pay in send_pays {
             let mut key = hex::encode(&send_pay.payment_hash);
             key.push('|');
-            key.push_str(&send_pay.groupid.to_string());
+            key.push_str(&send_pay.groupid);
             let payment = outbound_payments.entry(key).or_insert(SendPayAgg {
                 state: 0,
                 created_at: send_pay.created_at,
@@ -2147,7 +2147,7 @@ impl TryFrom<ListsendpaysPayments> for SendPay {
                 .created_index
                 .ok_or(NodeError::generic("missing created index"))?,
             updated_index: value.updated_index,
-            groupid: value.groupid,
+            groupid: value.groupid.to_string(),
             partid: value.partid,
             payment_hash: value.payment_hash,
             status: value.status.try_into()?,

--- a/libs/sdk-core/src/persist/migrations.rs
+++ b/libs/sdk-core/src/persist/migrations.rs
@@ -457,9 +457,10 @@ pub(crate) fn current_migrations() -> Vec<&'static str> {
        ",
        "DELETE FROM payments",
        "DELETE FROM cached_items WHERE key = 'sync_state'",
-       // Change groupid type to TEXT
+       // Delete send_pays, re-create it with groupid column as TEXT
        "
        ALTER TABLE send_pays RENAME TO send_pays_old;
+       DROP TABLE send_pays_old;
 
        CREATE TABLE send_pays (
         created_index INTEGER PRIMARY KEY NOT NULL,
@@ -480,9 +481,7 @@ pub(crate) fn current_migrations() -> Vec<&'static str> {
         erroronion BLOB
        ) STRICT;
 
-       INSERT INTO send_pays SELECT * FROM send_pays_old;
-
-       DROP TABLE send_pays_old;
+       DELETE FROM cached_items WHERE key = 'sync_state';
        ",
     ]
 }

--- a/libs/sdk-core/src/persist/migrations.rs
+++ b/libs/sdk-core/src/persist/migrations.rs
@@ -459,8 +459,7 @@ pub(crate) fn current_migrations() -> Vec<&'static str> {
        "DELETE FROM cached_items WHERE key = 'sync_state'",
        // Delete send_pays, re-create it with groupid column as TEXT
        "
-       ALTER TABLE send_pays RENAME TO send_pays_old;
-       DROP TABLE send_pays_old;
+       DROP TABLE send_pays;
 
        CREATE TABLE send_pays (
         created_index INTEGER PRIMARY KEY NOT NULL,

--- a/libs/sdk-core/src/persist/migrations.rs
+++ b/libs/sdk-core/src/persist/migrations.rs
@@ -457,6 +457,33 @@ pub(crate) fn current_migrations() -> Vec<&'static str> {
        ",
        "DELETE FROM payments",
        "DELETE FROM cached_items WHERE key = 'sync_state'",
+       // Change groupid type to TEXT
+       "
+       ALTER TABLE send_pays RENAME TO send_pays_old;
+
+       CREATE TABLE send_pays (
+        created_index INTEGER PRIMARY KEY NOT NULL,
+        updated_index INTEGER,
+        groupid TEXT NOT NULL,
+        partid INTEGER,
+        payment_hash BLOB NOT NULL,
+        status INTEGER NOT NULL,
+        amount_msat INTEGER,
+        destination BLOB,
+        created_at INTEGER NOT NULL,
+        amount_sent_msat INTEGER,
+        label TEXT,
+        bolt11 TEXT,
+        description TEXT,
+        bolt12 TEXT,
+        payment_preimage BLOB,
+        erroronion BLOB
+       ) STRICT;
+
+       INSERT INTO send_pays SELECT * FROM send_pays_old;
+
+       DROP TABLE send_pays_old;
+       ",
     ]
 }
 


### PR DESCRIPTION
Restoring a node kept panicking with a  `ToSqlConversionFailure(TryFromIntError(()))` error. Turns out this was caused by how we persist `SendPay.groupid`.

In `cln_grpc` this field is defined as `uint64` and deserialized as `u64`:

https://github.com/ElementsProject/lightning/blob/e66653fa1d847e28bd812356a762225a44bfae83/cln-grpc/proto/node.proto#L935

However we map it to an `INTEGER` in the DB, which actually accepts _signed_ 64 bit numbers. If we try to persist positive integers that use the 64th bit, inserting it into SQL will fail with `ToSqlConversionFailure(TryFromIntError(()))`.

This is exactly what caused `restore` to fail in my case, as I had several `groupids` bigger than `2^63`.

This PR fixes this by converting `SendPay.groupid` to `String` and storing it as `TEXT`. Since we only use it as a `String`, we don't have to re-convert it back to `u64` when deserializing `SendPay` from the DB.