### PR TITLE
configure grpc connection for breez server

### DIFF
--- a/libs/sdk-common/src/breez_server.rs
+++ b/libs/sdk-common/src/breez_server.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use anyhow::Result;
 use log::trace;
 use tokio::sync::Mutex;
@@ -29,16 +31,24 @@ pub struct BreezServer {
 impl BreezServer {
     pub fn new(server_url: String, api_key: Option<String>) -> Result<Self> {
         Ok(Self {
-            grpc_channel: Mutex::new(Endpoint::from_shared(server_url.clone())?.connect_lazy()),
+            grpc_channel: Mutex::new(Self::create_endpoint(&server_url)?.connect_lazy()),
             api_key,
             server_url,
         })
     }
 
     pub async fn reconnect(&self) -> Result<()> {
-        *self.grpc_channel.lock().await =
-            Endpoint::from_shared(self.server_url.clone())?.connect_lazy();
+        *self.grpc_channel.lock().await = Self::create_endpoint(&self.server_url)?.connect_lazy();
         Ok(())
+    }
+
+    fn create_endpoint(server_url: &str) -> Result<Endpoint> {
+        Ok(Endpoint::from_shared(server_url.to_string())?
+            .http2_keep_alive_interval(Duration::new(5, 0))
+            .tcp_keepalive(Some(Duration::from_secs(5)))
+            .http2_keep_alive_interval(Duration::from_secs(5))
+            .keep_alive_timeout(Duration::from_secs(5))
+            .keep_alive_while_idle(true))
     }
 
     fn api_key_metadata(&self) -> Result<Option<MetadataValue<Ascii>>, ServiceConnectivityError> {

--- a/libs/sdk-common/src/breez_server.rs
+++ b/libs/sdk-common/src/breez_server.rs
@@ -46,7 +46,6 @@ impl BreezServer {
         Ok(Endpoint::from_shared(server_url.to_string())?
             .http2_keep_alive_interval(Duration::new(5, 0))
             .tcp_keepalive(Some(Duration::from_secs(5)))
-            .http2_keep_alive_interval(Duration::from_secs(5))
             .keep_alive_timeout(Duration::from_secs(5))
             .keep_alive_while_idle(true))
     }


### PR DESCRIPTION
This PR allows Breez grpc connection to recover from a stale connection in no more than 5 seconds. Previously it could take up to 20 seconds.