### PR TITLE
remove hibernation logic

### DIFF
--- a/libs/sdk-common/src/breez_server.rs
+++ b/libs/sdk-common/src/breez_server.rs
@@ -26,7 +26,6 @@ pub static STAGING_BREEZSERVER_URL: &str = "https://bs1-st.breez.technology:443"
 pub struct BreezServer {
     grpc_channel: Mutex<Channel>,
     api_key: Option<String>,
-    server_url: String,
 }
 
 impl BreezServer {
@@ -34,13 +33,7 @@ impl BreezServer {
         Ok(Self {
             grpc_channel: Mutex::new(Self::create_endpoint(&server_url)?.connect_lazy()),
             api_key,
-            server_url,
         })
-    }
-
-    pub async fn reconnect(&self) -> Result<()> {
-        *self.grpc_channel.lock().await = Self::create_endpoint(&self.server_url)?.connect_lazy();
-        Ok(())
     }
 
     fn create_endpoint(server_url: &str) -> Result<Endpoint> {

--- a/libs/sdk-core/src/node_api.rs
+++ b/libs/sdk-core/src/node_api.rs
@@ -114,7 +114,6 @@ pub struct FetchBolt11Result {
 /// Trait covering functions affecting the LN node
 #[tonic::async_trait]
 pub trait NodeAPI: Send + Sync {
-    async fn reconnect(&self);
     async fn node_credentials(&self) -> NodeResult<Option<NodeCredentials>>;
     async fn configure_node(&self, close_to_address: Option<String>) -> NodeResult<()>;
     async fn create_invoice(&self, request: CreateInvoiceRequest) -> NodeResult<String>;

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -330,7 +330,6 @@ pub struct MockNodeAPI {
 
 #[tonic::async_trait]
 impl NodeAPI for MockNodeAPI {
-    async fn reconnect(&self) {}
     async fn node_credentials(&self) -> NodeResult<Option<NodeCredentials>> {
         Err(NodeError::Generic("Not implemented".to_string()))
     }


### PR DESCRIPTION
The reconnect after hibernation does not fix the root cause of errors originating from lost grpc connections after hibernation. When the app comes back from hibernation, any already outgoing grpc request will fail with a transport error. The only way to get around that is by retrying the request. Also, grpc connections are automatically reestablished after such a failure occurs. If the grpc client gets a timeout or broken connection failure on one request, the next request will succeed with a fresh underlying connection.

retrying requests is implemented in #1133