### PR TITLE
Fix clippy issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -242,9 +242,8 @@ jobs:
       - name: clippy
         run: |
           cd libs
-          # Explicitly allow clippy::uninlined-format-args lint because it's present in the generated breez_sdk.uniffi.rs
-          cargo clippy -- -D warnings -A clippy::uninlined-format-args
-          cargo clippy --tests -- -D warnings -A clippy::uninlined-format-args
+          cargo clippy -- -D warnings
+          cargo clippy --tests -- -D warnings
           cd ../tools/sdk-cli
           cargo clippy -- -D warnings
   

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,8 @@ fmt:
 	cd tools/sdk-cli && cargo fmt -- --check
 
 clippy:
-	# Explicitly allow clippy::uninlined-format-args lint because it's present in the generated breez_sdk.uniffi.rs
-	cd libs && cargo clippy -- -D warnings -A clippy::uninlined-format-args
-	cd libs && cargo clippy --tests -- -D warnings -A clippy::uninlined-format-args
+	cd libs && cargo clippy -- -D warnings
+	cd libs && cargo clippy --tests -- -D warnings
 	cd tools/sdk-cli && cargo clippy -- -D warnings
 
 codegen: flutter-codegen react-native-codegen

--- a/libs/sdk-bindings/Cargo.toml
+++ b/libs/sdk-bindings/Cargo.toml
@@ -13,6 +13,11 @@ crate-type = ["staticlib", "cdylib", "lib"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+# Explicitly allow clippy warnings present in the generated breez_sdk.uniffi.rs
+[lints.clippy]
+uninlined-format-args = "allow"
+useless_conversion = "allow"
+
 [dependencies]
 anyhow = { workspace = true }
 breez-sdk-core = { path = "../sdk-core" }

--- a/libs/sdk-common/src/invoice.rs
+++ b/libs/sdk-common/src/invoice.rs
@@ -97,7 +97,7 @@ fn parse_short_channel_id(id_str: &str) -> InvoiceResult<u64> {
     let tx_num = parts[1].parse::<u64>()?;
     let tx_out = parts[2].parse::<u64>()?;
 
-    Ok((block_num & 0xFFFFFF) << 40 | (tx_num & 0xFFFFFF) << 16 | (tx_out & 0xFFFF))
+    Ok(((block_num & 0xFFFFFF) << 40) | ((tx_num & 0xFFFFFF) << 16) | (tx_out & 0xFFFF))
 }
 
 fn format_short_channel_id(id: u64) -> String {


### PR DESCRIPTION
Fixes these clippy issues:
```
error: operator precedence can trip the unwary
   --> sdk-common/src/invoice.rs:100:8
    |
100 |     Ok((block_num & 0xFFFFFF) << 40 | (tx_num & 0xFFFFFF) << 16 | (tx_out & 0xFFFF))
    |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider parenthesizing your expression: `((block_num & 0xFFFFFF) << 40) | ((tx_num & 0xFFFFFF) << 16)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#precedence
    = note: `-D clippy::precedence` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::precedence)]`
```

```
error: useless conversion to the same type: `breez_sdk_core::error::ConnectError`
    --> /home/runner/work/breez-sdk-greenlight/breez-sdk-greenlight/libs/target/debug/build/breez_sdk-1e37e56222681eb0/out/breez_sdk.uniffi.rs:4064:11
     |
4064 |         }).map_err(Into::into).map_err(<FfiConverterTypeConnectError as uniffi::FfiConverter>::lower)?;
     |           ^^^^^^^^^^^^^^^^^^^^ help: consider removing
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion
     = note: `-D clippy::useless-conversion` implied by `-D warnings`
     = help: to override `-D warnings` add `#[allow(clippy::useless_conversion)]`
```