### PR TITLE
Remove send_onchain

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -791,24 +791,9 @@ dictionary SendPaymentResponse {
     Payment payment;
 };
 
-dictionary MaxReverseSwapAmountResponse {
-    u64 total_sat;
-};
-
-dictionary SendOnchainRequest {
-    u64 amount_sat;
-    string onchain_recipient_address;
-    string pair_hash;
-    u32 sat_per_vbyte;
-};
-
 dictionary PayOnchainRequest {
     string recipient_address;
     PrepareOnchainPaymentResponse prepare_res;
-};
-
-dictionary SendOnchainResponse {
-    ReverseSwapInfo reverse_swap_info;
 };
 
 dictionary PayOnchainResponse {
@@ -965,16 +950,7 @@ interface BlockingBreezServices {
    sequence<ReverseSwapInfo> in_progress_onchain_payments();
 
    [Throws=SdkError]
-   sequence<ReverseSwapInfo> in_progress_reverse_swaps();
-   
-   [Throws=SdkError]
    void claim_reverse_swap(string lockup_address);
-
-   [Throws=SdkError]
-   MaxReverseSwapAmountResponse max_reverse_swap_amount();
-
-   [Throws=SendOnchainError]
-   SendOnchainResponse send_onchain(SendOnchainRequest req);
 
    [Throws=SendOnchainError]
    PayOnchainResponse pay_onchain(PayOnchainRequest req);

--- a/libs/sdk-bindings/src/uniffi_binding.rs
+++ b/libs/sdk-bindings/src/uniffi_binding.rs
@@ -14,22 +14,21 @@ use breez_sdk_core::{
     LnPaymentDetails, LnUrlAuthError, LnUrlAuthRequestData, LnUrlCallbackStatus, LnUrlErrorData,
     LnUrlPayError, LnUrlPayErrorData, LnUrlPayRequest, LnUrlPayRequestData, LnUrlWithdrawError,
     LnUrlWithdrawRequest, LnUrlWithdrawRequestData, LnUrlWithdrawResult, LnUrlWithdrawSuccessData,
-    LocaleOverrides, LocalizedName, LogEntry, LogStream, LspInformation,
-    MaxReverseSwapAmountResponse, MessageSuccessActionData, MetadataFilter, MetadataItem, Network,
-    NodeConfig, NodeCredentials, NodeState, OnchainPaymentLimitsResponse, OpenChannelFeeRequest,
-    OpenChannelFeeResponse, OpeningFeeParams, OpeningFeeParamsMenu, PayOnchainRequest,
-    PayOnchainResponse, Payment, PaymentDetails, PaymentFailedData, PaymentStatus, PaymentType,
-    PaymentTypeFilter, PrepareOnchainPaymentRequest, PrepareOnchainPaymentResponse,
-    PrepareRedeemOnchainFundsRequest, PrepareRedeemOnchainFundsResponse, PrepareRefundRequest,
-    PrepareRefundResponse, Rate, ReceiveOnchainRequest, ReceivePaymentRequest,
-    ReceivePaymentResponse, RecommendedFees, RedeemOnchainFundsRequest, RedeemOnchainFundsResponse,
-    RefundRequest, RefundResponse, ReportIssueRequest, ReportPaymentFailureDetails,
-    ReverseSwapFeesRequest, ReverseSwapInfo, ReverseSwapPairInfo, ReverseSwapStatus, RouteHint,
-    RouteHintHop, SendOnchainRequest, SendOnchainResponse, SendPaymentRequest, SendPaymentResponse,
-    SendSpontaneousPaymentRequest, ServiceHealthCheckResponse, SignMessageRequest,
-    SignMessageResponse, StaticBackupRequest, StaticBackupResponse, SuccessActionProcessed,
-    SwapAmountType, SwapInfo, SwapStatus, Symbol, TlvEntry, UnspentTransactionOutput,
-    UrlSuccessActionData,
+    LocaleOverrides, LocalizedName, LogEntry, LogStream, LspInformation, MessageSuccessActionData,
+    MetadataFilter, MetadataItem, Network, NodeConfig, NodeCredentials, NodeState,
+    OnchainPaymentLimitsResponse, OpenChannelFeeRequest, OpenChannelFeeResponse, OpeningFeeParams,
+    OpeningFeeParamsMenu, PayOnchainRequest, PayOnchainResponse, Payment, PaymentDetails,
+    PaymentFailedData, PaymentStatus, PaymentType, PaymentTypeFilter, PrepareOnchainPaymentRequest,
+    PrepareOnchainPaymentResponse, PrepareRedeemOnchainFundsRequest,
+    PrepareRedeemOnchainFundsResponse, PrepareRefundRequest, PrepareRefundResponse, Rate,
+    ReceiveOnchainRequest, ReceivePaymentRequest, ReceivePaymentResponse, RecommendedFees,
+    RedeemOnchainFundsRequest, RedeemOnchainFundsResponse, RefundRequest, RefundResponse,
+    ReportIssueRequest, ReportPaymentFailureDetails, ReverseSwapFeesRequest, ReverseSwapInfo,
+    ReverseSwapPairInfo, ReverseSwapStatus, RouteHint, RouteHintHop, SendPaymentRequest,
+    SendPaymentResponse, SendSpontaneousPaymentRequest, ServiceHealthCheckResponse,
+    SignMessageRequest, SignMessageResponse, StaticBackupRequest, StaticBackupResponse,
+    SuccessActionProcessed, SwapAmountType, SwapInfo, SwapStatus, Symbol, TlvEntry,
+    UnspentTransactionOutput, UrlSuccessActionData,
 };
 use log::{Level, LevelFilter, Metadata, Record};
 use once_cell::sync::{Lazy, OnceCell};
@@ -332,26 +331,8 @@ impl BlockingBreezServices {
         rt().block_on(self.breez_services.in_progress_onchain_payments())
     }
 
-    pub fn in_progress_reverse_swaps(&self) -> SdkResult<Vec<ReverseSwapInfo>> {
-        #[allow(deprecated)]
-        rt().block_on(self.breez_services.in_progress_reverse_swaps())
-    }
-
     pub fn claim_reverse_swap(&self, lockup_address: String) -> SdkResult<()> {
         rt().block_on(self.breez_services.claim_reverse_swap(lockup_address))
-    }
-
-    pub fn max_reverse_swap_amount(&self) -> SdkResult<MaxReverseSwapAmountResponse> {
-        #[allow(deprecated)]
-        rt().block_on(self.breez_services.max_reverse_swap_amount())
-    }
-
-    pub fn send_onchain(
-        &self,
-        req: SendOnchainRequest,
-    ) -> Result<SendOnchainResponse, SendOnchainError> {
-        #[allow(deprecated)]
-        rt().block_on(self.breez_services.send_onchain(req))
     }
 
     pub fn pay_onchain(

--- a/libs/sdk-core/src/binding.rs
+++ b/libs/sdk-core/src/binding.rs
@@ -39,16 +39,16 @@ use crate::models::{Config, LogEntry, NodeState, Payment, SwapInfo};
 use crate::{
     BackupStatus, BuyBitcoinRequest, BuyBitcoinResponse, CheckMessageRequest, CheckMessageResponse,
     ConfigureNodeRequest, ConnectRequest, EnvironmentType, ListPaymentsRequest, ListSwapsRequest,
-    LnUrlAuthError, MaxReverseSwapAmountResponse, NodeConfig, NodeCredentials,
-    OnchainPaymentLimitsResponse, OpenChannelFeeRequest, OpenChannelFeeResponse, PayOnchainRequest,
-    PayOnchainResponse, PrepareOnchainPaymentRequest, PrepareOnchainPaymentResponse,
-    PrepareRedeemOnchainFundsRequest, PrepareRedeemOnchainFundsResponse, PrepareRefundRequest,
-    PrepareRefundResponse, ReceiveOnchainRequest, ReceivePaymentRequest, ReceivePaymentResponse,
+    LnUrlAuthError, NodeConfig, NodeCredentials, OnchainPaymentLimitsResponse,
+    OpenChannelFeeRequest, OpenChannelFeeResponse, PayOnchainRequest, PayOnchainResponse,
+    PrepareOnchainPaymentRequest, PrepareOnchainPaymentResponse, PrepareRedeemOnchainFundsRequest,
+    PrepareRedeemOnchainFundsResponse, PrepareRefundRequest, PrepareRefundResponse,
+    ReceiveOnchainRequest, ReceivePaymentRequest, ReceivePaymentResponse,
     RedeemOnchainFundsRequest, RedeemOnchainFundsResponse, RefundRequest, RefundResponse,
     ReportIssueRequest, ReverseSwapFeesRequest, ReverseSwapInfo, ReverseSwapPairInfo,
-    SendOnchainRequest, SendOnchainResponse, SendPaymentRequest, SendPaymentResponse,
-    SendSpontaneousPaymentRequest, ServiceHealthCheckResponse, SignMessageRequest,
-    SignMessageResponse, StaticBackupRequest, StaticBackupResponse,
+    SendPaymentRequest, SendPaymentResponse, SendSpontaneousPaymentRequest,
+    ServiceHealthCheckResponse, SignMessageRequest, SignMessageResponse, StaticBackupRequest,
+    StaticBackupResponse,
 };
 
 // === FRB mirroring
@@ -601,20 +601,6 @@ pub fn list_fiat_currencies() -> Result<Vec<FiatCurrency>> {
 
 /*  On-Chain Swap API's */
 
-/// See [BreezServices::max_reverse_swap_amount]
-pub fn max_reverse_swap_amount() -> Result<MaxReverseSwapAmountResponse> {
-    #[allow(deprecated)]
-    block_on(async { get_breez_services().await?.max_reverse_swap_amount().await })
-        .map_err(anyhow::Error::new::<SdkError>)
-}
-
-/// See [BreezServices::send_onchain]
-pub fn send_onchain(req: SendOnchainRequest) -> Result<SendOnchainResponse> {
-    #[allow(deprecated)]
-    block_on(async { get_breez_services().await?.send_onchain(req).await })
-        .map_err(anyhow::Error::new::<SendOnchainError>)
-}
-
 /// See [BreezServices::pay_onchain]
 pub fn pay_onchain(req: PayOnchainRequest) -> Result<PayOnchainResponse> {
     block_on(async { get_breez_services().await?.pay_onchain(req).await })
@@ -696,18 +682,6 @@ pub fn in_progress_swap() -> Result<Option<SwapInfo>> {
 pub fn list_swaps(req: ListSwapsRequest) -> Result<Vec<SwapInfo>> {
     block_on(async { get_breez_services().await?.list_swaps(req).await })
         .map_err(anyhow::Error::new::<SdkError>)
-}
-
-/// See [BreezServices::in_progress_reverse_swaps]
-pub fn in_progress_reverse_swaps() -> Result<Vec<ReverseSwapInfo>> {
-    #[allow(deprecated)]
-    block_on(async {
-        get_breez_services()
-            .await?
-            .in_progress_reverse_swaps()
-            .await
-    })
-    .map_err(anyhow::Error::new::<SdkError>)
 }
 
 /// See [BreezServices::claim_reverse_swap]

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -1053,7 +1053,6 @@ impl BreezServices {
         // Calculate (send_amt, recv_amt) from the inputs and fees
         let fees_lockup = fee_info.fees_lockup;
         let p = fee_info.fees_percentage;
-        let fees_claim = BTCSendSwap::calculate_claim_tx_fee(req.claim_tx_feerate)?;
         let (send_amt, recv_amt) = match req.amount_type {
             SwapAmountType::Send => {
                 let temp_send_amt = req.amount_sat;

--- a/libs/sdk-core/src/bridge_generated.io.rs
+++ b/libs/sdk-core/src/bridge_generated.io.rs
@@ -209,16 +209,6 @@ pub extern "C" fn wire_list_fiat_currencies(port_: i64) {
 }
 
 #[no_mangle]
-pub extern "C" fn wire_max_reverse_swap_amount(port_: i64) {
-    wire_max_reverse_swap_amount_impl(port_)
-}
-
-#[no_mangle]
-pub extern "C" fn wire_send_onchain(port_: i64, req: *mut wire_SendOnchainRequest) {
-    wire_send_onchain_impl(port_, req)
-}
-
-#[no_mangle]
 pub extern "C" fn wire_pay_onchain(port_: i64, req: *mut wire_PayOnchainRequest) {
     wire_pay_onchain_impl(port_, req)
 }
@@ -279,11 +269,6 @@ pub extern "C" fn wire_in_progress_swap(port_: i64) {
 #[no_mangle]
 pub extern "C" fn wire_list_swaps(port_: i64, req: *mut wire_ListSwapsRequest) {
     wire_list_swaps_impl(port_, req)
-}
-
-#[no_mangle]
-pub extern "C" fn wire_in_progress_reverse_swaps(port_: i64) {
-    wire_in_progress_reverse_swaps_impl(port_)
 }
 
 #[no_mangle]
@@ -474,11 +459,6 @@ pub extern "C" fn new_box_autoadd_report_payment_failure_details_0(
 pub extern "C" fn new_box_autoadd_reverse_swap_fees_request_0() -> *mut wire_ReverseSwapFeesRequest
 {
     support::new_leak_box_ptr(wire_ReverseSwapFeesRequest::new_with_null_ptr())
-}
-
-#[no_mangle]
-pub extern "C" fn new_box_autoadd_send_onchain_request_0() -> *mut wire_SendOnchainRequest {
-    support::new_leak_box_ptr(wire_SendOnchainRequest::new_with_null_ptr())
 }
 
 #[no_mangle]
@@ -726,12 +706,6 @@ impl Wire2Api<ReverseSwapFeesRequest> for *mut wire_ReverseSwapFeesRequest {
     fn wire2api(self) -> ReverseSwapFeesRequest {
         let wrap = unsafe { support::box_from_leak_ptr(self) };
         Wire2Api::<ReverseSwapFeesRequest>::wire2api(*wrap).into()
-    }
-}
-impl Wire2Api<SendOnchainRequest> for *mut wire_SendOnchainRequest {
-    fn wire2api(self) -> SendOnchainRequest {
-        let wrap = unsafe { support::box_from_leak_ptr(self) };
-        Wire2Api::<SendOnchainRequest>::wire2api(*wrap).into()
     }
 }
 impl Wire2Api<SendPaymentRequest> for *mut wire_SendPaymentRequest {
@@ -1114,16 +1088,6 @@ impl Wire2Api<ReverseSwapFeesRequest> for wire_ReverseSwapFeesRequest {
         }
     }
 }
-impl Wire2Api<SendOnchainRequest> for wire_SendOnchainRequest {
-    fn wire2api(self) -> SendOnchainRequest {
-        SendOnchainRequest {
-            amount_sat: self.amount_sat.wire2api(),
-            onchain_recipient_address: self.onchain_recipient_address.wire2api(),
-            pair_hash: self.pair_hash.wire2api(),
-            sat_per_vbyte: self.sat_per_vbyte.wire2api(),
-        }
-    }
-}
 impl Wire2Api<SendPaymentRequest> for wire_SendPaymentRequest {
     fn wire2api(self) -> SendPaymentRequest {
         SendPaymentRequest {
@@ -1452,15 +1416,6 @@ pub struct wire_ReportPaymentFailureDetails {
 pub struct wire_ReverseSwapFeesRequest {
     send_amount_sat: *mut u64,
     claim_tx_feerate: *mut u32,
-}
-
-#[repr(C)]
-#[derive(Clone)]
-pub struct wire_SendOnchainRequest {
-    amount_sat: u64,
-    onchain_recipient_address: *mut wire_uint_8_list,
-    pair_hash: *mut wire_uint_8_list,
-    sat_per_vbyte: u32,
 }
 
 #[repr(C)]
@@ -2070,23 +2025,6 @@ impl NewWithNullPtr for wire_ReverseSwapFeesRequest {
 }
 
 impl Default for wire_ReverseSwapFeesRequest {
-    fn default() -> Self {
-        Self::new_with_null_ptr()
-    }
-}
-
-impl NewWithNullPtr for wire_SendOnchainRequest {
-    fn new_with_null_ptr() -> Self {
-        Self {
-            amount_sat: Default::default(),
-            onchain_recipient_address: core::ptr::null_mut(),
-            pair_hash: core::ptr::null_mut(),
-            sat_per_vbyte: Default::default(),
-        }
-    }
-}
-
-impl Default for wire_SendOnchainRequest {
     fn default() -> Self {
         Self::new_with_null_ptr()
     }

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -50,7 +50,6 @@ use crate::models::ListPaymentsRequest;
 use crate::models::ListSwapsRequest;
 use crate::models::LnPaymentDetails;
 use crate::models::LogEntry;
-use crate::models::MaxReverseSwapAmountResponse;
 use crate::models::MetadataFilter;
 use crate::models::NodeConfig;
 use crate::models::NodeCredentials;
@@ -86,8 +85,6 @@ use crate::models::ReverseSwapFeesRequest;
 use crate::models::ReverseSwapInfo;
 use crate::models::ReverseSwapPairInfo;
 use crate::models::ReverseSwapStatus;
-use crate::models::SendOnchainRequest;
-use crate::models::SendOnchainResponse;
 use crate::models::SendPaymentRequest;
 use crate::models::SendPaymentResponse;
 use crate::models::SendSpontaneousPaymentRequest;
@@ -607,29 +604,6 @@ fn wire_list_fiat_currencies_impl(port_: MessagePort) {
         move || move |task_callback| list_fiat_currencies(),
     )
 }
-fn wire_max_reverse_swap_amount_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, MaxReverseSwapAmountResponse, _>(
-        WrapInfo {
-            debug_name: "max_reverse_swap_amount",
-            port: Some(port_),
-            mode: FfiCallMode::Normal,
-        },
-        move || move |task_callback| max_reverse_swap_amount(),
-    )
-}
-fn wire_send_onchain_impl(port_: MessagePort, req: impl Wire2Api<SendOnchainRequest> + UnwindSafe) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, SendOnchainResponse, _>(
-        WrapInfo {
-            debug_name: "send_onchain",
-            port: Some(port_),
-            mode: FfiCallMode::Normal,
-        },
-        move || {
-            let api_req = req.wire2api();
-            move |task_callback| send_onchain(api_req)
-        },
-    )
-}
 fn wire_pay_onchain_impl(port_: MessagePort, req: impl Wire2Api<PayOnchainRequest> + UnwindSafe) {
     FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, PayOnchainResponse, _>(
         WrapInfo {
@@ -787,16 +761,6 @@ fn wire_list_swaps_impl(port_: MessagePort, req: impl Wire2Api<ListSwapsRequest>
             let api_req = req.wire2api();
             move |task_callback| list_swaps(api_req)
         },
-    )
-}
-fn wire_in_progress_reverse_swaps_impl(port_: MessagePort) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap::<_, _, _, Vec<ReverseSwapInfo>, _>(
-        WrapInfo {
-            debug_name: "in_progress_reverse_swaps",
-            port: Some(port_),
-            mode: FfiCallMode::Normal,
-        },
-        move || move |task_callback| in_progress_reverse_swaps(),
     )
 }
 fn wire_claim_reverse_swap_impl(
@@ -1993,18 +1957,6 @@ impl rust2dart::IntoIntoDart<LspInformation> for LspInformation {
     }
 }
 
-impl support::IntoDart for MaxReverseSwapAmountResponse {
-    fn into_dart(self) -> support::DartAbi {
-        vec![self.total_sat.into_into_dart().into_dart()].into_dart()
-    }
-}
-impl support::IntoDartExceptPrimitive for MaxReverseSwapAmountResponse {}
-impl rust2dart::IntoIntoDart<MaxReverseSwapAmountResponse> for MaxReverseSwapAmountResponse {
-    fn into_into_dart(self) -> Self {
-        self
-    }
-}
-
 impl support::IntoDart for mirror_MessageSuccessActionData {
     fn into_dart(self) -> support::DartAbi {
         vec![self.0.message.into_into_dart().into_dart()].into_dart()
@@ -2495,18 +2447,6 @@ impl support::IntoDartExceptPrimitive for mirror_RouteHintHop {}
 impl rust2dart::IntoIntoDart<mirror_RouteHintHop> for RouteHintHop {
     fn into_into_dart(self) -> mirror_RouteHintHop {
         mirror_RouteHintHop(self)
-    }
-}
-
-impl support::IntoDart for SendOnchainResponse {
-    fn into_dart(self) -> support::DartAbi {
-        vec![self.reverse_swap_info.into_into_dart().into_dart()].into_dart()
-    }
-}
-impl support::IntoDartExceptPrimitive for SendOnchainResponse {}
-impl rust2dart::IntoIntoDart<SendOnchainResponse> for SendOnchainResponse {
-    fn into_into_dart(self) -> Self {
-        self
     }
 }
 

--- a/libs/sdk-core/src/error.rs
+++ b/libs/sdk-core/src/error.rs
@@ -562,6 +562,14 @@ impl From<ReverseSwapError> for SendOnchainError {
     }
 }
 
+impl From<PersistError> for SendOnchainError {
+    fn from(err: PersistError) -> Self {
+        Self::Generic {
+            err: err.to_string(),
+        }
+    }
+}
+
 /// Error returned by [crate::breez_services::BreezServices::send_payment] and [crate::breez_services::BreezServices::send_spontaneous_payment]
 #[derive(Clone, Debug, Error)]
 pub enum SendPaymentError {

--- a/libs/sdk-core/src/lib.rs
+++ b/libs/sdk-core/src/lib.rs
@@ -106,8 +106,9 @@
 //! ### D. Sending to an on-chain address (swap-out)
 //!
 //! * [BreezServices::fetch_reverse_swap_fees] to get the current swap-out fees
-//! * [BreezServices::send_onchain] to start the swap-out
-//! * [BreezServices::in_progress_reverse_swaps] to see any in-progress swaps
+//! * [BreezServices::prepare_onchain_payment] to prepare the swap-out
+//! * [BreezServices::pay_onchain] to start the swap-out
+//! * [BreezServices::in_progress_onchain_payments] to see any in-progress swaps
 //!
 //! ### E. Using LNURL
 //!

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -793,12 +793,6 @@ pub struct ReverseSwapFeesRequest {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct MaxReverseSwapAmountResponse {
-    /// The total sats that can be sent onchain.
-    pub total_sat: u64,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MaxChannelAmount {
     /// The channel id.
     pub channel_id: String,
@@ -995,18 +989,6 @@ pub struct RedeemOnchainFundsRequest {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RedeemOnchainFundsResponse {
     pub txid: Vec<u8>,
-}
-
-#[derive(Clone)]
-pub struct SendOnchainRequest {
-    pub amount_sat: u64,
-    pub onchain_recipient_address: String,
-    pub pair_hash: String,
-    pub sat_per_vbyte: u32,
-}
-
-pub struct SendOnchainResponse {
-    pub reverse_swap_info: ReverseSwapInfo,
 }
 
 pub enum SwapAmountType {

--- a/libs/sdk-core/src/swap_out/reverseswap.rs
+++ b/libs/sdk-core/src/swap_out/reverseswap.rs
@@ -28,7 +28,7 @@ use crate::swap_in::swap::create_swap_keys;
 use crate::{
     ensure_sdk, BreezEvent, Config, FullReverseSwapInfo, PayOnchainRequest, PaymentStatus,
     ReverseSwapInfo, ReverseSwapInfoCached, ReverseSwapPairInfo, ReverseSwapStatus,
-    ReverseSwapStatus::*, RouteHintHop, SendOnchainRequest,
+    ReverseSwapStatus::*, RouteHintHop,
 };
 
 // Estimates based on https://github.com/BoltzExchange/boltz-backend/blob/master/lib/rates/FeeProvider.ts#L31-L42
@@ -73,34 +73,6 @@ impl From<&Option<OnchainTx>> for TxStatus {
                 Some(_) => TxStatus::Confirmed,
                 None => TxStatus::Mempool,
             },
-        }
-    }
-}
-
-#[derive(Clone)]
-pub(crate) enum CreateReverseSwapArg {
-    /// Used for backward compatibility with older SDK nodes. Works with the [FullReverseSwapInfo]
-    /// `sat_per_vbyte` instead of the newer `receive_amount_sat`.
-    V1(SendOnchainRequest),
-    V2(PayOnchainRequest),
-}
-impl CreateReverseSwapArg {
-    fn pair_hash(&self) -> String {
-        match self {
-            CreateReverseSwapArg::V1(s) => s.pair_hash.clone(),
-            CreateReverseSwapArg::V2(s) => s.prepare_res.fees_hash.clone(),
-        }
-    }
-    fn send_amount_sat(&self) -> u64 {
-        match self {
-            CreateReverseSwapArg::V1(s) => s.amount_sat,
-            CreateReverseSwapArg::V2(s) => s.prepare_res.sender_amount_sat,
-        }
-    }
-    fn onchain_recipient_address(&self) -> String {
-        match self {
-            CreateReverseSwapArg::V1(s) => s.onchain_recipient_address.clone(),
-            CreateReverseSwapArg::V2(s) => s.recipient_address.clone(),
         }
     }
 }
@@ -213,9 +185,9 @@ impl BTCSendSwap {
     /// status persisted.
     pub(crate) async fn create_reverse_swap(
         &self,
-        req: CreateReverseSwapArg,
+        req: PayOnchainRequest,
     ) -> ReverseSwapResult<FullReverseSwapInfo> {
-        Self::validate_recipient_address(&req.onchain_recipient_address())?;
+        Self::validate_recipient_address(&req.recipient_address)?;
 
         let routing_node = self
             .reverse_swapper_api
@@ -226,38 +198,35 @@ impl BTCSendSwap {
             .create_and_validate_rev_swap_on_remote(req.clone(), routing_node)
             .await?;
 
-        // For v2 reverse swaps, we perform validation on the created swap
-        if let CreateReverseSwapArg::V2(req) = req {
-            trace!("create_rev_swap v2 request: {req:?}");
-            trace!("create_rev_swap v2 created_rsi: {created_rsi:?}");
+        // Perform validation on the created swap
+        trace!("create_rev_swap v2 request: {req:?}");
+        trace!("create_rev_swap v2 created_rsi: {created_rsi:?}");
 
-            // Validate send_amount
-            let request_send_amount_sat = req.prepare_res.sender_amount_sat;
-            let request_send_amount_msat = request_send_amount_sat * 1_000;
-            created_rsi.validate_invoice_amount(request_send_amount_msat)?;
+        // Validate send_amount
+        let request_send_amount_sat = req.prepare_res.sender_amount_sat;
+        let request_send_amount_msat = request_send_amount_sat * 1_000;
+        created_rsi.validate_invoice_amount(request_send_amount_msat)?;
 
-            // Validate onchain_amount
-            let lockup_fee_sat = req.prepare_res.fees_lockup;
-            let service_fee_sat = super::get_service_fee_sat(
-                req.prepare_res.sender_amount_sat,
-                req.prepare_res.fees_percentage,
-            );
-            trace!("create_rev_swap v2 service_fee_sat: {service_fee_sat} sat");
-            let expected_onchain_amount =
-                request_send_amount_sat - service_fee_sat - lockup_fee_sat;
-            ensure_sdk!(
-                created_rsi.onchain_amount_sat == expected_onchain_amount,
-                ReverseSwapError::generic("Unexpected onchain amount (lockup fee or service fee)")
-            );
+        // Validate onchain_amount
+        let lockup_fee_sat = req.prepare_res.fees_lockup;
+        let service_fee_sat = super::get_service_fee_sat(
+            req.prepare_res.sender_amount_sat,
+            req.prepare_res.fees_percentage,
+        );
+        trace!("create_rev_swap v2 service_fee_sat: {service_fee_sat} sat");
+        let expected_onchain_amount = request_send_amount_sat - service_fee_sat - lockup_fee_sat;
+        ensure_sdk!(
+            created_rsi.onchain_amount_sat == expected_onchain_amount,
+            ReverseSwapError::generic("Unexpected onchain amount (lockup fee or service fee)")
+        );
 
-            // Validate claim_fee. If onchain_amount and claim_fee are both valid, receive_amount is also valid.
-            ensure_sdk!(
-                created_rsi.onchain_amount_sat > req.prepare_res.recipient_amount_sat,
-                ReverseSwapError::generic("Unexpected receive amount")
-            );
-            let claim_fee = created_rsi.onchain_amount_sat - req.prepare_res.recipient_amount_sat;
-            Self::validate_claim_tx_fee(claim_fee)?;
-        }
+        // Validate claim_fee. If onchain_amount and claim_fee are both valid, receive_amount is also valid.
+        ensure_sdk!(
+            created_rsi.onchain_amount_sat > req.prepare_res.recipient_amount_sat,
+            ReverseSwapError::generic("Unexpected receive amount")
+        );
+        let claim_fee = created_rsi.onchain_amount_sat - req.prepare_res.recipient_amount_sat;
+        Self::validate_claim_tx_fee(claim_fee)?;
 
         self.persister.insert_reverse_swap(&created_rsi)?;
         info!("Created and persisted reverse swap {}", created_rsi.id);
@@ -343,7 +312,7 @@ impl BTCSendSwap {
     /// before returning it
     async fn create_and_validate_rev_swap_on_remote(
         &self,
-        req: CreateReverseSwapArg,
+        req: PayOnchainRequest,
         routing_node: String,
     ) -> ReverseSwapResult<FullReverseSwapInfo> {
         let reverse_swap_keys = create_swap_keys()?;
@@ -351,30 +320,26 @@ impl BTCSendSwap {
         let boltz_response = self
             .reverse_swap_service_api
             .create_reverse_swap_on_remote(
-                req.send_amount_sat(),
+                req.prepare_res.sender_amount_sat,
                 reverse_swap_keys.preimage_hash_bytes().to_hex(),
                 reverse_swap_keys.public_key()?.to_hex(),
-                req.pair_hash(),
+                req.prepare_res.fees_hash,
                 routing_node,
             )
             .await?;
-        let (sat_per_vbyte, receive_amount_sat) = match &req {
-            CreateReverseSwapArg::V1(req) => (Some(req.sat_per_vbyte), None),
-            CreateReverseSwapArg::V2(req) => (None, Some(req.prepare_res.recipient_amount_sat)),
-        };
         match boltz_response {
             BoltzApiCreateReverseSwapResponse::BoltzApiSuccess(response) => {
                 let res = FullReverseSwapInfo {
                     created_at_block_height: self.chain_service.current_tip().await?,
-                    claim_pubkey: req.onchain_recipient_address(),
+                    claim_pubkey: req.recipient_address,
                     invoice: response.invoice,
                     preimage: reverse_swap_keys.preimage,
                     private_key: reverse_swap_keys.priv_key,
                     timeout_block_height: response.timeout_block_height,
                     id: response.id,
                     onchain_amount_sat: response.onchain_amount,
-                    sat_per_vbyte,
-                    receive_amount_sat,
+                    sat_per_vbyte: None,
+                    receive_amount_sat: Some(req.prepare_res.recipient_amount_sat),
                     redeem_script: response.redeem_script,
                     cache: ReverseSwapInfoCached {
                         status: Initial,
@@ -383,7 +348,7 @@ impl BTCSendSwap {
                     },
                 };
 
-                res.validate_invoice(req.send_amount_sat() * 1_000)?;
+                res.validate_invoice(req.prepare_res.sender_amount_sat * 1_000)?;
                 res.validate_redeem_script(response.lockup_address, self.config.network)?;
                 Ok(res)
             }

--- a/libs/sdk-flutter/ios/Classes/bridge_generated.h
+++ b/libs/sdk-flutter/ios/Classes/bridge_generated.h
@@ -215,13 +215,6 @@ typedef struct wire_ReportIssueRequest {
   union ReportIssueRequestKind *kind;
 } wire_ReportIssueRequest;
 
-typedef struct wire_SendOnchainRequest {
-  uint64_t amount_sat;
-  struct wire_uint_8_list *onchain_recipient_address;
-  struct wire_uint_8_list *pair_hash;
-  uint32_t sat_per_vbyte;
-} wire_SendOnchainRequest;
-
 typedef struct wire_PrepareOnchainPaymentResponse {
   struct wire_uint_8_list *fees_hash;
   double fees_percentage;
@@ -393,10 +386,6 @@ void wire_fetch_fiat_rates(int64_t port_);
 
 void wire_list_fiat_currencies(int64_t port_);
 
-void wire_max_reverse_swap_amount(int64_t port_);
-
-void wire_send_onchain(int64_t port_, struct wire_SendOnchainRequest *req);
-
 void wire_pay_onchain(int64_t port_, struct wire_PayOnchainRequest *req);
 
 void wire_receive_onchain(int64_t port_, struct wire_ReceiveOnchainRequest *req);
@@ -421,8 +410,6 @@ void wire_redeem_swap(int64_t port_, struct wire_uint_8_list *swap_address);
 void wire_in_progress_swap(int64_t port_);
 
 void wire_list_swaps(int64_t port_, struct wire_ListSwapsRequest *req);
-
-void wire_in_progress_reverse_swaps(int64_t port_);
 
 void wire_claim_reverse_swap(int64_t port_, struct wire_uint_8_list *lockup_address);
 
@@ -496,8 +483,6 @@ struct wire_ReportPaymentFailureDetails *new_box_autoadd_report_payment_failure_
 
 struct wire_ReverseSwapFeesRequest *new_box_autoadd_reverse_swap_fees_request_0(void);
 
-struct wire_SendOnchainRequest *new_box_autoadd_send_onchain_request_0(void);
-
 struct wire_SendPaymentRequest *new_box_autoadd_send_payment_request_0(void);
 
 struct wire_SendSpontaneousPaymentRequest *new_box_autoadd_send_spontaneous_payment_request_0(void);
@@ -567,8 +552,6 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_report_issue);
     dummy_var ^= ((int64_t) (void*) wire_fetch_fiat_rates);
     dummy_var ^= ((int64_t) (void*) wire_list_fiat_currencies);
-    dummy_var ^= ((int64_t) (void*) wire_max_reverse_swap_amount);
-    dummy_var ^= ((int64_t) (void*) wire_send_onchain);
     dummy_var ^= ((int64_t) (void*) wire_pay_onchain);
     dummy_var ^= ((int64_t) (void*) wire_receive_onchain);
     dummy_var ^= ((int64_t) (void*) wire_buy_bitcoin);
@@ -581,7 +564,6 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_redeem_swap);
     dummy_var ^= ((int64_t) (void*) wire_in_progress_swap);
     dummy_var ^= ((int64_t) (void*) wire_list_swaps);
-    dummy_var ^= ((int64_t) (void*) wire_in_progress_reverse_swaps);
     dummy_var ^= ((int64_t) (void*) wire_claim_reverse_swap);
     dummy_var ^= ((int64_t) (void*) wire_open_channel_fee);
     dummy_var ^= ((int64_t) (void*) wire_fetch_reverse_swap_fees);
@@ -618,7 +600,6 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_report_issue_request_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_report_payment_failure_details_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_reverse_swap_fees_request_0);
-    dummy_var ^= ((int64_t) (void*) new_box_autoadd_send_onchain_request_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_send_payment_request_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_send_spontaneous_payment_request_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_sign_message_request_0);

--- a/libs/sdk-flutter/lib/breez_sdk.dart
+++ b/libs/sdk-flutter/lib/breez_sdk.dart
@@ -322,17 +322,6 @@ class BreezSDK {
 
   /* On-Chain Swap API's */
 
-  /// Creates a reverse swap and attempts to pay the HODL invoice
-  @Deprecated(
-    'Use payOnchain instead. '
-    'This method was deprecated after v0.3.2',
-  )
-  Future<SendOnchainResponse> sendOnchain({
-    required SendOnchainRequest req,
-  }) async {
-    return await _lnToolkit.sendOnchain(req: req);
-  }
-
   Future<OnchainPaymentLimitsResponse> onchainPaymentLimits() async {
     return await _lnToolkit.onchainPaymentLimits();
   }
@@ -365,15 +354,6 @@ class BreezSDK {
     final redeemOnchainFundsResponse = await _lnToolkit.redeemOnchainFunds(req: req);
     await listPayments(req: const ListPaymentsRequest());
     return redeemOnchainFundsResponse;
-  }
-
-  /// Returns the max amount that can be sent on-chain using the send_onchain method.
-  /// The returned amount is the sum of the max amount that can be sent on each channel
-  /// minus the expected fees.
-  /// This is possible since the route to the swapper node is known in advance and is expected
-  /// to consist of maximum 3 hops.
-  Future<MaxReverseSwapAmountResponse> maxReverseSwapAmount() async {
-    return await _lnToolkit.maxReverseSwapAmount();
   }
 
   /* Refundables API's */
@@ -419,13 +399,6 @@ class BreezSDK {
   }) async {
     return await _lnToolkit.redeemSwap(swapAddress: swapAddress);
   }
-
-  /// Returns the blocking [ReverseSwapInfo]s that are in progress
-  @Deprecated(
-    'Use inProgressOnchainPayments instead. '
-    'This method was deprecated after v0.3.6',
-  )
-  Future<List<ReverseSwapInfo>> inProgressReverseSwaps() async => _lnToolkit.inProgressReverseSwaps();
 
   /// Claims an individual reverse swap.
   ///

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -210,16 +210,6 @@ abstract class BreezSdkCore {
 
   FlutterRustBridgeTaskConstMeta get kListFiatCurrenciesConstMeta;
 
-  /// See [BreezServices::max_reverse_swap_amount]
-  Future<MaxReverseSwapAmountResponse> maxReverseSwapAmount({dynamic hint});
-
-  FlutterRustBridgeTaskConstMeta get kMaxReverseSwapAmountConstMeta;
-
-  /// See [BreezServices::send_onchain]
-  Future<SendOnchainResponse> sendOnchain({required SendOnchainRequest req, dynamic hint});
-
-  FlutterRustBridgeTaskConstMeta get kSendOnchainConstMeta;
-
   /// See [BreezServices::pay_onchain]
   Future<PayOnchainResponse> payOnchain({required PayOnchainRequest req, dynamic hint});
 
@@ -281,11 +271,6 @@ abstract class BreezSdkCore {
   Future<List<SwapInfo>> listSwaps({required ListSwapsRequest req, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kListSwapsConstMeta;
-
-  /// See [BreezServices::in_progress_reverse_swaps]
-  Future<List<ReverseSwapInfo>> inProgressReverseSwaps({dynamic hint});
-
-  FlutterRustBridgeTaskConstMeta get kInProgressReverseSwapsConstMeta;
 
   /// See [BreezServices::claim_reverse_swap]
   Future<void> claimReverseSwap({required String lockupAddress, dynamic hint});
@@ -1076,15 +1061,6 @@ class LspInformation {
   });
 }
 
-class MaxReverseSwapAmountResponse {
-  /// The total sats that can be sent onchain.
-  final int totalSat;
-
-  const MaxReverseSwapAmountResponse({
-    required this.totalSat,
-  });
-}
-
 class MessageSuccessActionData {
   final String message;
 
@@ -1701,28 +1677,6 @@ class RouteHintHop {
     required this.cltvExpiryDelta,
     this.htlcMinimumMsat,
     this.htlcMaximumMsat,
-  });
-}
-
-class SendOnchainRequest {
-  final int amountSat;
-  final String onchainRecipientAddress;
-  final String pairHash;
-  final int satPerVbyte;
-
-  const SendOnchainRequest({
-    required this.amountSat,
-    required this.onchainRecipientAddress,
-    required this.pairHash,
-    required this.satPerVbyte,
-  });
-}
-
-class SendOnchainResponse {
-  final ReverseSwapInfo reverseSwapInfo;
-
-  const SendOnchainResponse({
-    required this.reverseSwapInfo,
   });
 }
 
@@ -2690,39 +2644,6 @@ class BreezSdkCoreImpl implements BreezSdkCore {
         argNames: [],
       );
 
-  Future<MaxReverseSwapAmountResponse> maxReverseSwapAmount({dynamic hint}) {
-    return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_max_reverse_swap_amount(port_),
-      parseSuccessData: _wire2api_max_reverse_swap_amount_response,
-      parseErrorData: _wire2api_FrbAnyhowException,
-      constMeta: kMaxReverseSwapAmountConstMeta,
-      argValues: [],
-      hint: hint,
-    ));
-  }
-
-  FlutterRustBridgeTaskConstMeta get kMaxReverseSwapAmountConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "max_reverse_swap_amount",
-        argNames: [],
-      );
-
-  Future<SendOnchainResponse> sendOnchain({required SendOnchainRequest req, dynamic hint}) {
-    var arg0 = _platform.api2wire_box_autoadd_send_onchain_request(req);
-    return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_send_onchain(port_, arg0),
-      parseSuccessData: _wire2api_send_onchain_response,
-      parseErrorData: _wire2api_FrbAnyhowException,
-      constMeta: kSendOnchainConstMeta,
-      argValues: [req],
-      hint: hint,
-    ));
-  }
-
-  FlutterRustBridgeTaskConstMeta get kSendOnchainConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "send_onchain",
-        argNames: ["req"],
-      );
-
   Future<PayOnchainResponse> payOnchain({required PayOnchainRequest req, dynamic hint}) {
     var arg0 = _platform.api2wire_box_autoadd_pay_onchain_request(req);
     return _platform.executeNormal(FlutterRustBridgeTask(
@@ -2925,22 +2846,6 @@ class BreezSdkCoreImpl implements BreezSdkCore {
   FlutterRustBridgeTaskConstMeta get kListSwapsConstMeta => const FlutterRustBridgeTaskConstMeta(
         debugName: "list_swaps",
         argNames: ["req"],
-      );
-
-  Future<List<ReverseSwapInfo>> inProgressReverseSwaps({dynamic hint}) {
-    return _platform.executeNormal(FlutterRustBridgeTask(
-      callFfi: (port_) => _platform.inner.wire_in_progress_reverse_swaps(port_),
-      parseSuccessData: _wire2api_list_reverse_swap_info,
-      parseErrorData: _wire2api_FrbAnyhowException,
-      constMeta: kInProgressReverseSwapsConstMeta,
-      argValues: [],
-      hint: hint,
-    ));
-  }
-
-  FlutterRustBridgeTaskConstMeta get kInProgressReverseSwapsConstMeta => const FlutterRustBridgeTaskConstMeta(
-        debugName: "in_progress_reverse_swaps",
-        argNames: [],
       );
 
   Future<void> claimReverseSwap({required String lockupAddress, dynamic hint}) {
@@ -3761,14 +3666,6 @@ class BreezSdkCoreImpl implements BreezSdkCore {
     );
   }
 
-  MaxReverseSwapAmountResponse _wire2api_max_reverse_swap_amount_response(dynamic raw) {
-    final arr = raw as List<dynamic>;
-    if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
-    return MaxReverseSwapAmountResponse(
-      totalSat: _wire2api_u64(arr[0]),
-    );
-  }
-
   MessageSuccessActionData _wire2api_message_success_action_data(dynamic raw) {
     final arr = raw as List<dynamic>;
     if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
@@ -4111,14 +4008,6 @@ class BreezSdkCoreImpl implements BreezSdkCore {
       cltvExpiryDelta: _wire2api_u64(arr[4]),
       htlcMinimumMsat: _wire2api_opt_box_autoadd_u64(arr[5]),
       htlcMaximumMsat: _wire2api_opt_box_autoadd_u64(arr[6]),
-    );
-  }
-
-  SendOnchainResponse _wire2api_send_onchain_response(dynamic raw) {
-    final arr = raw as List<dynamic>;
-    if (arr.length != 1) throw Exception('unexpected arr length: expect 1 but see ${arr.length}');
-    return SendOnchainResponse(
-      reverseSwapInfo: _wire2api_reverse_swap_info(arr[0]),
     );
   }
 
@@ -4539,13 +4428,6 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
   }
 
   @protected
-  ffi.Pointer<wire_SendOnchainRequest> api2wire_box_autoadd_send_onchain_request(SendOnchainRequest raw) {
-    final ptr = inner.new_box_autoadd_send_onchain_request_0();
-    _api_fill_to_wire_send_onchain_request(raw, ptr.ref);
-    return ptr;
-  }
-
-  @protected
   ffi.Pointer<wire_SendPaymentRequest> api2wire_box_autoadd_send_payment_request(SendPaymentRequest raw) {
     final ptr = inner.new_box_autoadd_send_payment_request_0();
     _api_fill_to_wire_send_payment_request(raw, ptr.ref);
@@ -4826,11 +4708,6 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
     _api_fill_to_wire_reverse_swap_fees_request(apiObj, wireObj.ref);
   }
 
-  void _api_fill_to_wire_box_autoadd_send_onchain_request(
-      SendOnchainRequest apiObj, ffi.Pointer<wire_SendOnchainRequest> wireObj) {
-    _api_fill_to_wire_send_onchain_request(apiObj, wireObj.ref);
-  }
-
   void _api_fill_to_wire_box_autoadd_send_payment_request(
       SendPaymentRequest apiObj, ffi.Pointer<wire_SendPaymentRequest> wireObj) {
     _api_fill_to_wire_send_payment_request(apiObj, wireObj.ref);
@@ -5078,13 +4955,6 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
       ReverseSwapFeesRequest apiObj, wire_ReverseSwapFeesRequest wireObj) {
     wireObj.send_amount_sat = api2wire_opt_box_autoadd_u64(apiObj.sendAmountSat);
     wireObj.claim_tx_feerate = api2wire_opt_box_autoadd_u32(apiObj.claimTxFeerate);
-  }
-
-  void _api_fill_to_wire_send_onchain_request(SendOnchainRequest apiObj, wire_SendOnchainRequest wireObj) {
-    wireObj.amount_sat = api2wire_u64(apiObj.amountSat);
-    wireObj.onchain_recipient_address = api2wire_String(apiObj.onchainRecipientAddress);
-    wireObj.pair_hash = api2wire_String(apiObj.pairHash);
-    wireObj.sat_per_vbyte = api2wire_u32(apiObj.satPerVbyte);
   }
 
   void _api_fill_to_wire_send_payment_request(SendPaymentRequest apiObj, wire_SendPaymentRequest wireObj) {
@@ -5766,35 +5636,6 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
       _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_list_fiat_currencies');
   late final _wire_list_fiat_currencies = _wire_list_fiat_currenciesPtr.asFunction<void Function(int)>();
 
-  void wire_max_reverse_swap_amount(
-    int port_,
-  ) {
-    return _wire_max_reverse_swap_amount(
-      port_,
-    );
-  }
-
-  late final _wire_max_reverse_swap_amountPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_max_reverse_swap_amount');
-  late final _wire_max_reverse_swap_amount =
-      _wire_max_reverse_swap_amountPtr.asFunction<void Function(int)>();
-
-  void wire_send_onchain(
-    int port_,
-    ffi.Pointer<wire_SendOnchainRequest> req,
-  ) {
-    return _wire_send_onchain(
-      port_,
-      req,
-    );
-  }
-
-  late final _wire_send_onchainPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64, ffi.Pointer<wire_SendOnchainRequest>)>>(
-          'wire_send_onchain');
-  late final _wire_send_onchain =
-      _wire_send_onchainPtr.asFunction<void Function(int, ffi.Pointer<wire_SendOnchainRequest>)>();
-
   void wire_pay_onchain(
     int port_,
     ffi.Pointer<wire_PayOnchainRequest> req,
@@ -5974,19 +5815,6 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
           'wire_list_swaps');
   late final _wire_list_swaps =
       _wire_list_swapsPtr.asFunction<void Function(int, ffi.Pointer<wire_ListSwapsRequest>)>();
-
-  void wire_in_progress_reverse_swaps(
-    int port_,
-  ) {
-    return _wire_in_progress_reverse_swaps(
-      port_,
-    );
-  }
-
-  late final _wire_in_progress_reverse_swapsPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>('wire_in_progress_reverse_swaps');
-  late final _wire_in_progress_reverse_swaps =
-      _wire_in_progress_reverse_swapsPtr.asFunction<void Function(int)>();
 
   void wire_claim_reverse_swap(
     int port_,
@@ -6397,16 +6225,6 @@ class BreezSdkCoreWire implements FlutterRustBridgeWireBase {
           'new_box_autoadd_reverse_swap_fees_request_0');
   late final _new_box_autoadd_reverse_swap_fees_request_0 = _new_box_autoadd_reverse_swap_fees_request_0Ptr
       .asFunction<ffi.Pointer<wire_ReverseSwapFeesRequest> Function()>();
-
-  ffi.Pointer<wire_SendOnchainRequest> new_box_autoadd_send_onchain_request_0() {
-    return _new_box_autoadd_send_onchain_request_0();
-  }
-
-  late final _new_box_autoadd_send_onchain_request_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_SendOnchainRequest> Function()>>(
-          'new_box_autoadd_send_onchain_request_0');
-  late final _new_box_autoadd_send_onchain_request_0 = _new_box_autoadd_send_onchain_request_0Ptr
-      .asFunction<ffi.Pointer<wire_SendOnchainRequest> Function()>();
 
   ffi.Pointer<wire_SendPaymentRequest> new_box_autoadd_send_payment_request_0() {
     return _new_box_autoadd_send_payment_request_0();
@@ -6867,18 +6685,6 @@ final class wire_ReportIssueRequest extends ffi.Struct {
   external int tag;
 
   external ffi.Pointer<ReportIssueRequestKind> kind;
-}
-
-final class wire_SendOnchainRequest extends ffi.Struct {
-  @ffi.Uint64()
-  external int amount_sat;
-
-  external ffi.Pointer<wire_uint_8_list> onchain_recipient_address;
-
-  external ffi.Pointer<wire_uint_8_list> pair_hash;
-
-  @ffi.Uint32()
-  external int sat_per_vbyte;
 }
 
 final class wire_PrepareOnchainPaymentResponse extends ffi.Struct {

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -1650,38 +1650,6 @@ fun asLspInformationList(arr: ReadableArray): List<LspInformation> {
     return list
 }
 
-fun asMaxReverseSwapAmountResponse(maxReverseSwapAmountResponse: ReadableMap): MaxReverseSwapAmountResponse? {
-    if (!validateMandatoryFields(
-            maxReverseSwapAmountResponse,
-            arrayOf(
-                "totalSat",
-            ),
-        )
-    ) {
-        return null
-    }
-    val totalSat = maxReverseSwapAmountResponse.getDouble("totalSat").toULong()
-    return MaxReverseSwapAmountResponse(
-        totalSat,
-    )
-}
-
-fun readableMapOf(maxReverseSwapAmountResponse: MaxReverseSwapAmountResponse): ReadableMap =
-    readableMapOf(
-        "totalSat" to maxReverseSwapAmountResponse.totalSat,
-    )
-
-fun asMaxReverseSwapAmountResponseList(arr: ReadableArray): List<MaxReverseSwapAmountResponse> {
-    val list = ArrayList<MaxReverseSwapAmountResponse>()
-    for (value in arr.toArrayList()) {
-        when (value) {
-            is ReadableMap -> list.add(asMaxReverseSwapAmountResponse(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
-        }
-    }
-    return list
-}
-
 fun asMessageSuccessActionData(messageSuccessActionData: ReadableMap): MessageSuccessActionData? {
     if (!validateMandatoryFields(
             messageSuccessActionData,
@@ -3158,82 +3126,6 @@ fun asRouteHintHopList(arr: ReadableArray): List<RouteHintHop> {
     for (value in arr.toArrayList()) {
         when (value) {
             is ReadableMap -> list.add(asRouteHintHop(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
-        }
-    }
-    return list
-}
-
-fun asSendOnchainRequest(sendOnchainRequest: ReadableMap): SendOnchainRequest? {
-    if (!validateMandatoryFields(
-            sendOnchainRequest,
-            arrayOf(
-                "amountSat",
-                "onchainRecipientAddress",
-                "pairHash",
-                "satPerVbyte",
-            ),
-        )
-    ) {
-        return null
-    }
-    val amountSat = sendOnchainRequest.getDouble("amountSat").toULong()
-    val onchainRecipientAddress = sendOnchainRequest.getString("onchainRecipientAddress")!!
-    val pairHash = sendOnchainRequest.getString("pairHash")!!
-    val satPerVbyte = sendOnchainRequest.getInt("satPerVbyte").toUInt()
-    return SendOnchainRequest(
-        amountSat,
-        onchainRecipientAddress,
-        pairHash,
-        satPerVbyte,
-    )
-}
-
-fun readableMapOf(sendOnchainRequest: SendOnchainRequest): ReadableMap =
-    readableMapOf(
-        "amountSat" to sendOnchainRequest.amountSat,
-        "onchainRecipientAddress" to sendOnchainRequest.onchainRecipientAddress,
-        "pairHash" to sendOnchainRequest.pairHash,
-        "satPerVbyte" to sendOnchainRequest.satPerVbyte,
-    )
-
-fun asSendOnchainRequestList(arr: ReadableArray): List<SendOnchainRequest> {
-    val list = ArrayList<SendOnchainRequest>()
-    for (value in arr.toArrayList()) {
-        when (value) {
-            is ReadableMap -> list.add(asSendOnchainRequest(value)!!)
-            else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
-        }
-    }
-    return list
-}
-
-fun asSendOnchainResponse(sendOnchainResponse: ReadableMap): SendOnchainResponse? {
-    if (!validateMandatoryFields(
-            sendOnchainResponse,
-            arrayOf(
-                "reverseSwapInfo",
-            ),
-        )
-    ) {
-        return null
-    }
-    val reverseSwapInfo = sendOnchainResponse.getMap("reverseSwapInfo")?.let { asReverseSwapInfo(it) }!!
-    return SendOnchainResponse(
-        reverseSwapInfo,
-    )
-}
-
-fun readableMapOf(sendOnchainResponse: SendOnchainResponse): ReadableMap =
-    readableMapOf(
-        "reverseSwapInfo" to readableMapOf(sendOnchainResponse.reverseSwapInfo),
-    )
-
-fun asSendOnchainResponseList(arr: ReadableArray): List<SendOnchainResponse> {
-    val list = ArrayList<SendOnchainResponse>()
-    for (value in arr.toArrayList()) {
-        when (value) {
-            is ReadableMap -> list.add(asSendOnchainResponse(value)!!)
             else -> throw SdkException.Generic(errUnexpectedType("${value::class.java.name}"))
         }
     }

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKModule.kt
@@ -830,18 +830,6 @@ class BreezSDKModule(
     }
 
     @ReactMethod
-    fun inProgressReverseSwaps(promise: Promise) {
-        executor.execute {
-            try {
-                val res = getBreezServices().inProgressReverseSwaps()
-                promise.resolve(readableArrayOf(res))
-            } catch (e: Exception) {
-                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
-            }
-        }
-    }
-
-    @ReactMethod
     fun claimReverseSwap(
         lockupAddress: String,
         promise: Promise,
@@ -850,35 +838,6 @@ class BreezSDKModule(
             try {
                 getBreezServices().claimReverseSwap(lockupAddress)
                 promise.resolve(readableMapOf("status" to "ok"))
-            } catch (e: Exception) {
-                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
-            }
-        }
-    }
-
-    @ReactMethod
-    fun maxReverseSwapAmount(promise: Promise) {
-        executor.execute {
-            try {
-                val res = getBreezServices().maxReverseSwapAmount()
-                promise.resolve(readableMapOf(res))
-            } catch (e: Exception) {
-                promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
-            }
-        }
-    }
-
-    @ReactMethod
-    fun sendOnchain(
-        req: ReadableMap,
-        promise: Promise,
-    ) {
-        executor.execute {
-            try {
-                val sendOnchainRequest =
-                    asSendOnchainRequest(req) ?: run { throw SdkException.Generic(errMissingMandatoryField("req", "SendOnchainRequest")) }
-                val res = getBreezServices().sendOnchain(sendOnchainRequest)
-                promise.resolve(readableMapOf(res))
             } catch (e: Exception) {
                 promise.reject(e.javaClass.simpleName.replace("Exception", "Error"), e.message, e)
             }

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -1921,38 +1921,6 @@ enum BreezSDKMapper {
         return lspInformationList.map { v -> [String: Any?] in return dictionaryOf(lspInformation: v) }
     }
 
-    static func asMaxReverseSwapAmountResponse(maxReverseSwapAmountResponse: [String: Any?]) throws -> MaxReverseSwapAmountResponse {
-        guard let totalSat = maxReverseSwapAmountResponse["totalSat"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "totalSat", typeName: "MaxReverseSwapAmountResponse"))
-        }
-
-        return MaxReverseSwapAmountResponse(
-            totalSat: totalSat)
-    }
-
-    static func dictionaryOf(maxReverseSwapAmountResponse: MaxReverseSwapAmountResponse) -> [String: Any?] {
-        return [
-            "totalSat": maxReverseSwapAmountResponse.totalSat,
-        ]
-    }
-
-    static func asMaxReverseSwapAmountResponseList(arr: [Any]) throws -> [MaxReverseSwapAmountResponse] {
-        var list = [MaxReverseSwapAmountResponse]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var maxReverseSwapAmountResponse = try asMaxReverseSwapAmountResponse(maxReverseSwapAmountResponse: val)
-                list.append(maxReverseSwapAmountResponse)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "MaxReverseSwapAmountResponse"))
-            }
-        }
-        return list
-    }
-
-    static func arrayOf(maxReverseSwapAmountResponseList: [MaxReverseSwapAmountResponse]) -> [Any] {
-        return maxReverseSwapAmountResponseList.map { v -> [String: Any?] in return dictionaryOf(maxReverseSwapAmountResponse: v) }
-    }
-
     static func asMessageSuccessActionData(messageSuccessActionData: [String: Any?]) throws -> MessageSuccessActionData {
         guard let message = messageSuccessActionData["message"] as? String else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "message", typeName: "MessageSuccessActionData"))
@@ -3591,87 +3559,6 @@ enum BreezSDKMapper {
 
     static func arrayOf(routeHintHopList: [RouteHintHop]) -> [Any] {
         return routeHintHopList.map { v -> [String: Any?] in return dictionaryOf(routeHintHop: v) }
-    }
-
-    static func asSendOnchainRequest(sendOnchainRequest: [String: Any?]) throws -> SendOnchainRequest {
-        guard let amountSat = sendOnchainRequest["amountSat"] as? UInt64 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "amountSat", typeName: "SendOnchainRequest"))
-        }
-        guard let onchainRecipientAddress = sendOnchainRequest["onchainRecipientAddress"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "onchainRecipientAddress", typeName: "SendOnchainRequest"))
-        }
-        guard let pairHash = sendOnchainRequest["pairHash"] as? String else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "pairHash", typeName: "SendOnchainRequest"))
-        }
-        guard let satPerVbyte = sendOnchainRequest["satPerVbyte"] as? UInt32 else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "satPerVbyte", typeName: "SendOnchainRequest"))
-        }
-
-        return SendOnchainRequest(
-            amountSat: amountSat,
-            onchainRecipientAddress: onchainRecipientAddress,
-            pairHash: pairHash,
-            satPerVbyte: satPerVbyte
-        )
-    }
-
-    static func dictionaryOf(sendOnchainRequest: SendOnchainRequest) -> [String: Any?] {
-        return [
-            "amountSat": sendOnchainRequest.amountSat,
-            "onchainRecipientAddress": sendOnchainRequest.onchainRecipientAddress,
-            "pairHash": sendOnchainRequest.pairHash,
-            "satPerVbyte": sendOnchainRequest.satPerVbyte,
-        ]
-    }
-
-    static func asSendOnchainRequestList(arr: [Any]) throws -> [SendOnchainRequest] {
-        var list = [SendOnchainRequest]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var sendOnchainRequest = try asSendOnchainRequest(sendOnchainRequest: val)
-                list.append(sendOnchainRequest)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "SendOnchainRequest"))
-            }
-        }
-        return list
-    }
-
-    static func arrayOf(sendOnchainRequestList: [SendOnchainRequest]) -> [Any] {
-        return sendOnchainRequestList.map { v -> [String: Any?] in return dictionaryOf(sendOnchainRequest: v) }
-    }
-
-    static func asSendOnchainResponse(sendOnchainResponse: [String: Any?]) throws -> SendOnchainResponse {
-        guard let reverseSwapInfoTmp = sendOnchainResponse["reverseSwapInfo"] as? [String: Any?] else {
-            throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "reverseSwapInfo", typeName: "SendOnchainResponse"))
-        }
-        let reverseSwapInfo = try asReverseSwapInfo(reverseSwapInfo: reverseSwapInfoTmp)
-
-        return SendOnchainResponse(
-            reverseSwapInfo: reverseSwapInfo)
-    }
-
-    static func dictionaryOf(sendOnchainResponse: SendOnchainResponse) -> [String: Any?] {
-        return [
-            "reverseSwapInfo": dictionaryOf(reverseSwapInfo: sendOnchainResponse.reverseSwapInfo),
-        ]
-    }
-
-    static func asSendOnchainResponseList(arr: [Any]) throws -> [SendOnchainResponse] {
-        var list = [SendOnchainResponse]()
-        for value in arr {
-            if let val = value as? [String: Any?] {
-                var sendOnchainResponse = try asSendOnchainResponse(sendOnchainResponse: val)
-                list.append(sendOnchainResponse)
-            } else {
-                throw SdkError.Generic(message: errUnexpectedType(typeName: "SendOnchainResponse"))
-            }
-        }
-        return list
-    }
-
-    static func arrayOf(sendOnchainResponseList: [SendOnchainResponse]) -> [Any] {
-        return sendOnchainResponseList.map { v -> [String: Any?] in return dictionaryOf(sendOnchainResponse: v) }
     }
 
     static func asSendPaymentRequest(sendPaymentRequest: [String: Any?]) throws -> SendPaymentRequest {

--- a/libs/sdk-react-native/ios/RNBreezSDK.m
+++ b/libs/sdk-react-native/ios/RNBreezSDK.m
@@ -290,23 +290,7 @@ RCT_EXTERN_METHOD(
 )
 
 RCT_EXTERN_METHOD(
-    inProgressReverseSwaps: (RCTPromiseResolveBlock)resolve
-    reject: (RCTPromiseRejectBlock)reject
-)
-
-RCT_EXTERN_METHOD(
     claimReverseSwap: (NSString*)lockupAddress
-    resolve: (RCTPromiseResolveBlock)resolve
-    reject: (RCTPromiseRejectBlock)reject
-)
-
-RCT_EXTERN_METHOD(
-    maxReverseSwapAmount: (RCTPromiseResolveBlock)resolve
-    reject: (RCTPromiseRejectBlock)reject
-)
-
-RCT_EXTERN_METHOD(
-    sendOnchain: (NSDictionary*)req
     resolve: (RCTPromiseResolveBlock)resolve
     reject: (RCTPromiseRejectBlock)reject
 )

--- a/libs/sdk-react-native/ios/RNBreezSDK.swift
+++ b/libs/sdk-react-native/ios/RNBreezSDK.swift
@@ -618,42 +618,11 @@ class RNBreezSDK: RCTEventEmitter {
         }
     }
 
-    @objc(inProgressReverseSwaps:reject:)
-    func inProgressReverseSwaps(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
-        do {
-            var res = try getBreezServices().inProgressReverseSwaps()
-            resolve(BreezSDKMapper.arrayOf(reverseSwapInfoList: res))
-        } catch let err {
-            rejectErr(err: err, reject: reject)
-        }
-    }
-
     @objc(claimReverseSwap:resolve:reject:)
     func claimReverseSwap(_ lockupAddress: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         do {
             try getBreezServices().claimReverseSwap(lockupAddress: lockupAddress)
             resolve(["status": "ok"])
-        } catch let err {
-            rejectErr(err: err, reject: reject)
-        }
-    }
-
-    @objc(maxReverseSwapAmount:reject:)
-    func maxReverseSwapAmount(_ resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
-        do {
-            var res = try getBreezServices().maxReverseSwapAmount()
-            resolve(BreezSDKMapper.dictionaryOf(maxReverseSwapAmountResponse: res))
-        } catch let err {
-            rejectErr(err: err, reject: reject)
-        }
-    }
-
-    @objc(sendOnchain:resolve:reject:)
-    func sendOnchain(_ req: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
-        do {
-            let sendOnchainRequest = try BreezSDKMapper.asSendOnchainRequest(sendOnchainRequest: req)
-            var res = try getBreezServices().sendOnchain(req: sendOnchainRequest)
-            resolve(BreezSDKMapper.dictionaryOf(sendOnchainResponse: res))
         } catch let err {
             rejectErr(err: err, reject: reject)
         }

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -270,10 +270,6 @@ export interface LspInformation {
     openingFeeParamsList: OpeningFeeParamsMenu
 }
 
-export interface MaxReverseSwapAmountResponse {
-    totalSat: number
-}
-
 export interface MessageSuccessActionData {
     message: string
 }
@@ -492,17 +488,6 @@ export interface RouteHintHop {
     cltvExpiryDelta: number
     htlcMinimumMsat?: number
     htlcMaximumMsat?: number
-}
-
-export interface SendOnchainRequest {
-    amountSat: number
-    onchainRecipientAddress: string
-    pairHash: string
-    satPerVbyte: number
-}
-
-export interface SendOnchainResponse {
-    reverseSwapInfo: ReverseSwapInfo
 }
 
 export interface SendPaymentRequest {
@@ -1117,23 +1102,8 @@ export const inProgressOnchainPayments = async (): Promise<ReverseSwapInfo[]> =>
     return response
 }
 
-export const inProgressReverseSwaps = async (): Promise<ReverseSwapInfo[]> => {
-    const response = await BreezSDK.inProgressReverseSwaps()
-    return response
-}
-
 export const claimReverseSwap = async (lockupAddress: string): Promise<void> => {
     await BreezSDK.claimReverseSwap(lockupAddress)
-}
-
-export const maxReverseSwapAmount = async (): Promise<MaxReverseSwapAmountResponse> => {
-    const response = await BreezSDK.maxReverseSwapAmount()
-    return response
-}
-
-export const sendOnchain = async (req: SendOnchainRequest): Promise<SendOnchainResponse> => {
-    const response = await BreezSDK.sendOnchain(req)
-    return response
 }
 
 export const payOnchain = async (req: PayOnchainRequest): Promise<PayOnchainResponse> => {

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -10,7 +10,7 @@ use breez_sdk_core::{
     LnUrlWithdrawRequest, MetadataFilter, PayOnchainRequest, PrepareOnchainPaymentRequest,
     PrepareRedeemOnchainFundsRequest, PrepareRefundRequest, ReceiveOnchainRequest,
     ReceivePaymentRequest, RedeemOnchainFundsRequest, RefundRequest, ReportIssueRequest,
-    ReportPaymentFailureDetails, ReverseSwapFeesRequest, SendOnchainRequest, SendPaymentRequest,
+    ReportPaymentFailureDetails, ReverseSwapFeesRequest, SendPaymentRequest,
     SendSpontaneousPaymentRequest, SignMessageRequest, StaticBackupRequest, SwapAmountType,
 };
 use breez_sdk_core::{GreenlightNodeConfig, NodeConfig};
@@ -149,32 +149,6 @@ pub(crate) async fn handle_command(
             result.push('\n');
             result.push_str(&build_qr_text(&recv_payment_response.ln_invoice.bolt11));
             Ok(result)
-        }
-        Commands::SendOnchain {
-            amount_sat,
-            onchain_recipient_address,
-            sat_per_vbyte,
-        } => {
-            let pair_info = sdk()?
-                .fetch_reverse_swap_fees(ReverseSwapFeesRequest::default())
-                .await
-                .map_err(|e| anyhow!("Failed to fetch reverse swap fee infos: {e}"))?;
-
-            #[allow(deprecated)]
-            let rev_swap_res = sdk()?
-                .send_onchain(SendOnchainRequest {
-                    amount_sat,
-                    onchain_recipient_address,
-                    pair_hash: pair_info.fees_hash,
-                    sat_per_vbyte,
-                })
-                .await?;
-            serde_json::to_string_pretty(&rev_swap_res.reverse_swap_info).map_err(|e| e.into())
-        }
-        Commands::MaxReverseSwapAmount {} => {
-            #[allow(deprecated)]
-            let response = sdk()?.max_reverse_swap_amount().await?;
-            serde_json::to_string_pretty(&response).map_err(|e| e.into())
         }
         Commands::OnchainPaymentLimits {} => {
             let response = sdk()?.onchain_payment_limits().await?;

--- a/tools/sdk-cli/src/commands.rs
+++ b/tools/sdk-cli/src/commands.rs
@@ -147,17 +147,6 @@ pub(crate) enum Commands {
         limit: Option<u32>,
     },
 
-    /// [swap-out] Send on-chain using a reverse swap
-    SendOnchain {
-        amount_sat: u64,
-        onchain_recipient_address: String,
-        /// The fee rate for the claim transaction
-        sat_per_vbyte: u32,
-    },
-
-    /// [swap-out] The maximum amount that can be sent onchain with a reverse swap
-    MaxReverseSwapAmount {},
-
     /// [swap-out] Get the current fees for a potential new reverse swap
     FetchOnchainFees {
         #[clap(name = "amount", short = 'a', long = "amt")]


### PR DESCRIPTION
The `send_onchain` function was deprecated since SDK version 0.3.6. It
has been replaced with `pay_onchain`. Removed deprecated functions:
- `send_onchain`, has replacement `pay_onchain`
- `max_reverse_swap_amount` has replacement `onchain_payment_limits`
- `on_progress_reverse_swaps` has replacement
`in_progress_onchain_payments`