### PR TITLE
Fix swift CI build

### DIFF
--- a/.github/workflows/build-bindings-ios.yml
+++ b/.github/workflows/build-bindings-ios.yml
@@ -47,6 +47,9 @@ jobs:
         rustup toolchain install stable --profile minimal
         rustup target add ${{ matrix.target }}
 
+    - name: Set IPHONEOS_DEPLOYMENT_TARGET 
+      run: echo "IPHONEOS_DEPLOYMENT_TARGET=12.0" >> $GITHUB_ENV
+
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:


### PR DESCRIPTION
The swift and react-native packages failed to publish for 0.6.6. Looks like swift was published manually and I've triggered the react-native publish just now.