### PR TITLE
sdk-common: Expose if BIP353 is used for parsing

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -744,7 +744,7 @@ interface InputType {
     Bolt11(LNInvoice invoice);
     NodeId(string node_id);
     Url(string url);
-    LnUrlPay(LnUrlPayRequestData data);
+    LnUrlPay(LnUrlPayRequestData data, string? bip353_address);
     LnUrlWithdraw(LnUrlWithdrawRequestData data);
     LnUrlAuth(LnUrlAuthRequestData data);
     LnUrlError(LnUrlErrorData data);

--- a/libs/sdk-common/src/input_parser.rs
+++ b/libs/sdk-common/src/input_parser.rs
@@ -648,7 +648,7 @@ pub enum InputType {
     #[cfg(feature = "liquid")]
     Bolt12Offer {
         offer: LNOffer,
-        /// The BIP353 address in case one was resolved
+        /// The BIP353 address from which this InputType was resolved
         bip353_address: Option<String>,
     },
     NodeId {
@@ -666,7 +666,7 @@ pub enum InputType {
     /// - LUD-17 Support for lnurlp prefix with non-bech32-encoded LNURL URLs
     LnUrlPay {
         data: LnUrlPayRequestData,
-        /// The BIP353 address in case one was resolved
+        /// The BIP353 address from which this InputType was resolved
         bip353_address: Option<String>,
     },
 

--- a/libs/sdk-core/src/binding.rs
+++ b/libs/sdk-core/src/binding.rs
@@ -160,14 +160,31 @@ pub struct _LnUrlWithdrawRequestData {
 
 #[frb(mirror(InputType))]
 pub enum _InputType {
-    BitcoinAddress { address: BitcoinAddressData },
-    Bolt11 { invoice: LNInvoice },
-    NodeId { node_id: String },
-    Url { url: String },
-    LnUrlPay { data: LnUrlPayRequestData },
-    LnUrlWithdraw { data: LnUrlWithdrawRequestData },
-    LnUrlAuth { data: LnUrlAuthRequestData },
-    LnUrlError { data: LnUrlErrorData },
+    BitcoinAddress {
+        address: BitcoinAddressData,
+    },
+    Bolt11 {
+        invoice: LNInvoice,
+    },
+    NodeId {
+        node_id: String,
+    },
+    Url {
+        url: String,
+    },
+    LnUrlPay {
+        data: LnUrlPayRequestData,
+        bip353_address: Option<String>,
+    },
+    LnUrlWithdraw {
+        data: LnUrlWithdrawRequestData,
+    },
+    LnUrlAuth {
+        data: LnUrlAuthRequestData,
+    },
+    LnUrlError {
+        data: LnUrlErrorData,
+    },
 }
 
 #[frb(mirror(BitcoinAddressData))]

--- a/libs/sdk-core/src/bridge_generated.rs
+++ b/libs/sdk-core/src/bridge_generated.rs
@@ -1009,8 +1009,12 @@ const _: fn() = || {
         InputType::Url { url } => {
             let _: String = url;
         }
-        InputType::LnUrlPay { data } => {
+        InputType::LnUrlPay {
+            data,
+            bip353_address,
+        } => {
             let _: LnUrlPayRequestData = data;
+            let _: Option<String> = bip353_address;
         }
         InputType::LnUrlWithdraw { data } => {
             let _: LnUrlWithdrawRequestData = data;
@@ -1608,7 +1612,14 @@ impl support::IntoDart for mirror_InputType {
                 vec![2.into_dart(), node_id.into_into_dart().into_dart()]
             }
             InputType::Url { url } => vec![3.into_dart(), url.into_into_dart().into_dart()],
-            InputType::LnUrlPay { data } => vec![4.into_dart(), data.into_into_dart().into_dart()],
+            InputType::LnUrlPay {
+                data,
+                bip353_address,
+            } => vec![
+                4.into_dart(),
+                data.into_into_dart().into_dart(),
+                bip353_address.into_dart(),
+            ],
             InputType::LnUrlWithdraw { data } => {
                 vec![5.into_dart(), data.into_into_dart().into_dart()]
             }

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -668,6 +668,7 @@ sealed class InputType with _$InputType {
   }) = InputType_Url;
   const factory InputType.lnUrlPay({
     required LnUrlPayRequestData data,
+    String? bip353Address,
   }) = InputType_LnUrlPay;
   const factory InputType.lnUrlWithdraw({
     required LnUrlWithdrawRequestData data,
@@ -3378,6 +3379,7 @@ class BreezSdkCoreImpl implements BreezSdkCore {
       case 4:
         return InputType_LnUrlPay(
           data: _wire2api_box_autoadd_ln_url_pay_request_data(raw[1]),
+          bip353Address: _wire2api_opt_String(raw[2]),
         );
       case 5:
         return InputType_LnUrlWithdraw(

--- a/libs/sdk-flutter/lib/bridge_generated.freezed.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.freezed.dart
@@ -2182,7 +2182,7 @@ mixin _$InputType {
     required TResult Function(LNInvoice invoice) bolt11,
     required TResult Function(String nodeId) nodeId,
     required TResult Function(String url) url,
-    required TResult Function(LnUrlPayRequestData data) lnUrlPay,
+    required TResult Function(LnUrlPayRequestData data, String? bip353Address) lnUrlPay,
     required TResult Function(LnUrlWithdrawRequestData data) lnUrlWithdraw,
     required TResult Function(LnUrlAuthRequestData data) lnUrlAuth,
     required TResult Function(LnUrlErrorData data) lnUrlError,
@@ -2194,7 +2194,7 @@ mixin _$InputType {
     TResult? Function(LNInvoice invoice)? bolt11,
     TResult? Function(String nodeId)? nodeId,
     TResult? Function(String url)? url,
-    TResult? Function(LnUrlPayRequestData data)? lnUrlPay,
+    TResult? Function(LnUrlPayRequestData data, String? bip353Address)? lnUrlPay,
     TResult? Function(LnUrlWithdrawRequestData data)? lnUrlWithdraw,
     TResult? Function(LnUrlAuthRequestData data)? lnUrlAuth,
     TResult? Function(LnUrlErrorData data)? lnUrlError,
@@ -2206,7 +2206,7 @@ mixin _$InputType {
     TResult Function(LNInvoice invoice)? bolt11,
     TResult Function(String nodeId)? nodeId,
     TResult Function(String url)? url,
-    TResult Function(LnUrlPayRequestData data)? lnUrlPay,
+    TResult Function(LnUrlPayRequestData data, String? bip353Address)? lnUrlPay,
     TResult Function(LnUrlWithdrawRequestData data)? lnUrlWithdraw,
     TResult Function(LnUrlAuthRequestData data)? lnUrlAuth,
     TResult Function(LnUrlErrorData data)? lnUrlError,
@@ -2336,7 +2336,7 @@ class _$InputType_BitcoinAddressImpl implements InputType_BitcoinAddress {
     required TResult Function(LNInvoice invoice) bolt11,
     required TResult Function(String nodeId) nodeId,
     required TResult Function(String url) url,
-    required TResult Function(LnUrlPayRequestData data) lnUrlPay,
+    required TResult Function(LnUrlPayRequestData data, String? bip353Address) lnUrlPay,
     required TResult Function(LnUrlWithdrawRequestData data) lnUrlWithdraw,
     required TResult Function(LnUrlAuthRequestData data) lnUrlAuth,
     required TResult Function(LnUrlErrorData data) lnUrlError,
@@ -2351,7 +2351,7 @@ class _$InputType_BitcoinAddressImpl implements InputType_BitcoinAddress {
     TResult? Function(LNInvoice invoice)? bolt11,
     TResult? Function(String nodeId)? nodeId,
     TResult? Function(String url)? url,
-    TResult? Function(LnUrlPayRequestData data)? lnUrlPay,
+    TResult? Function(LnUrlPayRequestData data, String? bip353Address)? lnUrlPay,
     TResult? Function(LnUrlWithdrawRequestData data)? lnUrlWithdraw,
     TResult? Function(LnUrlAuthRequestData data)? lnUrlAuth,
     TResult? Function(LnUrlErrorData data)? lnUrlError,
@@ -2366,7 +2366,7 @@ class _$InputType_BitcoinAddressImpl implements InputType_BitcoinAddress {
     TResult Function(LNInvoice invoice)? bolt11,
     TResult Function(String nodeId)? nodeId,
     TResult Function(String url)? url,
-    TResult Function(LnUrlPayRequestData data)? lnUrlPay,
+    TResult Function(LnUrlPayRequestData data, String? bip353Address)? lnUrlPay,
     TResult Function(LnUrlWithdrawRequestData data)? lnUrlWithdraw,
     TResult Function(LnUrlAuthRequestData data)? lnUrlAuth,
     TResult Function(LnUrlErrorData data)? lnUrlError,
@@ -2505,7 +2505,7 @@ class _$InputType_Bolt11Impl implements InputType_Bolt11 {
     required TResult Function(LNInvoice invoice) bolt11,
     required TResult Function(String nodeId) nodeId,
     required TResult Function(String url) url,
-    required TResult Function(LnUrlPayRequestData data) lnUrlPay,
+    required TResult Function(LnUrlPayRequestData data, String? bip353Address) lnUrlPay,
     required TResult Function(LnUrlWithdrawRequestData data) lnUrlWithdraw,
     required TResult Function(LnUrlAuthRequestData data) lnUrlAuth,
     required TResult Function(LnUrlErrorData data) lnUrlError,
@@ -2520,7 +2520,7 @@ class _$InputType_Bolt11Impl implements InputType_Bolt11 {
     TResult? Function(LNInvoice invoice)? bolt11,
     TResult? Function(String nodeId)? nodeId,
     TResult? Function(String url)? url,
-    TResult? Function(LnUrlPayRequestData data)? lnUrlPay,
+    TResult? Function(LnUrlPayRequestData data, String? bip353Address)? lnUrlPay,
     TResult? Function(LnUrlWithdrawRequestData data)? lnUrlWithdraw,
     TResult? Function(LnUrlAuthRequestData data)? lnUrlAuth,
     TResult? Function(LnUrlErrorData data)? lnUrlError,
@@ -2535,7 +2535,7 @@ class _$InputType_Bolt11Impl implements InputType_Bolt11 {
     TResult Function(LNInvoice invoice)? bolt11,
     TResult Function(String nodeId)? nodeId,
     TResult Function(String url)? url,
-    TResult Function(LnUrlPayRequestData data)? lnUrlPay,
+    TResult Function(LnUrlPayRequestData data, String? bip353Address)? lnUrlPay,
     TResult Function(LnUrlWithdrawRequestData data)? lnUrlWithdraw,
     TResult Function(LnUrlAuthRequestData data)? lnUrlAuth,
     TResult Function(LnUrlErrorData data)? lnUrlError,
@@ -2672,7 +2672,7 @@ class _$InputType_NodeIdImpl implements InputType_NodeId {
     required TResult Function(LNInvoice invoice) bolt11,
     required TResult Function(String nodeId) nodeId,
     required TResult Function(String url) url,
-    required TResult Function(LnUrlPayRequestData data) lnUrlPay,
+    required TResult Function(LnUrlPayRequestData data, String? bip353Address) lnUrlPay,
     required TResult Function(LnUrlWithdrawRequestData data) lnUrlWithdraw,
     required TResult Function(LnUrlAuthRequestData data) lnUrlAuth,
     required TResult Function(LnUrlErrorData data) lnUrlError,
@@ -2687,7 +2687,7 @@ class _$InputType_NodeIdImpl implements InputType_NodeId {
     TResult? Function(LNInvoice invoice)? bolt11,
     TResult? Function(String nodeId)? nodeId,
     TResult? Function(String url)? url,
-    TResult? Function(LnUrlPayRequestData data)? lnUrlPay,
+    TResult? Function(LnUrlPayRequestData data, String? bip353Address)? lnUrlPay,
     TResult? Function(LnUrlWithdrawRequestData data)? lnUrlWithdraw,
     TResult? Function(LnUrlAuthRequestData data)? lnUrlAuth,
     TResult? Function(LnUrlErrorData data)? lnUrlError,
@@ -2702,7 +2702,7 @@ class _$InputType_NodeIdImpl implements InputType_NodeId {
     TResult Function(LNInvoice invoice)? bolt11,
     TResult Function(String nodeId)? nodeId,
     TResult Function(String url)? url,
-    TResult Function(LnUrlPayRequestData data)? lnUrlPay,
+    TResult Function(LnUrlPayRequestData data, String? bip353Address)? lnUrlPay,
     TResult Function(LnUrlWithdrawRequestData data)? lnUrlWithdraw,
     TResult Function(LnUrlAuthRequestData data)? lnUrlAuth,
     TResult Function(LnUrlErrorData data)? lnUrlError,
@@ -2837,7 +2837,7 @@ class _$InputType_UrlImpl implements InputType_Url {
     required TResult Function(LNInvoice invoice) bolt11,
     required TResult Function(String nodeId) nodeId,
     required TResult Function(String url) url,
-    required TResult Function(LnUrlPayRequestData data) lnUrlPay,
+    required TResult Function(LnUrlPayRequestData data, String? bip353Address) lnUrlPay,
     required TResult Function(LnUrlWithdrawRequestData data) lnUrlWithdraw,
     required TResult Function(LnUrlAuthRequestData data) lnUrlAuth,
     required TResult Function(LnUrlErrorData data) lnUrlError,
@@ -2852,7 +2852,7 @@ class _$InputType_UrlImpl implements InputType_Url {
     TResult? Function(LNInvoice invoice)? bolt11,
     TResult? Function(String nodeId)? nodeId,
     TResult? Function(String url)? url,
-    TResult? Function(LnUrlPayRequestData data)? lnUrlPay,
+    TResult? Function(LnUrlPayRequestData data, String? bip353Address)? lnUrlPay,
     TResult? Function(LnUrlWithdrawRequestData data)? lnUrlWithdraw,
     TResult? Function(LnUrlAuthRequestData data)? lnUrlAuth,
     TResult? Function(LnUrlErrorData data)? lnUrlError,
@@ -2867,7 +2867,7 @@ class _$InputType_UrlImpl implements InputType_Url {
     TResult Function(LNInvoice invoice)? bolt11,
     TResult Function(String nodeId)? nodeId,
     TResult Function(String url)? url,
-    TResult Function(LnUrlPayRequestData data)? lnUrlPay,
+    TResult Function(LnUrlPayRequestData data, String? bip353Address)? lnUrlPay,
     TResult Function(LnUrlWithdrawRequestData data)? lnUrlWithdraw,
     TResult Function(LnUrlAuthRequestData data)? lnUrlAuth,
     TResult Function(LnUrlErrorData data)? lnUrlError,
@@ -2943,7 +2943,7 @@ abstract class _$$InputType_LnUrlPayImplCopyWith<$Res> {
           _$InputType_LnUrlPayImpl value, $Res Function(_$InputType_LnUrlPayImpl) then) =
       __$$InputType_LnUrlPayImplCopyWithImpl<$Res>;
   @useResult
-  $Res call({LnUrlPayRequestData data});
+  $Res call({LnUrlPayRequestData data, String? bip353Address});
 }
 
 /// @nodoc
@@ -2958,12 +2958,17 @@ class __$$InputType_LnUrlPayImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? data = null,
+    Object? bip353Address = freezed,
   }) {
     return _then(_$InputType_LnUrlPayImpl(
       data: null == data
           ? _value.data
           : data // ignore: cast_nullable_to_non_nullable
               as LnUrlPayRequestData,
+      bip353Address: freezed == bip353Address
+          ? _value.bip353Address
+          : bip353Address // ignore: cast_nullable_to_non_nullable
+              as String?,
     ));
   }
 }
@@ -2971,14 +2976,16 @@ class __$$InputType_LnUrlPayImplCopyWithImpl<$Res>
 /// @nodoc
 
 class _$InputType_LnUrlPayImpl implements InputType_LnUrlPay {
-  const _$InputType_LnUrlPayImpl({required this.data});
+  const _$InputType_LnUrlPayImpl({required this.data, this.bip353Address});
 
   @override
   final LnUrlPayRequestData data;
+  @override
+  final String? bip353Address;
 
   @override
   String toString() {
-    return 'InputType.lnUrlPay(data: $data)';
+    return 'InputType.lnUrlPay(data: $data, bip353Address: $bip353Address)';
   }
 
   @override
@@ -2986,11 +2993,12 @@ class _$InputType_LnUrlPayImpl implements InputType_LnUrlPay {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$InputType_LnUrlPayImpl &&
-            (identical(other.data, data) || other.data == data));
+            (identical(other.data, data) || other.data == data) &&
+            (identical(other.bip353Address, bip353Address) || other.bip353Address == bip353Address));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, data);
+  int get hashCode => Object.hash(runtimeType, data, bip353Address);
 
   @JsonKey(ignore: true)
   @override
@@ -3005,12 +3013,12 @@ class _$InputType_LnUrlPayImpl implements InputType_LnUrlPay {
     required TResult Function(LNInvoice invoice) bolt11,
     required TResult Function(String nodeId) nodeId,
     required TResult Function(String url) url,
-    required TResult Function(LnUrlPayRequestData data) lnUrlPay,
+    required TResult Function(LnUrlPayRequestData data, String? bip353Address) lnUrlPay,
     required TResult Function(LnUrlWithdrawRequestData data) lnUrlWithdraw,
     required TResult Function(LnUrlAuthRequestData data) lnUrlAuth,
     required TResult Function(LnUrlErrorData data) lnUrlError,
   }) {
-    return lnUrlPay(data);
+    return lnUrlPay(data, bip353Address);
   }
 
   @override
@@ -3020,12 +3028,12 @@ class _$InputType_LnUrlPayImpl implements InputType_LnUrlPay {
     TResult? Function(LNInvoice invoice)? bolt11,
     TResult? Function(String nodeId)? nodeId,
     TResult? Function(String url)? url,
-    TResult? Function(LnUrlPayRequestData data)? lnUrlPay,
+    TResult? Function(LnUrlPayRequestData data, String? bip353Address)? lnUrlPay,
     TResult? Function(LnUrlWithdrawRequestData data)? lnUrlWithdraw,
     TResult? Function(LnUrlAuthRequestData data)? lnUrlAuth,
     TResult? Function(LnUrlErrorData data)? lnUrlError,
   }) {
-    return lnUrlPay?.call(data);
+    return lnUrlPay?.call(data, bip353Address);
   }
 
   @override
@@ -3035,14 +3043,14 @@ class _$InputType_LnUrlPayImpl implements InputType_LnUrlPay {
     TResult Function(LNInvoice invoice)? bolt11,
     TResult Function(String nodeId)? nodeId,
     TResult Function(String url)? url,
-    TResult Function(LnUrlPayRequestData data)? lnUrlPay,
+    TResult Function(LnUrlPayRequestData data, String? bip353Address)? lnUrlPay,
     TResult Function(LnUrlWithdrawRequestData data)? lnUrlWithdraw,
     TResult Function(LnUrlAuthRequestData data)? lnUrlAuth,
     TResult Function(LnUrlErrorData data)? lnUrlError,
     required TResult orElse(),
   }) {
     if (lnUrlPay != null) {
-      return lnUrlPay(data);
+      return lnUrlPay(data, bip353Address);
     }
     return orElse();
   }
@@ -3098,9 +3106,11 @@ class _$InputType_LnUrlPayImpl implements InputType_LnUrlPay {
 }
 
 abstract class InputType_LnUrlPay implements InputType {
-  const factory InputType_LnUrlPay({required final LnUrlPayRequestData data}) = _$InputType_LnUrlPayImpl;
+  const factory InputType_LnUrlPay({required final LnUrlPayRequestData data, final String? bip353Address}) =
+      _$InputType_LnUrlPayImpl;
 
   LnUrlPayRequestData get data;
+  String? get bip353Address;
   @JsonKey(ignore: true)
   _$$InputType_LnUrlPayImplCopyWith<_$InputType_LnUrlPayImpl> get copyWith =>
       throw _privateConstructorUsedError;
@@ -3174,7 +3184,7 @@ class _$InputType_LnUrlWithdrawImpl implements InputType_LnUrlWithdraw {
     required TResult Function(LNInvoice invoice) bolt11,
     required TResult Function(String nodeId) nodeId,
     required TResult Function(String url) url,
-    required TResult Function(LnUrlPayRequestData data) lnUrlPay,
+    required TResult Function(LnUrlPayRequestData data, String? bip353Address) lnUrlPay,
     required TResult Function(LnUrlWithdrawRequestData data) lnUrlWithdraw,
     required TResult Function(LnUrlAuthRequestData data) lnUrlAuth,
     required TResult Function(LnUrlErrorData data) lnUrlError,
@@ -3189,7 +3199,7 @@ class _$InputType_LnUrlWithdrawImpl implements InputType_LnUrlWithdraw {
     TResult? Function(LNInvoice invoice)? bolt11,
     TResult? Function(String nodeId)? nodeId,
     TResult? Function(String url)? url,
-    TResult? Function(LnUrlPayRequestData data)? lnUrlPay,
+    TResult? Function(LnUrlPayRequestData data, String? bip353Address)? lnUrlPay,
     TResult? Function(LnUrlWithdrawRequestData data)? lnUrlWithdraw,
     TResult? Function(LnUrlAuthRequestData data)? lnUrlAuth,
     TResult? Function(LnUrlErrorData data)? lnUrlError,
@@ -3204,7 +3214,7 @@ class _$InputType_LnUrlWithdrawImpl implements InputType_LnUrlWithdraw {
     TResult Function(LNInvoice invoice)? bolt11,
     TResult Function(String nodeId)? nodeId,
     TResult Function(String url)? url,
-    TResult Function(LnUrlPayRequestData data)? lnUrlPay,
+    TResult Function(LnUrlPayRequestData data, String? bip353Address)? lnUrlPay,
     TResult Function(LnUrlWithdrawRequestData data)? lnUrlWithdraw,
     TResult Function(LnUrlAuthRequestData data)? lnUrlAuth,
     TResult Function(LnUrlErrorData data)? lnUrlError,
@@ -3344,7 +3354,7 @@ class _$InputType_LnUrlAuthImpl implements InputType_LnUrlAuth {
     required TResult Function(LNInvoice invoice) bolt11,
     required TResult Function(String nodeId) nodeId,
     required TResult Function(String url) url,
-    required TResult Function(LnUrlPayRequestData data) lnUrlPay,
+    required TResult Function(LnUrlPayRequestData data, String? bip353Address) lnUrlPay,
     required TResult Function(LnUrlWithdrawRequestData data) lnUrlWithdraw,
     required TResult Function(LnUrlAuthRequestData data) lnUrlAuth,
     required TResult Function(LnUrlErrorData data) lnUrlError,
@@ -3359,7 +3369,7 @@ class _$InputType_LnUrlAuthImpl implements InputType_LnUrlAuth {
     TResult? Function(LNInvoice invoice)? bolt11,
     TResult? Function(String nodeId)? nodeId,
     TResult? Function(String url)? url,
-    TResult? Function(LnUrlPayRequestData data)? lnUrlPay,
+    TResult? Function(LnUrlPayRequestData data, String? bip353Address)? lnUrlPay,
     TResult? Function(LnUrlWithdrawRequestData data)? lnUrlWithdraw,
     TResult? Function(LnUrlAuthRequestData data)? lnUrlAuth,
     TResult? Function(LnUrlErrorData data)? lnUrlError,
@@ -3374,7 +3384,7 @@ class _$InputType_LnUrlAuthImpl implements InputType_LnUrlAuth {
     TResult Function(LNInvoice invoice)? bolt11,
     TResult Function(String nodeId)? nodeId,
     TResult Function(String url)? url,
-    TResult Function(LnUrlPayRequestData data)? lnUrlPay,
+    TResult Function(LnUrlPayRequestData data, String? bip353Address)? lnUrlPay,
     TResult Function(LnUrlWithdrawRequestData data)? lnUrlWithdraw,
     TResult Function(LnUrlAuthRequestData data)? lnUrlAuth,
     TResult Function(LnUrlErrorData data)? lnUrlError,
@@ -3513,7 +3523,7 @@ class _$InputType_LnUrlErrorImpl implements InputType_LnUrlError {
     required TResult Function(LNInvoice invoice) bolt11,
     required TResult Function(String nodeId) nodeId,
     required TResult Function(String url) url,
-    required TResult Function(LnUrlPayRequestData data) lnUrlPay,
+    required TResult Function(LnUrlPayRequestData data, String? bip353Address) lnUrlPay,
     required TResult Function(LnUrlWithdrawRequestData data) lnUrlWithdraw,
     required TResult Function(LnUrlAuthRequestData data) lnUrlAuth,
     required TResult Function(LnUrlErrorData data) lnUrlError,
@@ -3528,7 +3538,7 @@ class _$InputType_LnUrlErrorImpl implements InputType_LnUrlError {
     TResult? Function(LNInvoice invoice)? bolt11,
     TResult? Function(String nodeId)? nodeId,
     TResult? Function(String url)? url,
-    TResult? Function(LnUrlPayRequestData data)? lnUrlPay,
+    TResult? Function(LnUrlPayRequestData data, String? bip353Address)? lnUrlPay,
     TResult? Function(LnUrlWithdrawRequestData data)? lnUrlWithdraw,
     TResult? Function(LnUrlAuthRequestData data)? lnUrlAuth,
     TResult? Function(LnUrlErrorData data)? lnUrlError,
@@ -3543,7 +3553,7 @@ class _$InputType_LnUrlErrorImpl implements InputType_LnUrlError {
     TResult Function(LNInvoice invoice)? bolt11,
     TResult Function(String nodeId)? nodeId,
     TResult Function(String url)? url,
-    TResult Function(LnUrlPayRequestData data)? lnUrlPay,
+    TResult Function(LnUrlPayRequestData data, String? bip353Address)? lnUrlPay,
     TResult Function(LnUrlWithdrawRequestData data)? lnUrlWithdraw,
     TResult Function(LnUrlAuthRequestData data)? lnUrlAuth,
     TResult Function(LnUrlErrorData data)? lnUrlError,

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -3964,6 +3964,7 @@ fun readableMapOf(inputType: InputType): ReadableMap? {
         is InputType.LnUrlPay -> {
             pushToMap(map, "type", "lnUrlPay")
             pushToMap(map, "data", readableMapOf(inputType.data))
+            pushToMap(map, "bip353Address", inputType.bip353Address)
         }
         is InputType.LnUrlWithdraw -> {
             pushToMap(map, "type", "lnUrlWithdraw")

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -4763,11 +4763,12 @@ enum BreezSDKMapper {
             ]
 
         case let .lnUrlPay(
-            data
+            data, bip353Address
         ):
             return [
                 "type": "lnUrlPay",
                 "data": dictionaryOf(lnUrlPayRequestData: data),
+                "bip353Address": bip353Address == nil ? nil : bip353Address,
             ]
 
         case let .lnUrlWithdraw(

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -690,6 +690,7 @@ export type InputType = {
 } | {
     type: InputTypeVariant.LN_URL_PAY,
     data: LnUrlPayRequestData
+    bip353Address?: string
 } | {
     type: InputTypeVariant.LN_URL_WITHDRAW,
     data: LnUrlWithdrawRequestData

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -467,7 +467,7 @@ pub(crate) async fn handle_command(
             validate_success_url,
             use_trampoline,
         } => match parse(&lnurl, None).await? {
-            LnUrlPay { data: pd } => {
+            LnUrlPay { data: pd, .. } => {
                 let prompt = format!(
                     "Amount to pay in millisatoshi (min {} msat, max {} msat: ",
                     pd.min_sendable, pd.max_sendable


### PR DESCRIPTION
This adds a bip353_address field to Bolt12 and LnUrlPay input types to allow users of `parse()` to tell if a particular input was a BIP353 address.

This is needed in the nodeless SDK for https://github.com/breez/breez-sdk-liquid/issues/714.  