### PR TITLE
Update LNURL structs

### DIFF
--- a/libs/sdk-common/src/lnurl/specs/pay.rs
+++ b/libs/sdk-common/src/lnurl/specs/pay.rs
@@ -173,7 +173,7 @@ pub mod model {
     /// Payload of the AES success action, as received from the LNURL endpoint
     ///
     /// See [AesSuccessActionDataDecrypted] for a similar wrapper containing the decrypted payload
-    #[derive(Debug, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
     pub struct AesSuccessActionData {
         /// Contents description, up to 144 characters
         pub description: String,
@@ -243,7 +243,7 @@ pub mod model {
     ///
     /// Receiving any other (unsupported) success action type will result in a failed parsing,
     /// which will abort the LNURL-pay workflow, as per LUD-09.
-    #[derive(Debug, Deserialize, Serialize)]
+    #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
     #[serde(rename_all = "camelCase")]
     #[serde(tag = "tag")]
     pub enum SuccessAction {

--- a/libs/sdk-common/src/lnurl/specs/withdraw.rs
+++ b/libs/sdk-common/src/lnurl/specs/withdraw.rs
@@ -146,6 +146,14 @@ pub mod model {
         ServiceConnectivity { err: String },
     }
 
+    impl From<anyhow::Error> for LnUrlWithdrawError {
+        fn from(err: anyhow::Error) -> Self {
+            Self::Generic {
+                err: err.to_string(),
+            }
+        }
+    }
+
     impl From<InvoiceError> for LnUrlWithdrawError {
         fn from(value: InvoiceError) -> Self {
             match value {


### PR DESCRIPTION
This PR:
- adds Clone and PartialEq traits to LNURL success action structs
- adds anyhow error conversion to LnUrlWithdrawError

Used in https://github.com/breez/breez-sdk-liquid/pull/617