### PR TITLE
detect and act on network change

### DIFF
--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -1610,9 +1610,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.3"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -1864,7 +1864,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.3",
+ "hermit-abi 0.3.9",
  "rustix",
  "windows-sys 0.48.0",
 ]
@@ -2071,13 +2071,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
+ "hermit-abi 0.3.9",
  "libc",
  "wasi",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2237,7 +2238,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.3",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 
@@ -3744,21 +3745,20 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.34.0"
+version = "1.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9"
+checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.5.5",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3773,9 +3773,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.2.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/libs/Cargo.toml
+++ b/libs/Cargo.toml
@@ -43,7 +43,7 @@ serde_json = "1.0"
 strum = "0.25"
 strum_macros = "0.25"
 thiserror = "1.0.56"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1.41", features = ["full"] }
 tonic = "^0.8"
 tonic-build = "^0.8"
 uniffi = "0.23.0"

--- a/libs/sdk-common/src/breez_server.rs
+++ b/libs/sdk-common/src/breez_server.rs
@@ -16,7 +16,7 @@ use crate::grpc::support_client::SupportClient;
 use crate::grpc::swapper_client::SwapperClient;
 use crate::grpc::{ChainApiServersRequest, PingRequest};
 use crate::prelude::{ServiceConnectivityError, ServiceConnectivityErrorKind};
-use crate::tonic_wrap::with_connection_fallback;
+use crate::with_connection_retry;
 
 pub static PRODUCTION_BREEZSERVER_URL: &str = "https://bs1.breez.technology:443";
 pub static STAGING_BREEZSERVER_URL: &str = "https://bs1-st.breez.technology:443";
