### PR TITLE
allow mpp in open channel invoices

### DIFF
--- a/libs/sdk-common/src/invoice.rs
+++ b/libs/sdk-common/src/invoice.rs
@@ -213,7 +213,8 @@ pub fn add_routing_hints(
         .timestamp(invoice.timestamp())
         .expiry_time(invoice.expiry_time())
         .payment_secret(*invoice.payment_secret())
-        .min_final_cltv_expiry_delta(invoice.min_final_cltv_expiry_delta());
+        .min_final_cltv_expiry_delta(invoice.min_final_cltv_expiry_delta())
+        .basic_mpp();
     if let Some(new_amount_msat) = new_amount_msats {
         invoice_builder = invoice_builder.amount_milli_satoshis(new_amount_msat)
     }


### PR DESCRIPTION
Invoices for channel opens didn't have the feature flag 'basic mpp' set. This means senders would not attempt to pay the open channel invoice if their balance was spread out over multiple channels, but not one of the channels contains the full amount to pay the invoice.

This PR sets the basic mpp feature in open channel invoices, so they can be paid with MPP.