### PR TITLE
sdk-common: Support regtest

### DIFF
--- a/libs/sdk-common/src/input_parser.rs
+++ b/libs/sdk-common/src/input_parser.rs
@@ -614,7 +614,7 @@ pub enum InputType {
     /// # Supported standards
     ///
     /// - plain on-chain liquid address
-    /// - BIP21 on liquid/liquidtestnet
+    /// - BIP21 on liquid/liquidtestnet/liquidregtest
     #[cfg(feature = "liquid")]
     LiquidAddress {
         address: LiquidAddressData,

--- a/libs/sdk-common/src/liquid/bip21.rs
+++ b/libs/sdk-common/src/liquid/bip21.rs
@@ -70,6 +70,7 @@ impl LiquidAddressData {
                 let scheme = match self.network {
                     Network::Bitcoin => "liquidnetwork",
                     Network::Testnet => "liquidtestnet",
+                    Network::Regtest => "liquidregtest",
                     _ => {
                         return Err(URISerializationError::UnsupportedNetwork);
                     }
@@ -108,6 +109,7 @@ impl LiquidAddressData {
         let network = match network {
             "liquidnetwork" => Network::Bitcoin,
             "liquidtestnet" => Network::Testnet,
+            "liquidregtest" => Network::Regtest,
             _ => return Err(DeserializeError::InvalidScheme),
         };
 
@@ -192,6 +194,8 @@ impl LiquidAddressData {
             Network::Bitcoin
         } else if elements_address.params.eq(&AddressParams::LIQUID_TESTNET) {
             Network::Testnet
+        } else if elements_address.params.eq(&AddressParams::ELEMENTS) {
+            Network::Regtest
         } else {
             return Err(DeserializeError::InvalidAddress(
                 AddressError::InvalidAddress("The specified asset is not supported".to_string()),


### PR DESCRIPTION
This adds support for regtest in sdk-common, specifically wrt parsing and generation of BIP21s and onchain addresses. The motivation for this is supporting regtest in the nodeless SDK.