@@ -113,20 +113,17 @@ impl BreezServer {
 
     pub async fn fetch_mempoolspace_urls(&self) -> Result<Vec<String>, ServiceConnectivityError> {
         let mut client = self.get_information_client().await;
-        let mut client_clone = client.clone();
         let chain_api_servers =
-            with_connection_fallback(client.chain_api_servers(ChainApiServersRequest {}), || {
-                client_clone.chain_api_servers(ChainApiServersRequest {})
-            })
-            .await
-            .map_err(|e| {
-                ServiceConnectivityError::new(
-                    ServiceConnectivityErrorKind::Other,
-                    format!("(Breez: {e:?}) Failed to fetch ChainApiServers"),
-                )
-            })?
-            .into_inner()
-            .servers;
+            with_connection_retry!(client.chain_api_servers(ChainApiServersRequest {}))
+                .await
+                .map_err(|e| {
+                    ServiceConnectivityError::new(
+                        ServiceConnectivityErrorKind::Other,
+                        format!("(Breez: {e:?}) Failed to fetch ChainApiServers"),
+                    )
+                })?
+                .into_inner()
+                .servers;
         trace!("Received chain_api_servers: {chain_api_servers:?}");
 
         let mempoolspace_urls = chain_api_servers
@@ -141,21 +138,18 @@ impl BreezServer {
 
     pub async fn fetch_boltz_swapper_urls(&self) -> Result<Vec<String>, ServiceConnectivityError> {
         let mut client = self.get_information_client().await;
-        let mut client_clone = client.clone();
 
         let chain_api_servers =
-            with_connection_fallback(client.chain_api_servers(ChainApiServersRequest {}), || {
-                client_clone.chain_api_servers(ChainApiServersRequest {})
-            })
-            .await
-            .map_err(|e| {
-                ServiceConnectivityError::new(
-                    ServiceConnectivityErrorKind::Other,
-                    format!("(Breez: {e:?}) Failed to fetch ChainApiServers"),
-                )
-            })?
-            .into_inner()
-            .servers;
+            with_connection_retry!(client.chain_api_servers(ChainApiServersRequest {}))
+                .await
+                .map_err(|e| {
+                    ServiceConnectivityError::new(
+                        ServiceConnectivityErrorKind::Other,
+                        format!("(Breez: {e:?}) Failed to fetch ChainApiServers"),
+                    )
+                })?
+                .into_inner()
+                .servers;
         trace!("Received chain_api_servers: {chain_api_servers:?}");
 
         let boltz_swapper_urls = chain_api_servers

--- a/libs/sdk-common/src/lib.rs
+++ b/libs/sdk-common/src/lib.rs
@@ -9,6 +9,7 @@ pub mod invoice;
 pub mod liquid;
 mod lnurl;
 mod model;
+pub mod tonic_wrap;
 mod utils;
 
 // Re-export commonly used crates, to make it easy for callers to use the specific versions we're using.

--- a/libs/sdk-common/src/tonic_wrap/mod.rs
+++ b/libs/sdk-common/src/tonic_wrap/mod.rs
@@ -20,9 +20,10 @@ impl Display for Status {
 
 pub struct TransportError(pub tonic::transport::Error);
 
-const BROKEN_CONNECTION_STRINGS: [&str; 2] = [
+const BROKEN_CONNECTION_STRINGS: [&str; 3] = [
     "http2 error: keep-alive timed out",
     "connection error: address not available",
+    "connection error: timed out",
 ];
 
 impl Display for TransportError {
@@ -77,7 +78,7 @@ where
     // It's a bit of a guess which errors can occur here. hyper Io errors start
     // with 'connection error'. These are some of the errors seen before.
     if !BROKEN_CONNECTION_STRINGS.contains(&source.to_string().as_str()) {
-        debug!("transport error string is: {}", source.to_string());
+        debug!("transport error string is: '{}'", source.to_string());
         return Err(status);
     }
 

--- a/libs/sdk-common/src/tonic_wrap/mod.rs
+++ b/libs/sdk-common/src/tonic_wrap/mod.rs
@@ -1,5 +1,7 @@
 use std::{error::Error, fmt::Display, future::Future};
 
+use log::debug;
+
 pub struct Status(pub tonic::Status);
 
 impl Display for Status {
@@ -75,6 +77,6 @@ where
         "with_connection_fallback: initial call failed due to keepalive 
         timeout. Retrying fallback."
     );
-    let res = fallback().await;
-    res
+
+    fallback().await
 }

--- a/libs/sdk-common/src/tonic_wrap/mod.rs
+++ b/libs/sdk-common/src/tonic_wrap/mod.rs
@@ -20,10 +20,11 @@ impl Display for Status {
 
 pub struct TransportError(pub tonic::transport::Error);
 
-const BROKEN_CONNECTION_STRINGS: [&str; 3] = [
+const BROKEN_CONNECTION_STRINGS: [&str; 4] = [
     "http2 error: keep-alive timed out",
     "connection error: address not available",
     "connection error: timed out",
+    "connection error: unexpected end of file",
 ];
 
 impl Display for TransportError {

--- a/libs/sdk-core/src/error.rs
+++ b/libs/sdk-core/src/error.rs
@@ -446,7 +446,7 @@ impl From<serde_json::Error> for SdkError {
 impl From<tonic::transport::Error> for SdkError {
     fn from(err: tonic::transport::Error) -> Self {
         Self::ServiceConnectivity {
-            err: crate::tonic_wrap::TransportError(err).to_string(),
+            err: sdk_common::tonic_wrap::TransportError(err).to_string(),
         }
     }
 }
@@ -454,7 +454,7 @@ impl From<tonic::transport::Error> for SdkError {
 impl From<tonic::Status> for SdkError {
     fn from(err: tonic::Status) -> Self {
         Self::Generic {
-            err: crate::tonic_wrap::Status(err).to_string(),
+            err: sdk_common::tonic_wrap::Status(err).to_string(),
         }
     }
 }

--- a/libs/sdk-core/src/greenlight/backup_transport.rs
+++ b/libs/sdk-core/src/greenlight/backup_transport.rs
@@ -5,7 +5,7 @@ use crate::{
 
 use super::node_api::Greenlight;
 use gl_client::pb::cln;
-use sdk_common::tonic_wrap::with_connection_fallback;
+use sdk_common::with_connection_retry;
 use std::sync::Arc;
 
 const BREEZ_SDK_DATASTORE_PATH: [&str; 2] = ["breez-sdk", "backup"];
@@ -25,15 +25,12 @@ impl BackupTransport for GLBackupTransport {
     async fn pull(&self) -> SdkResult<Option<BackupState>> {
         let key = self.gl_key();
         let mut client = self.inner.get_node_client().await?;
-        let mut client_clone = client.clone();
 
         let req = cln::ListdatastoreRequest { key };
         let response: cln::ListdatastoreResponse =
-            with_connection_fallback(client.list_datastore(req.clone()), || {
-                client_clone.list_datastore(req)
-            })
-            .await?
-            .into_inner();
+            with_connection_retry!(client.list_datastore(req.clone()))
+                .await?
+                .into_inner();
         let store = response.datastore;
         match store.len() {
             0 => Ok(None),
@@ -51,7 +48,6 @@ impl BackupTransport for GLBackupTransport {
         let key = self.gl_key();
         info!("set_value key = {:?} data length={:?}", key, hex.len());
         let mut client = self.inner.get_node_client().await?;
-        let mut client_clone = client.clone();
 
         let mut mode = cln::datastore_request::DatastoreMode::MustCreate;
         if version.is_some() {
@@ -64,11 +60,9 @@ impl BackupTransport for GLBackupTransport {
             generation: version,
             mode: Some(mode.into()),
         };
-        let response = with_connection_fallback(client.datastore(req.clone()), || {
-            client_clone.datastore(req)
-        })
-        .await?
-        .into_inner();
+        let response = with_connection_retry!(client.datastore(req.clone()))
+            .await?
+            .into_inner();
         Ok(response.generation.unwrap())
     }
 }

--- a/libs/sdk-core/src/greenlight/error.rs
+++ b/libs/sdk-core/src/greenlight/error.rs
@@ -154,7 +154,7 @@ impl From<SystemTimeError> for NodeError {
 
 impl From<tonic::Status> for NodeError {
     fn from(status: tonic::Status) -> Self {
-        let wrapped_status = crate::tonic_wrap::Status(status.clone());
+        let wrapped_status = sdk_common::tonic_wrap::Status(status.clone());
         match parse_cln_error(status) {
             Ok(code) => match code {
                 // Pay errors

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -52,9 +52,9 @@ use crate::lightning_invoice::{RawBolt11Invoice, SignedRawBolt11Invoice};
 use crate::node_api::{CreateInvoiceRequest, FetchBolt11Result, NodeAPI, NodeError, NodeResult};
 use crate::persist::db::SqliteStorage;
 use crate::persist::send_pays::{SendPay, SendPayStatus};
-use crate::tonic_wrap::with_connection_fallback;
 use crate::{models::*, LspInformation};
 use crate::{NodeConfig, PrepareRedeemOnchainFundsRequest, PrepareRedeemOnchainFundsResponse};
+use sdk_common::tonic_wrap::with_connection_fallback;
 
 const MAX_PAYMENT_AMOUNT_MSAT: u64 = 4294967000;
 const MAX_INBOUND_LIQUIDITY_MSAT: u64 = 4000000000;
@@ -162,12 +162,7 @@ impl Greenlight {
                 match encrypted_creds {
                     Some(c) => {
                         persister.set_gl_credentials(c)?;
-                        Greenlight::new(
-                            config,
-                            seed,
-                            creds.clone(),
-                            persister,
-                        )
+                        Greenlight::new(config, seed, creds.clone(), persister)
                     }
                     None => Err(NodeError::generic("Failed to encrypt credentials")),
                 }

--- a/libs/sdk-core/src/lib.rs
+++ b/libs/sdk-core/src/lib.rs
@@ -187,7 +187,6 @@ mod swap_out;
 #[allow(unused_mut)]
 #[allow(dead_code)]
 mod test_utils;
-mod tonic_wrap;
 
 pub use breez_services::{
     mnemonic_to_seed, BackupFailedData, BreezEvent, BreezServices, CheckMessageRequest,

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -14,6 +14,7 @@ use sdk_common::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use strum_macros::{Display, EnumString};
+use tonic_wrap::with_connection_fallback;
 
 use crate::bitcoin::blockdata::opcodes;
 use crate::bitcoin::blockdata::script::Builder;
@@ -400,12 +401,15 @@ pub(crate) trait ReverseSwapperRoutingAPI: Send + Sync {
 #[tonic::async_trait]
 impl ReverseSwapperRoutingAPI for BreezServer {
     async fn fetch_reverse_routing_node(&self) -> ReverseSwapResult<Vec<u8>> {
-        Ok(self
-            .get_swapper_client()
-            .await
-            .get_reverse_routing_node(grpc::GetReverseRoutingNodeRequest::default())
-            .await
-            .map(|reply| reply.into_inner().node_id)?)
+        let mut client = self.get_swapper_client().await;
+        let mut client_clone = client.clone();
+
+        Ok(with_connection_fallback(
+            client.get_reverse_routing_node(grpc::GetReverseRoutingNodeRequest::default()),
+            || client_clone.get_reverse_routing_node(grpc::GetReverseRoutingNodeRequest::default()),
+        )
+        .await
+        .map(|reply| reply.into_inner().node_id)?)
     }
 }
 

--- a/libs/sdk-core/src/swap_in/error.rs
+++ b/libs/sdk-core/src/swap_in/error.rs
@@ -44,6 +44,6 @@ impl From<SdkError> for SwapError {
 
 impl From<tonic::Status> for SwapError {
     fn from(status: tonic::Status) -> Self {
-        Self::Generic(crate::tonic_wrap::Status(status).to_string())
+        Self::Generic(sdk_common::tonic_wrap::Status(status).to_string())
     }
 }

--- a/libs/sdk-core/src/swap_out/error.rs
+++ b/libs/sdk-core/src/swap_out/error.rs
@@ -113,6 +113,6 @@ impl From<serde_json::Error> for ReverseSwapError {
 
 impl From<tonic::Status> for ReverseSwapError {
     fn from(err: tonic::Status) -> Self {
-        Self::Generic(crate::tonic_wrap::Status(err).to_string())
+        Self::Generic(sdk_common::tonic_wrap::Status(err).to_string())
     }
 }

--- a/tools/sdk-cli/Cargo.lock
+++ b/tools/sdk-cli/Cargo.lock
@@ -1468,9 +1468,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.1"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -1568,7 +1568,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -1691,7 +1691,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi 0.3.9",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -1708,7 +1708,7 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi 0.3.9",
  "io-lifetimes",
  "rustix 0.37.27",
  "windows-sys 0.48.0",
@@ -1912,13 +1912,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
+ "hermit-abi 0.3.9",
  "libc",
  "wasi",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2379,9 +2380,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
@@ -3288,6 +3289,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3509,21 +3520,20 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.2"
+version = "1.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
+checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
 dependencies = [
- "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.8",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3538,9 +3548,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
When there is a network change, tonic behaves as follows:
- After the keepalive timeout, reconnect automatically.
- Before the keepalive timeout, any grpc call will time out. After the timeout, the connection is reestablished.

This commit adds a mechanism to reconnect all grpc clients after one of the clients detects a network change. Initially it was attempted to only retry based on a keepalive timeout error, but a network change affects all grpc clients, so subsequent requests to other grpc endpoints would still fail with a timeout. Ofcourse those grpc clients can also add a retry-on-timeout, but since it is known at this point the grpc clients are temporarily dead, reconnect them immediately. This ensures subsequent calls to other endpoints won't add additional time by waiting for a timeout.

Currently this PR wraps the `trampoline_pay`, `pay`, and `invoice` calls in the greenlight client.

tokio was bumped to allow cloning watch::Sender