### PR TITLE
Add namespace to gradle files on Flutter plugin to be compatible with AGP 8.+

### DIFF
--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/ConfirmTransaction.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/ConfirmTransaction.kt
@@ -36,7 +36,7 @@ class ConfirmTransactionJob(
 
     override fun start(breezSDK: BlockingBreezServices) {
         try {
-            val request = Json.decodeFromString(AddressTxsConfirmedRequest.serializer(), payload)
+            val request = Json.decodeFromString<AddressTxsConfirmedRequest>(AddressTxsConfirmedRequest.serializer(), payload)
             this.bitcoinAddress = request.address
         } catch (e: Exception) {
             logger.log(TAG, "Failed to decode payload: ${e.message}", "WARN")

--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/LnurlPayInfo.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/LnurlPayInfo.kt
@@ -53,7 +53,7 @@ class LnurlPayInfoJob(
     override fun start(breezSDK: BlockingBreezServices) {
         var request: LnurlInfoRequest? = null
         try {
-            request = Json.decodeFromString(LnurlInfoRequest.serializer(), payload)
+            request = Json.decodeFromString<LnurlInfoRequest>(LnurlInfoRequest.serializer(), payload)
             // Get the fee parameters offered by the LSP for opening a new channel
             val ofp = breezSDK.openChannelFee(OpenChannelFeeRequest(amountMsat = null)).feeParams
             // Calculate the maximum receivable amount within the fee limit (in millisatoshis)

--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/LnurlPayInvoice.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/LnurlPayInvoice.kt
@@ -49,7 +49,7 @@ class LnurlPayInvoiceJob(
     override fun start(breezSDK: BlockingBreezServices) {
         var request: LnurlInvoiceRequest? = null
         try {
-            request = Json.decodeFromString(LnurlInvoiceRequest.serializer(), payload)
+            request = Json.decodeFromString<LnurlInvoiceRequest>(LnurlInvoiceRequest.serializer(), payload)
             // Get channel setup fee for invoice amount
             val ofpResp =
                 breezSDK.openChannelFee(OpenChannelFeeRequest(amountMsat = request.amount))

--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/ReceivePayment.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/ReceivePayment.kt
@@ -36,7 +36,7 @@ class ReceivePaymentJob(
 
     override fun start(breezSDK: BlockingBreezServices) {
         try {
-            val request = Json.decodeFromString(ReceivePaymentRequest.serializer(), payload)
+            val request = Json.decodeFromString<ReceivePaymentRequest>(ReceivePaymentRequest.serializer(), payload)
             val payment = breezSDK.paymentByHash(request.paymentHash)
             if (payment != null) {
                 this.receivedPayment = payment

--- a/libs/sdk-flutter/android/build.gradle
+++ b/libs/sdk-flutter/android/build.gradle
@@ -1,36 +1,23 @@
+plugins {
+    id 'com.android.library'
+    id 'org.jetbrains.kotlin.android'
+    id 'org.jetbrains.kotlin.plugin.serialization'
+}
+
 group 'com.breez.breez_sdk'
 version '1.0-SNAPSHOT'
 
-buildscript {
-    ext.kotlin_version = '1.8.20'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
-rootProject.allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
-}
-
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlinx-serialization'
-
 android {
-    compileSdkVersion 33
+    namespace = 'com.breez.breez_sdk'
+    compileSdk = 34
+
+    defaultConfig {
+        minSdk = 24
+    }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     kotlinOptions {
@@ -38,16 +25,13 @@ android {
     }
 
     sourceSets {
-        main.java.srcDirs += 'src/main/kotlin'
-    }
-
-    defaultConfig {
-        minSdkVersion 24
+        main {
+            java.srcDirs += 'src/main/kotlin'
+        }
     }
 }
 
 dependencies {
     implementation "net.java.dev.jna:jna:5.14.0@aar"
-    /* JSON serialization */
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3'
 }

--- a/libs/sdk-flutter/android/build.gradle
+++ b/libs/sdk-flutter/android/build.gradle
@@ -16,12 +16,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '11'
     }
 
     sourceSets {

--- a/libs/sdk-flutter/android/build.gradle.production
+++ b/libs/sdk-flutter/android/build.gradle.production
@@ -1,37 +1,23 @@
+plugins {
+    id 'com.android.library'
+    id 'org.jetbrains.kotlin.android'
+    id 'org.jetbrains.kotlin.plugin.serialization'
+}
+
 group 'com.breez.breez_sdk'
 version '0.6.2'
 
-buildscript {
-    ext.kotlin_version = '1.8.20'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
-rootProject.allprojects {
-    repositories {
-        google()
-        mavenCentral()
-        maven { url("https://mvn.breez.technology/releases") }
-    }
-}
-
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
-apply plugin: 'kotlinx-serialization'
-
 android {
-    compileSdkVersion 33
+    namespace = 'com.breez.breez_sdk'
+    compileSdk = 34
+
+    defaultConfig {
+        minSdk = 24
+    }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     kotlinOptions {
@@ -39,18 +25,14 @@ android {
     }
 
     sourceSets {
-        main.java.srcDirs += 'src/main/kotlin'
-    }
-
-    defaultConfig {
-        minSdkVersion 24
+        main {
+            java.srcDirs += 'src/main/kotlin'
+        }
     }
 }
 
 dependencies {
     api "breez_sdk:bindings-android:$version"
     implementation "net.java.dev.jna:jna:5.14.0@aar"
-    /* JSON serialization */
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3'
-
 }

--- a/libs/sdk-flutter/android/build.gradle.production
+++ b/libs/sdk-flutter/android/build.gradle.production
@@ -16,12 +16,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '11'
     }
 
     sourceSets {

--- a/libs/sdk-flutter/android/settings.gradle
+++ b/libs/sdk-flutter/android/settings.gradle
@@ -2,7 +2,9 @@ rootProject.name = 'breez_sdk'
 
 dependencyResolutionManagement {
     repositories {
-        maven { url("https://mvn.breez.technology/releases") }
+        google()
+        mavenCentral()
+        maven { url = uri("https://mvn.breez.technology/releases") }
     }
     repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
 }

--- a/libs/sdk-flutter/android/src/main/AndroidManifest.xml
+++ b/libs/sdk-flutter/android/src/main/AndroidManifest.xml
@@ -1,3 +1,0 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.breez.breez_sdk">
-</manifest>


### PR DESCRIPTION
This PR addresses compatibility with Android Gradle Plugin (AGP) 8.+, the second error seen on issue https://github.com/breez/breez-sdk-greenlight/issues/1128

### Changelist
- Add namespace to gradle files on Flutter plugin
  - AGP 8.+ requires each module to declare a namespace. This change ensures the plugin is compliant with the latest AGP requirements.
- Removing unnecessary `AndroidManifest.xml`
  - As the namespace is now declared in the Gradle files, the redundant AndroidManifest.xml has been removed.  
- Explicitly specifying types for decoded values
  - Addresses type inference failures.