### PR TITLE
fix refund tx id conflicts

### DIFF
--- a/libs/sdk-core/src/persist/swap.rs
+++ b/libs/sdk-core/src/persist/swap.rs
@@ -199,7 +199,7 @@ impl SqliteStorage {
         refund_tx_id: String,
     ) -> PersistResult<()> {
         self.get_connection()?.execute(
-            "INSERT INTO sync.swap_refunds (bitcoin_address, refund_tx_id) VALUES(:bitcoin_address, :refund_tx_id)",
+            "INSERT OR IGNORE INTO sync.swap_refunds (bitcoin_address, refund_tx_id) VALUES(:bitcoin_address, :refund_tx_id)",
             named_params! {
              ":bitcoin_address": bitcoin_address,
              ":refund_tx_id": refund_tx_id,

--- a/libs/sdk-core/src/persist/sync.rs
+++ b/libs/sdk-core/src/persist/sync.rs
@@ -151,12 +151,11 @@ impl SqliteStorage {
         // sync remote swap_refunds table
         tx.execute(
             "
-        INSERT INTO sync.swap_refunds
+        INSERT OR IGNORE INTO sync.swap_refunds
          SELECT
           bitcoin_address,
           refund_tx_id
-         FROM remote_sync.swap_refunds
-         WHERE bitcoin_address NOT IN (SELECT bitcoin_address FROM sync.swap_refunds);",
+         FROM remote_sync.swap_refunds;",
             [],
         )?;
 


### PR DESCRIPTION
If a swap refund tx id is already in the database, the insert can be ignored. Fixes https://github.com/breez/breez-sdk-relai/issues/159