### PR TITLE
Taproot swaps (V2)

### DIFF
--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -684,6 +684,7 @@ dependencies = [
  "rusqlite_migration",
  "ryu",
  "sdk-common",
+ "secp256k1 0.30.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -3930,6 +3931,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "secp256k1"
+version = "0.30.0"
+source = "git+https://github.com/rust-bitcoin/rust-secp256k1?rev=1cc7410df436b73d06db3c8ff7cbb29a78916b06#1cc7410df436b73d06db3c8ff7cbb29a78916b06"
+dependencies = [
+ "bitcoin_hashes 0.14.0",
+ "rand",
+ "secp256k1-sys 0.11.0",
+]
+
+[[package]]
 name = "secp256k1-sys"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3952,6 +3963,14 @@ name = "secp256k1-sys"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.11.0"
+source = "git+https://github.com/rust-bitcoin/rust-secp256k1?rev=1cc7410df436b73d06db3c8ff7cbb29a78916b06#1cc7410df436b73d06db3c8ff7cbb29a78916b06"
 dependencies = [
  "cc",
 ]

--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -154,6 +154,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
 name = "anyhow"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -673,6 +679,7 @@ dependencies = [
  "lazy_static",
  "log",
  "miniz_oxide 0.7.4",
+ "mockall 0.13.1",
  "once_cell",
  "openssl",
  "prost 0.11.9",
@@ -1557,7 +1564,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "log",
- "mockall",
+ "mockall 0.11.4",
  "picky",
  "picky-asn1-der 0.4.1",
  "picky-asn1-x509 0.12.0",
@@ -2597,8 +2604,22 @@ dependencies = [
  "downcast",
  "fragile",
  "lazy_static",
- "mockall_derive",
- "predicates",
+ "mockall_derive 0.11.4",
+ "predicates 2.1.5",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive 0.13.1",
+ "predicates 3.1.3",
  "predicates-tree",
 ]
 
@@ -2612,6 +2633,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3161,6 +3194,16 @@ dependencies = [
  "normalize-line-endings",
  "predicates-core",
  "regex",
+]
+
+[[package]]
+name = "predicates"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
+dependencies = [
+ "anstyle",
+ "predicates-core",
 ]
 
 [[package]]

--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -2615,7 +2615,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "downcast",
  "fragile",
  "mockall_derive 0.13.1",
@@ -2641,7 +2641,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.98",

--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -806,6 +806,7 @@ dictionary PrepareRefundRequest {
     string swap_address;
     string to_address;
     u32 sat_per_vbyte;
+    boolean? unilateral = null;
 };
 
 dictionary PrepareRefundResponse {
@@ -817,6 +818,7 @@ dictionary RefundRequest {
     string swap_address;
     string to_address;
     u32 sat_per_vbyte;
+    boolean? unilateral = null;
 };
 
 dictionary RefundResponse {

--- a/libs/sdk-common/src/breez_server.rs
+++ b/libs/sdk-common/src/breez_server.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use log::trace;
 use tokio::sync::Mutex;
 use tonic::codegen::InterceptedService;
@@ -31,7 +30,7 @@ pub struct BreezServer {
 }
 
 impl BreezServer {
-    pub fn new(server_url: String, api_key: Option<String>) -> Result<Self> {
+    pub fn new(server_url: String, api_key: Option<String>) -> anyhow::Result<Self> {
         Ok(Self {
             grpc_client: Mutex::new(GrpcClient::new(server_url)?),
             api_key,
@@ -108,7 +107,7 @@ impl BreezServer {
         ))
     }
 
-    pub async fn ping(&self) -> Result<String> {
+    pub async fn ping(&self) -> anyhow::Result<String> {
         let request = Request::new(PingRequest {});
         let response = self
             .get_information_client()

--- a/libs/sdk-common/src/breez_server.rs
+++ b/libs/sdk-common/src/breez_server.rs
@@ -95,8 +95,17 @@ impl BreezServer {
         SwapperClient::new(self.grpc_client.lock().await.clone().into_inner())
     }
 
-    pub async fn get_taproot_swapper_client(&self) -> TaprootSwapperClient<Transport> {
-        TaprootSwapperClient::new(self.grpc_client.lock().await.clone().into_inner())
+    pub async fn get_taproot_swapper_client(
+        &self,
+    ) -> Result<
+        TaprootSwapperClient<InterceptedService<Transport, ApiKeyInterceptor>>,
+        ServiceConnectivityError,
+    > {
+        let api_key_metadata = self.api_key_metadata()?;
+        Ok(TaprootSwapperClient::with_interceptor(
+            self.grpc_client.lock().await.clone().into_inner(),
+            ApiKeyInterceptor { api_key_metadata },
+        ))
     }
 
     pub async fn ping(&self) -> Result<String> {

--- a/libs/sdk-common/src/breez_server.rs
+++ b/libs/sdk-common/src/breez_server.rs
@@ -13,6 +13,7 @@ use crate::grpc::payment_notifier_client::PaymentNotifierClient;
 use crate::grpc::signer_client::SignerClient;
 use crate::grpc::support_client::SupportClient;
 use crate::grpc::swapper_client::SwapperClient;
+use crate::grpc::taproot_swapper_client::TaprootSwapperClient;
 use crate::grpc::transport::{GrpcClient, Transport};
 use crate::grpc::{ChainApiServersRequest, PingRequest};
 use crate::prelude::{ServiceConnectivityError, ServiceConnectivityErrorKind};
@@ -92,6 +93,10 @@ impl BreezServer {
 
     pub async fn get_swapper_client(&self) -> SwapperClient<Transport> {
         SwapperClient::new(self.grpc_client.lock().await.clone().into_inner())
+    }
+
+    pub async fn get_taproot_swapper_client(&self) -> TaprootSwapperClient<Transport> {
+        TaprootSwapperClient::new(self.grpc_client.lock().await.clone().into_inner())
     }
 
     pub async fn ping(&self) -> Result<String> {

--- a/libs/sdk-common/src/grpc/proto/breez.proto
+++ b/libs/sdk-common/src/grpc/proto/breez.proto
@@ -108,6 +108,55 @@ service Support {
   rpc BreezStatus(BreezStatusRequest) returns (BreezStatusReply) {}
 }
 
+service TaprootSwapper {
+    rpc CreateSwap (CreateSwapRequest) returns (CreateSwapResponse) {}
+    rpc PaySwap (PaySwapRequest) returns (PaySwapResponse) {}
+    rpc RefundSwap (RefundSwapRequest) returns (RefundSwapResponse) {}
+    rpc SwapParameters (SwapParametersRequest) returns (SwapParametersResponse) {}
+}
+
+message CreateSwapRequest {
+    bytes hash = 1;
+    bytes refund_pubkey = 2;
+}
+  
+message CreateSwapResponse {
+    string address = 1;
+    bytes claim_pubkey = 2;
+    uint32 lock_time = 3;
+    SwapParameters parameters = 4;
+}
+
+message PaySwapRequest {
+    string payment_request = 1;
+}
+
+message PaySwapResponse {}
+
+message RefundSwapRequest {
+    string address = 1;
+    bytes transaction = 2;
+    uint32 input_index = 3;
+    bytes pub_nonce = 4;
+}
+
+message RefundSwapResponse {
+    bytes pub_nonce = 1;
+    bytes partial_signature = 2;
+}
+
+message SwapParameters {
+    uint64 max_swap_amount_sat = 1;
+    uint64 min_swap_amount_sat = 2;
+    uint64 min_utxo_amount_sat = 3;
+}
+
+message SwapParametersRequest {}
+
+message SwapParametersResponse {
+    SwapParameters parameters = 1;
+}
+
 message SignUrlRequest {
   string baseUrl = 1 [ json_name = "base_url" ];
   string queryString = 2 [ json_name = "query_string" ];

--- a/libs/sdk-common/src/lnurl/specs/pay.rs
+++ b/libs/sdk-common/src/lnurl/specs/pay.rs
@@ -237,6 +237,16 @@ pub mod model {
         Url { data: UrlSuccessActionData },
     }
 
+    impl Default for SuccessActionProcessed {
+        fn default() -> Self {
+            Self::Message {
+                data: MessageSuccessActionData {
+                    message: "".to_string(),
+                },
+            }
+        }
+    }
+
     /// Supported success action types
     ///
     /// Receiving any other (unsupported) success action type will result in a failed parsing,

--- a/libs/sdk-core/Cargo.toml
+++ b/libs/sdk-core/Cargo.toml
@@ -42,6 +42,7 @@ lazy_static = "^1.4.0"
 log = { workspace = true }
 once_cell = { workspace = true }
 openssl = { version = "0.10", features = ["vendored"] }
+secp256k1 = { git = "https://github.com/rust-bitcoin/rust-secp256k1", rev = "1cc7410df436b73d06db3c8ff7cbb29a78916b06"}
 strum = { workspace = true }
 strum_macros = { workspace = true }
 tempfile = "3"

--- a/libs/sdk-core/Cargo.toml
+++ b/libs/sdk-core/Cargo.toml
@@ -55,4 +55,5 @@ regex = { workspace = true }
 ryu = "1.0.18"
 
 [dev-dependencies]
+mockall = "0.13.1"
 sdk-common = { path = "../sdk-common", features = ["test-utils"] }

--- a/libs/sdk-core/src/backup.rs
+++ b/libs/sdk-core/src/backup.rs
@@ -788,7 +788,7 @@ mod tests {
             channel_opening_fees: Some(get_test_ofp_48h(1, 1).into()),
             confirmed_at: Some(555),
         };
-        persister.insert_swap(tested_swap_info).unwrap();
+        persister.insert_swap(&tested_swap_info).unwrap();
     }
 
     async fn wait_for_backup_success(mut subscription: Receiver<BreezEvent>) {

--- a/libs/sdk-core/src/backup.rs
+++ b/libs/sdk-core/src/backup.rs
@@ -444,6 +444,7 @@ impl BackupWorker {
 
 #[cfg(test)]
 mod tests {
+    use crate::persist::swap::SwapStorage;
     use crate::test_utils::get_test_ofp_48h;
     use crate::ListSwapsRequest;
     use crate::{

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -44,6 +44,7 @@ use crate::models::{
 use crate::node_api::{CreateInvoiceRequest, NodeAPI};
 use crate::persist::db::SqliteStorage;
 use crate::swap_in::swap::BTCReceiveSwap;
+use crate::swap_in::TaprootSwapperAPI;
 use crate::swap_out::boltzswap::BoltzApi;
 use crate::swap_out::reverseswap::BTCSendSwap;
 use crate::*;
@@ -2252,6 +2253,7 @@ struct BreezServicesBuilder {
     rest_client: Option<Arc<dyn RestClient>>,
     support_api: Option<Arc<dyn SupportAPI>>,
     swapper_api: Option<Arc<dyn SwapperAPI>>,
+    taproot_swapper_api: Option<Arc<dyn TaprootSwapperAPI>>,
     /// Reverse swap functionality on the Breez Server
     reverse_swapper_api: Option<Arc<dyn ReverseSwapperRoutingAPI>>,
     /// Reverse swap functionality on the 3rd party reverse swap service
@@ -2272,6 +2274,7 @@ impl BreezServicesBuilder {
             rest_client: None,
             support_api: None,
             swapper_api: None,
+            taproot_swapper_api: None,
             reverse_swapper_api: None,
             reverse_swap_service_api: None,
             buy_bitcoin_api: None,
@@ -2316,6 +2319,11 @@ impl BreezServicesBuilder {
 
     pub fn swapper_api(&mut self, swapper_api: Arc<dyn SwapperAPI>) -> &mut Self {
         self.swapper_api = Some(swapper_api.clone());
+        self
+    }
+
+    pub fn taproot_swapper_api(&mut self, swapper_api: Arc<dyn TaprootSwapperAPI>) -> &mut Self {
+        self.taproot_swapper_api = Some(swapper_api.clone());
         self
     }
 

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -2812,7 +2812,7 @@ impl PaymentReceiver {
         self.persister.insert_open_channel_payment_info(
             &parsed_invoice.payment_hash,
             params.payer_amount_msat,
-            invoice,
+            &signed_invoice,
         )?;
 
         Ok(signed_invoice)

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -45,7 +45,7 @@ use crate::node_api::{CreateInvoiceRequest, NodeAPI};
 use crate::persist::cache::NodeStateStorage;
 use crate::persist::db::SqliteStorage;
 use crate::persist::swap::SwapStorage;
-use crate::persist::transactions::CompletedPaymentStorage;
+use crate::persist::transactions::PaymentStorage;
 use crate::swap_in::{BTCReceiveSwap, BTCReceiveSwapParameters, TaprootSwapperAPI};
 use crate::swap_out::boltzswap::BoltzApi;
 use crate::swap_out::reverseswap::BTCSendSwap;
@@ -2483,7 +2483,7 @@ impl BreezServicesBuilder {
 
         let btc_receive_swapper = Arc::new(BTCReceiveSwap::new(BTCReceiveSwapParameters {
             chain_service: chain_service.clone(),
-            completed_payment_storage: persister.clone(),
+            payment_storage: persister.clone(),
             network: self.config.network.into(),
             node_api: unwrapped_node_api.clone(),
             node_state_storage: persister.clone(),

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -2550,6 +2550,7 @@ pub struct OpenChannelParams {
 
 #[tonic::async_trait]
 pub trait Receiver: Send + Sync {
+    fn open_channel_needed(&self, amount_msat: u64) -> Result<bool, ReceivePaymentError>;
     async fn receive_payment(
         &self,
         req: ReceivePaymentRequest,
@@ -2571,17 +2572,21 @@ pub(crate) struct PaymentReceiver {
 
 #[tonic::async_trait]
 impl Receiver for PaymentReceiver {
-    async fn receive_payment(
-        &self,
-        req: ReceivePaymentRequest,
-    ) -> Result<ReceivePaymentResponse, ReceivePaymentError> {
-        let lsp_info = get_lsp(self.persister.clone(), self.lsp.clone()).await?;
+    fn open_channel_needed(&self, amount_msat: u64) -> Result<bool, ReceivePaymentError> {
         let node_state = self
             .persister
             .get_node_state()?
             .ok_or(ReceivePaymentError::Generic {
                 err: "Node info not found".into(),
             })?;
+        Ok(node_state.max_receivable_single_payment_amount_msat < amount_msat)
+    }
+
+    async fn receive_payment(
+        &self,
+        req: ReceivePaymentRequest,
+    ) -> Result<ReceivePaymentResponse, ReceivePaymentError> {
+        let lsp_info = get_lsp(self.persister.clone(), self.lsp.clone()).await?;
         let expiry = req.expiry.unwrap_or(INVOICE_PAYMENT_FEE_EXPIRY_SECONDS);
 
         ensure_sdk!(
@@ -2596,8 +2601,7 @@ impl Receiver for PaymentReceiver {
         let mut channel_fees_msat = None;
 
         // check if we need to open channel
-        let open_channel_needed =
-            node_state.max_receivable_single_payment_amount_msat < req.amount_msat;
+        let open_channel_needed = self.open_channel_needed(req.amount_msat)?;
         if open_channel_needed {
             info!("We need to open a channel");
 

--- a/libs/sdk-core/src/bridge_generated.io.rs
+++ b/libs/sdk-core/src/bridge_generated.io.rs
@@ -1018,6 +1018,7 @@ impl Wire2Api<PrepareRefundRequest> for wire_PrepareRefundRequest {
             swap_address: self.swap_address.wire2api(),
             to_address: self.to_address.wire2api(),
             sat_per_vbyte: self.sat_per_vbyte.wire2api(),
+            unilateral: self.unilateral.wire2api(),
         }
     }
 }
@@ -1055,6 +1056,7 @@ impl Wire2Api<RefundRequest> for wire_RefundRequest {
             swap_address: self.swap_address.wire2api(),
             to_address: self.to_address.wire2api(),
             sat_per_vbyte: self.sat_per_vbyte.wire2api(),
+            unilateral: self.unilateral.wire2api(),
         }
     }
 }
@@ -1369,6 +1371,7 @@ pub struct wire_PrepareRefundRequest {
     swap_address: *mut wire_uint_8_list,
     to_address: *mut wire_uint_8_list,
     sat_per_vbyte: u32,
+    unilateral: *mut bool,
 }
 
 #[repr(C)]
@@ -1402,6 +1405,7 @@ pub struct wire_RefundRequest {
     swap_address: *mut wire_uint_8_list,
     to_address: *mut wire_uint_8_list,
     sat_per_vbyte: u32,
+    unilateral: *mut bool,
 }
 
 #[repr(C)]
@@ -1901,6 +1905,7 @@ impl NewWithNullPtr for wire_PrepareRefundRequest {
             swap_address: core::ptr::null_mut(),
             to_address: core::ptr::null_mut(),
             sat_per_vbyte: Default::default(),
+            unilateral: core::ptr::null_mut(),
         }
     }
 }
@@ -1966,6 +1971,7 @@ impl NewWithNullPtr for wire_RefundRequest {
             swap_address: core::ptr::null_mut(),
             to_address: core::ptr::null_mut(),
             sat_per_vbyte: Default::default(),
+            unilateral: core::ptr::null_mut(),
         }
     }
 }

--- a/libs/sdk-core/src/chain.rs
+++ b/libs/sdk-core/src/chain.rs
@@ -220,7 +220,7 @@ pub struct RecommendedFees {
     pub minimum_fee: u64,
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug)]
+#[derive(Default, Deserialize, Serialize, Clone, Debug)]
 pub struct OnchainTx {
     pub txid: String,
     pub version: u32,
@@ -233,7 +233,7 @@ pub struct OnchainTx {
     pub status: TxStatus,
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug)]
+#[derive(Default, Deserialize, Serialize, Clone, Debug)]
 pub struct TxStatus {
     pub confirmed: bool,
     pub block_height: Option<u32>,
@@ -241,7 +241,7 @@ pub struct TxStatus {
     pub block_time: Option<u64>,
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug)]
+#[derive(Default, Deserialize, Serialize, Clone, Debug)]
 pub struct Vout {
     pub scriptpubkey: String,
     pub scriptpubkey_asm: String,
@@ -250,7 +250,7 @@ pub struct Vout {
     pub value: u64,
 }
 
-#[derive(Deserialize, Serialize, Clone, Debug)]
+#[derive(Default, Deserialize, Serialize, Clone, Debug)]
 pub struct Vin {
     pub txid: String,
     pub vout: u32,

--- a/libs/sdk-core/src/chain.rs
+++ b/libs/sdk-core/src/chain.rs
@@ -128,37 +128,10 @@ pub struct Utxo {
 
 #[derive(Clone)]
 pub struct AddressUtxos {
-    pub unconfirmed: Vec<Utxo>,
     pub confirmed: Vec<Utxo>,
 }
 
 impl AddressUtxos {
-    pub(crate) fn unconfirmed_sats(&self) -> u64 {
-        self.unconfirmed
-            .iter()
-            .fold(0, |accum, item| accum + item.value)
-    }
-
-    pub(crate) fn unconfirmed_tx_ids(&self) -> Vec<String> {
-        self.unconfirmed
-            .iter()
-            .map(|c| c.out.txid.to_string())
-            .collect()
-    }
-
-    pub(crate) fn confirmed_sats(&self) -> u64 {
-        self.confirmed
-            .iter()
-            .fold(0, |accum, item| accum + item.value)
-    }
-
-    pub(crate) fn confirmed_tx_ids(&self) -> Vec<String> {
-        self.confirmed
-            .iter()
-            .map(|c| c.out.txid.to_string())
-            .collect()
-    }
-
     /// Get the highest block height of all confirmed transactions that paid to the given onchain address
     pub(crate) fn _confirmed_block(&self) -> u32 {
         self.confirmed.iter().fold(0, |b, item| {
@@ -213,11 +186,6 @@ pub(crate) fn get_utxos(
         }
     }
     let address_utxos = AddressUtxos {
-        unconfirmed: utxos
-            .clone()
-            .into_iter()
-            .filter(|u| u.block_height.is_none())
-            .collect(),
         confirmed: utxos
             .clone()
             .into_iter()
@@ -225,21 +193,6 @@ pub(crate) fn get_utxos(
             .collect(),
     };
     Ok(address_utxos)
-}
-
-/// Get the total count of transactions that have been sent to the given onchain address
-pub(crate) fn get_total_incoming_txs(address: String, transactions: Vec<OnchainTx>) -> u64 {
-    let mut total_incoming_txs = 0;
-    for tx in transactions.iter() {
-        if tx.status.confirmed {
-            for vout in tx.vout.iter() {
-                if vout.scriptpubkey_address == address {
-                    total_incoming_txs += 1;
-                }
-            }
-        }
-    }
-    total_incoming_txs
 }
 
 #[derive(Clone)]

--- a/libs/sdk-core/src/error.rs
+++ b/libs/sdk-core/src/error.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 
 use crate::{
     bitcoin::util::bip32, node_api::NodeError, persist::error::PersistError,
-    swap_in::error::SwapError, swap_out::error::ReverseSwapError,
+    swap_in::ReceiveSwapError, swap_out::error::ReverseSwapError,
 };
 
 pub type SdkResult<T, E = SdkError> = Result<T, E>;
@@ -189,10 +189,10 @@ impl From<SdkError> for ReceiveOnchainError {
     }
 }
 
-impl From<SwapError> for ReceiveOnchainError {
-    fn from(value: SwapError) -> Self {
+impl From<ReceiveSwapError> for ReceiveOnchainError {
+    fn from(value: ReceiveSwapError) -> Self {
         match value {
-            SwapError::ServiceConnectivity(err) => Self::ServiceConnectivity { err },
+            ReceiveSwapError::ServiceConnectivity(err) => Self::ServiceConnectivity { err },
             _ => Self::Generic {
                 err: value.to_string(),
             },
@@ -483,6 +483,17 @@ impl From<SendPaymentError> for SdkError {
             | SendPaymentError::RouteTooExpensive { err }
             | SendPaymentError::InsufficientBalance { err } => Self::Generic { err },
             SendPaymentError::ServiceConnectivity { err } => Self::ServiceConnectivity { err },
+        }
+    }
+}
+
+impl From<ReceiveSwapError> for SdkError {
+    fn from(value: ReceiveSwapError) -> Self {
+        match value {
+            ReceiveSwapError::ServiceConnectivity(err) => Self::ServiceConnectivity { err },
+            _ => Self::Generic {
+                err: value.to_string(),
+            },
         }
     }
 }

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -51,6 +51,7 @@ use crate::bitcoin::{
 use crate::lightning::util::message_signing::verify;
 use crate::lightning_invoice::{RawBolt11Invoice, SignedRawBolt11Invoice};
 use crate::node_api::{CreateInvoiceRequest, FetchBolt11Result, NodeAPI, NodeError, NodeResult};
+use crate::persist::cache::NodeStateStorage;
 use crate::persist::db::SqliteStorage;
 use crate::persist::send_pays::{SendPay, SendPayStatus};
 use crate::{models::*, LspInformation};
@@ -1875,11 +1876,11 @@ impl NodeAPI for Greenlight {
         }
     }
 
-    async fn max_sendable_amount(
+    async fn max_sendable_amount<'a>(
         &self,
         payee_node_id: Option<Vec<u8>>,
         max_hops: u32,
-        last_hop_hint: Option<&RouteHintHop>,
+        last_hop_hint: Option<&'a RouteHintHop>,
     ) -> NodeResult<Vec<MaxChannelAmount>> {
         let mut client = self.get_node_client().await?;
 

--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -1102,7 +1102,7 @@ impl NodeAPI for Greenlight {
 
         let status = match result.status() {
             ListinvoicesInvoicesStatus::Unpaid => DelinvoiceStatus::Unpaid,
-            ListinvoicesInvoicesStatus::Paid => DelinvoiceStatus::Paid,
+            ListinvoicesInvoicesStatus::Paid => return Err(NodeError::InvoiceAlreadyPaid),
             ListinvoicesInvoicesStatus::Expired => DelinvoiceStatus::Expired,
         };
         with_connection_retry!(client.del_invoice(DelinvoiceRequest {

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -1046,12 +1046,14 @@ pub struct PrepareRefundRequest {
     pub swap_address: String,
     pub to_address: String,
     pub sat_per_vbyte: u32,
+    pub unilateral: Option<bool>,
 }
 
 pub struct RefundRequest {
     pub swap_address: String,
     pub to_address: String,
     pub sat_per_vbyte: u32,
+    pub unilateral: Option<bool>,
 }
 
 pub struct PrepareRefundResponse {

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -30,8 +30,11 @@ pub const SWAP_PAYMENT_FEE_EXPIRY_SECONDS: u32 = 60 * 60 * 24 * 2; // 2 days
 pub const INVOICE_PAYMENT_FEE_EXPIRY_SECONDS: u32 = 60 * 60; // 60 minutes
 
 /// Different types of supported payments
-#[derive(Clone, PartialEq, Eq, Debug, EnumString, Display, Deserialize, Serialize, Hash)]
+#[derive(
+    Default, Clone, PartialEq, Eq, Debug, EnumString, Display, Deserialize, Serialize, Hash,
+)]
 pub enum PaymentType {
+    #[default]
     Sent,
     Received,
     ClosedChannel,
@@ -639,15 +642,16 @@ pub struct SyncResponse {
 }
 
 /// The status of a payment
-#[derive(Clone, Copy, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[derive(Default, Clone, Copy, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub enum PaymentStatus {
+    #[default]
     Pending = 0,
     Complete = 1,
     Failed = 2,
 }
 
 /// Represents a payment, including its [PaymentType] and [PaymentDetails]
-#[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
 pub struct Payment {
     pub id: String,
     pub payment_type: PaymentType,
@@ -715,6 +719,14 @@ pub enum PaymentDetails {
     },
 }
 
+impl Default for PaymentDetails {
+    fn default() -> Self {
+        Self::Ln {
+            data: LnPaymentDetails::default(),
+        }
+    }
+}
+
 impl PaymentDetails {
     pub fn add_pending_expiration_block(&mut self, htlc: Htlc) {
         if let PaymentDetails::Ln { data } = self {
@@ -724,7 +736,7 @@ impl PaymentDetails {
 }
 
 /// Details of a LN payment, as included in a [Payment]
-#[derive(PartialEq, Eq, Debug, Clone, Deserialize, Serialize)]
+#[derive(Default, PartialEq, Eq, Debug, Clone, Deserialize, Serialize)]
 pub struct LnPaymentDetails {
     pub payment_hash: String,
     pub label: String,

--- a/libs/sdk-core/src/models.rs
+++ b/libs/sdk-core/src/models.rs
@@ -606,7 +606,7 @@ pub struct BackupStatus {
 /// Note: The implementation attempts to provide the most up-to-date values,
 /// which may result in some short-lived inconsistencies
 /// (e.g., `channels_balance_msat` may be updated before `inbound_liquidity_msats`).
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+#[derive(Serialize, Default, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct NodeState {
     pub id: String,
     pub block_height: u32,
@@ -945,7 +945,7 @@ pub struct ReceiveOnchainRequest {
     pub opening_fee_params: Option<OpeningFeeParams>,
 }
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ListSwapsRequest {
     pub status: Option<Vec<SwapStatus>>,
     /// Epoch time, in seconds. If set, acts as filter for minimum swap creation time, inclusive.
@@ -1060,7 +1060,7 @@ pub struct RefundResponse {
 ///
 /// After they are received, the client shouldn't change them when calling LSP methods,
 /// otherwise the LSP may reject the call.
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, Eq, PartialEq)]
 pub struct OpeningFeeParams {
     /// The minimum value in millisatoshi we will require for incoming HTLCs on the channel
     pub min_msat: u64,
@@ -1264,11 +1264,12 @@ pub enum ChannelState {
 }
 
 /// The status of a swap
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Default, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub enum SwapStatus {
     /// The swap address has been created and either there aren't any confirmed transactions associated with it
     /// or there are confirmed transactions that are bellow the lock timeout which means the funds are still
     /// eligible to be redeemed normally.
+    #[default]
     Initial = 0,
 
     WaitingConfirmation = 1,
@@ -1346,7 +1347,7 @@ impl TryFrom<i32> for SwapStatus {
 /// The SwapInfo has a status which changes accordingly, documented in [SwapStatus].
 ///
 
-#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
+#[derive(Clone, Default, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub struct SwapInfo {
     /// Bitcoin address for this swap. Sats sent to this address will be swapped.
     pub bitcoin_address: String,

--- a/libs/sdk-core/src/node_api.rs
+++ b/libs/sdk-core/src/node_api.rs
@@ -63,6 +63,9 @@ pub enum NodeError {
 
     #[error("{0}")]
     InsufficientFunds(String),
+
+    #[error("invoice already paid")]
+    InvoiceAlreadyPaid,
 }
 
 impl NodeError {

--- a/libs/sdk-core/src/node_api.rs
+++ b/libs/sdk-core/src/node_api.rs
@@ -115,6 +115,7 @@ pub struct FetchBolt11Result {
 }
 
 /// Trait covering functions affecting the LN node
+#[cfg_attr(test, mockall::automock)]
 #[tonic::async_trait]
 pub trait NodeAPI: Send + Sync {
     async fn node_credentials(&self) -> NodeResult<Option<NodeCredentials>>;
@@ -157,11 +158,11 @@ pub trait NodeAPI: Send + Sync {
     async fn send_pay(&self, bolt11: String, max_hops: u32) -> NodeResult<PaymentResponse>;
 
     /// Calculates the maximum amount that can be sent to a node.
-    async fn max_sendable_amount(
+    async fn max_sendable_amount<'a>(
         &self,
         payee_node_id: Option<Vec<u8>>,
         max_hops: u32,
-        last_hop: Option<&RouteHintHop>,
+        last_hop: Option<&'a RouteHintHop>,
     ) -> NodeResult<Vec<MaxChannelAmount>>;
     async fn redeem_onchain_funds(
         &self,

--- a/libs/sdk-core/src/node_api.rs
+++ b/libs/sdk-core/src/node_api.rs
@@ -117,6 +117,7 @@ pub trait NodeAPI: Send + Sync {
     async fn node_credentials(&self) -> NodeResult<Option<NodeCredentials>>;
     async fn configure_node(&self, close_to_address: Option<String>) -> NodeResult<()>;
     async fn create_invoice(&self, request: CreateInvoiceRequest) -> NodeResult<String>;
+    async fn delete_invoice(&self, bolt11: String) -> NodeResult<()>;
     /// Fetches an existing BOLT11 invoice from the node
     async fn fetch_bolt11(&self, payment_hash: Vec<u8>) -> NodeResult<Option<FetchBolt11Result>>;
     async fn pull_changed(

--- a/libs/sdk-core/src/persist/cache.rs
+++ b/libs/sdk-core/src/persist/cache.rs
@@ -12,6 +12,27 @@ const KEY_STATIC_BACKUP: &str = "static_backup";
 const KEY_WEBHOOK_URL: &str = "webhook_url";
 const KEY_MEMPOOLSPACE_BASE_URLS: &str = "mempoolspace_base_urls";
 
+#[cfg_attr(test, mockall::automock)]
+pub(crate) trait NodeStateStorage: Send + Sync {
+    fn get_node_state(&self) -> PersistResult<Option<NodeState>>;
+    fn set_node_state(&self, state: &NodeState) -> PersistResult<()>;
+}
+
+impl NodeStateStorage for SqliteStorage {
+    fn set_node_state(&self, state: &NodeState) -> PersistResult<()> {
+        let serialized_state = serde_json::to_string(state)?;
+        self.update_cached_item(KEY_NODE_STATE, serialized_state)
+    }
+
+    fn get_node_state(&self) -> PersistResult<Option<NodeState>> {
+        let state_str = self.get_cached_item(KEY_NODE_STATE)?;
+        Ok(match state_str {
+            Some(str) => serde_json::from_str(str.as_str())?,
+            None => None,
+        })
+    }
+}
+
 impl SqliteStorage {
     pub fn get_cached_item(&self, key: &str) -> PersistResult<Option<String>> {
         let res = self.get_connection()?.query_row(
@@ -35,19 +56,6 @@ impl SqliteStorage {
         self.get_connection()?
             .execute("DELETE FROM cached_items WHERE key = ?1", [key])?;
         Ok(())
-    }
-
-    pub fn set_node_state(&self, state: &NodeState) -> PersistResult<()> {
-        let serialized_state = serde_json::to_string(state)?;
-        self.update_cached_item(KEY_NODE_STATE, serialized_state)
-    }
-
-    pub fn get_node_state(&self) -> PersistResult<Option<NodeState>> {
-        let state_str = self.get_cached_item(KEY_NODE_STATE)?;
-        Ok(match state_str {
-            Some(str) => serde_json::from_str(str.as_str())?,
-            None => None,
-        })
     }
 
     pub fn set_last_backup_time(&self, t: u64) -> PersistResult<()> {

--- a/libs/sdk-core/src/persist/migrations.rs
+++ b/libs/sdk-core/src/persist/migrations.rs
@@ -485,7 +485,8 @@ pub(crate) fn current_migrations() -> Vec<&'static str> {
        "ALTER TABLE payments ADD COLUMN is_pseudo INTEGER DEFAULT 0 NOT NULL;
         DELETE FROM payments;
         DELETE FROM cached_items WHERE key = 'sync_state';
-       "
+       ",
+       "ALTER TABLE swaps_info ADD COLUMN chain_data TEXT;"
     ]
 }
 

--- a/libs/sdk-core/src/persist/migrations.rs
+++ b/libs/sdk-core/src/persist/migrations.rs
@@ -672,5 +672,6 @@ pub(crate) fn current_sync_migrations() -> Vec<&'static str> {
         UPDATE swaps SET max_swapper_payable = max_allowed_deposit;
         ",
         "ALTER TABLE payments_external_info ADD COLUMN lnurl_pay_comment TEXT;",
+        "DELETE FROM open_channel_payment_info;",
 	]
 }

--- a/libs/sdk-core/src/persist/sync.rs
+++ b/libs/sdk-core/src/persist/sync.rs
@@ -272,6 +272,7 @@ mod tests {
 
     use crate::persist::db::SqliteStorage;
     use crate::persist::error::PersistResult;
+    use crate::persist::swap::SwapStorage;
     use crate::persist::test_utils;
     use crate::test_utils::{get_test_ofp_48h, rand_string, rand_vec_u8};
     use crate::{ListSwapsRequest, SwapInfo};

--- a/libs/sdk-core/src/persist/sync.rs
+++ b/libs/sdk-core/src/persist/sync.rs
@@ -282,7 +282,7 @@ mod tests {
         local_storage.init()?;
 
         let local_swap_info = create_test_swap_info();
-        local_storage.insert_swap(local_swap_info.clone())?;
+        local_storage.insert_swap(&local_swap_info)?;
 
         let mut remote_swap_info = local_swap_info;
         remote_swap_info.bitcoin_address = "2".into();
@@ -295,7 +295,7 @@ mod tests {
 
         let remote_storage = SqliteStorage::new(test_utils::create_test_sql_dir());
         remote_storage.init()?;
-        remote_storage.insert_swap(remote_swap_info)?;
+        remote_storage.insert_swap(&remote_swap_info)?;
 
         remote_storage.insert_open_channel_payment_info("123", 100000, "")?;
 
@@ -325,14 +325,14 @@ mod tests {
 
         // Swap is created with initial dynamic fee
         let local_swap_info = create_test_swap_info();
-        local_storage.insert_swap(local_swap_info.clone())?;
+        local_storage.insert_swap(&local_swap_info)?;
 
         // Sleep to cause a change in created_at
         tokio::time::sleep(Duration::from_secs(2)).await;
 
         // Swap address is re-used later with different (newer) dynamic fee
         let new_fees: crate::OpeningFeeParams = get_test_ofp_48h(10, 10).into();
-        local_storage.update_swap_fees(local_swap_info.bitcoin_address, new_fees.clone())?;
+        local_storage.update_swap_fees(&local_swap_info.bitcoin_address, &new_fees)?;
 
         let local_swaps = local_storage.list_swaps(ListSwapsRequest::default())?;
         assert_eq!(local_swaps.len(), 1);
@@ -373,15 +373,15 @@ mod tests {
         // - Local swap L2  (created_at +1s)
         // - Local swap L3  (created_at +1s)
         // - Remote swap R2 (created_at +1s)
-        remote_storage.insert_swap(pre_sync_r1.clone())?; // R1
+        remote_storage.insert_swap(&pre_sync_r1)?; // R1
         tokio::time::sleep(Duration::from_secs(1)).await;
-        local_storage.insert_swap(pre_sync_l1.clone())?; // L1
+        local_storage.insert_swap(&pre_sync_l1)?; // L1
         tokio::time::sleep(Duration::from_secs(1)).await;
-        local_storage.insert_swap(pre_sync_l2.clone())?; // L2
+        local_storage.insert_swap(&pre_sync_l2)?; // L2
         tokio::time::sleep(Duration::from_secs(1)).await;
-        local_storage.insert_swap(pre_sync_l3.clone())?; // L3
+        local_storage.insert_swap(&pre_sync_l3)?; // L3
         tokio::time::sleep(Duration::from_secs(1)).await;
-        remote_storage.insert_swap(pre_sync_r2.clone())?; // R2
+        remote_storage.insert_swap(&pre_sync_r2)?; // R2
 
         // The swap fees created_at are in this order: R1 < L1 < L2 < L3 < R2
 

--- a/libs/sdk-core/src/persist/transactions.rs
+++ b/libs/sdk-core/src/persist/transactions.rs
@@ -13,6 +13,23 @@ use crate::models::*;
 
 const METADATA_MAX_LEN: usize = 1000;
 
+#[cfg_attr(test, mockall::automock)]
+pub(crate) trait CompletedPaymentStorage: Send + Sync {
+    fn get_completed_payment_by_hash(&self, hash: &str) -> PersistResult<Option<Payment>>;
+}
+
+impl CompletedPaymentStorage for SqliteStorage {
+    /// Looks up a completed payment by hash.
+    ///
+    /// To include pending or failed payments in the lookup as well, use [Self::get_payment_by_hash]
+    fn get_completed_payment_by_hash(&self, hash: &str) -> PersistResult<Option<Payment>> {
+        let res = self
+            .get_payment_by_hash(hash)?
+            .filter(|p| p.status == PaymentStatus::Complete);
+        Ok(res)
+    }
+}
+
 impl SqliteStorage {
     /// Inserts payments into the payments table. These can be pending, completed and failed payments. Before
     /// persisting, it automatically deletes previously pending payments
@@ -308,7 +325,7 @@ impl SqliteStorage {
     /// To lookup a completed payment by hash, use [Self::get_completed_payment_by_hash]
     ///
     /// To query all payments, see [Self::list_payments]
-    pub(crate) fn get_payment_by_hash(&self, hash: &String) -> PersistResult<Option<Payment>> {
+    pub(crate) fn get_payment_by_hash(&self, hash: &str) -> PersistResult<Option<Payment>> {
         let query = self.select_payments_query("where id = ?1", 0, 1)?;
         Ok(self
             .get_connection()?
@@ -335,19 +352,6 @@ impl SqliteStorage {
                 |row| row.get(0),
             )
             .optional()?)
-    }
-
-    /// Looks up a completed payment by hash.
-    ///
-    /// To include pending or failed payments in the lookup as well, use [Self::get_payment_by_hash]
-    pub(crate) fn get_completed_payment_by_hash(
-        &self,
-        hash: &String,
-    ) -> PersistResult<Option<Payment>> {
-        let res = self
-            .get_payment_by_hash(hash)?
-            .filter(|p| p.status == PaymentStatus::Complete);
-        Ok(res)
     }
 
     fn sql_row_to_payment(&self, row: &Row) -> PersistResult<Payment, rusqlite::Error> {
@@ -504,136 +508,270 @@ impl ToSql for PaymentStatus {
     }
 }
 
-#[test]
-fn test_ln_transactions() -> PersistResult<(), Box<dyn std::error::Error>> {
-    use sdk_common::prelude::*;
-
-    use crate::models::{LnPaymentDetails, Payment, PaymentDetails};
-    use crate::persist::test_utils;
-
-    let lnurl_metadata = "{'key': 'sample-metadata-val'}";
-    let test_ln_address = "test@ln.adddress.com";
-    let test_lnurl_pay_domain = "example.com";
-    let test_lnurl_pay_comment = "Thank you Satoshi!";
-    let sa = SuccessActionProcessed::Message {
-        data: MessageSuccessActionData {
-            message: "test message".into(),
-        },
+#[cfg(test)]
+mod test {
+    use crate::{
+        persist::{db::SqliteStorage, error::PersistResult, swap::SwapStorage},
+        FullReverseSwapInfo, ListPaymentsRequest, MetadataFilter, OpeningFeeParams,
+        PaymentExternalInfo, PaymentStatus, PaymentType, PaymentTypeFilter, ReverseSwapInfo,
+        ReverseSwapInfoCached, ReverseSwapStatus, SwapInfo, SwapStatus,
     };
 
-    let payment_hash_with_lnurl_success_action = "123";
-    let payment_hash_with_lnurl_withdraw = "124";
-    let payment_hash_with_swap_info: Vec<u8> = vec![234, 12, 53, 124];
-    let payment_hash_with_lnurl_domain = "126";
-    let payment_hash_with_rev_swap_info: Vec<u8> = vec![8, 7, 6, 5, 4, 3, 2, 1];
-    let lnurl_withdraw_url = "https://test.lnurl.withdraw.link";
-    let swap_info = SwapInfo {
-        bitcoin_address: "123".to_string(),
-        created_at: 1234567,
-        lock_height: 7654321,
-        payment_hash: payment_hash_with_swap_info.clone(),
-        preimage: vec![1, 2, 3],
-        private_key: vec![3, 2, 1],
-        public_key: vec![1, 3, 2],
-        swapper_public_key: vec![2, 1, 3],
-        script: vec![2, 3, 1],
-        bolt11: Some("swap_bolt11".into()),
-        paid_msat: 50_000,
-        confirmed_sats: 50,
-        unconfirmed_sats: 0,
-        total_incoming_txs: 1,
-        status: SwapStatus::Refundable,
-        refund_tx_ids: vec![],
-        unconfirmed_tx_ids: vec![],
-        confirmed_tx_ids: vec![],
-        min_allowed_deposit: 5_000,
-        max_allowed_deposit: 1_000_000,
-        max_swapper_payable: 2_000_000,
-        last_redeem_error: None,
-        channel_opening_fees: Some(OpeningFeeParams {
-            min_msat: 5_000_000,
-            proportional: 50,
-            valid_until: "date".to_string(),
-            max_idle_time: 12345,
-            max_client_to_self_delay: 234,
-            promise: "promise".to_string(),
-        }),
-        confirmed_at: Some(555),
-    };
-    let rev_swap_preimage = vec![4, 4, 4, 4];
-    let full_ref_swap_info = FullReverseSwapInfo {
-        id: "rev_swap_id".to_string(),
-        created_at_block_height: 0,
-        preimage: rev_swap_preimage.clone(),
-        private_key: vec![],
-        claim_pubkey: "claim_pubkey".to_string(),
-        timeout_block_height: 600_000,
-        invoice: "645".to_string(),
-        redeem_script: "redeem_script".to_string(),
-        onchain_amount_sat: 250,
-        sat_per_vbyte: Some(50),
-        receive_amount_sat: None,
-        cache: ReverseSwapInfoCached {
-            status: ReverseSwapStatus::CompletedConfirmed,
+    #[test]
+    fn test_ln_transactions() -> PersistResult<(), Box<dyn std::error::Error>> {
+        use sdk_common::prelude::*;
+
+        use crate::models::{LnPaymentDetails, Payment, PaymentDetails};
+        use crate::persist::test_utils;
+
+        let lnurl_metadata = "{'key': 'sample-metadata-val'}";
+        let test_ln_address = "test@ln.adddress.com";
+        let test_lnurl_pay_domain = "example.com";
+        let test_lnurl_pay_comment = "Thank you Satoshi!";
+        let sa = SuccessActionProcessed::Message {
+            data: MessageSuccessActionData {
+                message: "test message".into(),
+            },
+        };
+
+        let payment_hash_with_lnurl_success_action = "123";
+        let payment_hash_with_lnurl_withdraw = "124";
+        let payment_hash_with_swap_info: Vec<u8> = vec![234, 12, 53, 124];
+        let payment_hash_with_lnurl_domain = "126";
+        let payment_hash_with_rev_swap_info: Vec<u8> = vec![8, 7, 6, 5, 4, 3, 2, 1];
+        let lnurl_withdraw_url = "https://test.lnurl.withdraw.link";
+        let swap_info = SwapInfo {
+            bitcoin_address: "123".to_string(),
+            created_at: 1234567,
+            lock_height: 7654321,
+            payment_hash: payment_hash_with_swap_info.clone(),
+            preimage: vec![1, 2, 3],
+            private_key: vec![3, 2, 1],
+            public_key: vec![1, 3, 2],
+            swapper_public_key: vec![2, 1, 3],
+            script: vec![2, 3, 1],
+            bolt11: Some("swap_bolt11".into()),
+            paid_msat: 50_000,
+            confirmed_sats: 50,
+            unconfirmed_sats: 0,
+            total_incoming_txs: 1,
+            status: SwapStatus::Refundable,
+            refund_tx_ids: vec![],
+            unconfirmed_tx_ids: vec![],
+            confirmed_tx_ids: vec![],
+            min_allowed_deposit: 5_000,
+            max_allowed_deposit: 1_000_000,
+            max_swapper_payable: 2_000_000,
+            last_redeem_error: None,
+            channel_opening_fees: Some(OpeningFeeParams {
+                min_msat: 5_000_000,
+                proportional: 50,
+                valid_until: "date".to_string(),
+                max_idle_time: 12345,
+                max_client_to_self_delay: 234,
+                promise: "promise".to_string(),
+            }),
+            confirmed_at: Some(555),
+        };
+        let rev_swap_preimage = vec![4, 4, 4, 4];
+        let full_ref_swap_info = FullReverseSwapInfo {
+            id: "rev_swap_id".to_string(),
+            created_at_block_height: 0,
+            preimage: rev_swap_preimage.clone(),
+            private_key: vec![],
+            claim_pubkey: "claim_pubkey".to_string(),
+            timeout_block_height: 600_000,
+            invoice: "645".to_string(),
+            redeem_script: "redeem_script".to_string(),
+            onchain_amount_sat: 250,
+            sat_per_vbyte: Some(50),
+            receive_amount_sat: None,
+            cache: ReverseSwapInfoCached {
+                status: ReverseSwapStatus::CompletedConfirmed,
+                lockup_txid: Some("lockup_txid".to_string()),
+                claim_txid: Some("claim_txid".to_string()),
+            },
+        };
+        let rev_swap_info = ReverseSwapInfo {
+            id: "rev_swap_id".to_string(),
+            claim_pubkey: "claim_pubkey".to_string(),
             lockup_txid: Some("lockup_txid".to_string()),
             claim_txid: Some("claim_txid".to_string()),
-        },
-    };
-    let rev_swap_info = ReverseSwapInfo {
-        id: "rev_swap_id".to_string(),
-        claim_pubkey: "claim_pubkey".to_string(),
-        lockup_txid: Some("lockup_txid".to_string()),
-        claim_txid: Some("claim_txid".to_string()),
-        onchain_amount_sat: 250,
-        status: ReverseSwapStatus::CompletedConfirmed,
-    };
-    let txs = [
-        Payment {
-            id: payment_hash_with_lnurl_success_action.to_string(),
-            payment_type: PaymentType::Sent,
-            payment_time: 1001,
-            amount_msat: 100,
-            fee_msat: 20,
-            status: PaymentStatus::Complete,
-            error: None,
-            description: None,
-            details: PaymentDetails::Ln {
-                data: LnPaymentDetails {
-                    payment_hash: payment_hash_with_lnurl_success_action.to_string(),
-                    label: "label".to_string(),
-                    destination_pubkey: "pubey".to_string(),
-                    payment_preimage: "1111".to_string(),
-                    keysend: true,
-                    bolt11: "bolt11".to_string(),
-                    lnurl_success_action: Some(sa.clone()),
-                    lnurl_pay_domain: None,
-                    lnurl_pay_comment: None,
-                    lnurl_metadata: Some(lnurl_metadata.to_string()),
-                    ln_address: Some(test_ln_address.to_string()),
-                    lnurl_withdraw_endpoint: None,
-                    swap_info: None,
-                    reverse_swap_info: None,
-                    pending_expiration_block: None,
-                    open_channel_bolt11: None,
+            onchain_amount_sat: 250,
+            status: ReverseSwapStatus::CompletedConfirmed,
+        };
+        let txs = [
+            Payment {
+                id: payment_hash_with_lnurl_success_action.to_string(),
+                payment_type: PaymentType::Sent,
+                payment_time: 1001,
+                amount_msat: 100,
+                fee_msat: 20,
+                status: PaymentStatus::Complete,
+                error: None,
+                description: None,
+                details: PaymentDetails::Ln {
+                    data: LnPaymentDetails {
+                        payment_hash: payment_hash_with_lnurl_success_action.to_string(),
+                        label: "label".to_string(),
+                        destination_pubkey: "pubey".to_string(),
+                        payment_preimage: "1111".to_string(),
+                        keysend: true,
+                        bolt11: "bolt11".to_string(),
+                        lnurl_success_action: Some(sa.clone()),
+                        lnurl_pay_domain: None,
+                        lnurl_pay_comment: None,
+                        lnurl_metadata: Some(lnurl_metadata.to_string()),
+                        ln_address: Some(test_ln_address.to_string()),
+                        lnurl_withdraw_endpoint: None,
+                        swap_info: None,
+                        reverse_swap_info: None,
+                        pending_expiration_block: None,
+                        open_channel_bolt11: None,
+                    },
                 },
+                metadata: None,
             },
-            metadata: None,
-        },
-        Payment {
-            id: payment_hash_with_lnurl_withdraw.to_string(),
-            payment_type: PaymentType::Received,
-            payment_time: 1000,
-            amount_msat: 100,
-            fee_msat: 20,
-            status: PaymentStatus::Complete,
+            Payment {
+                id: payment_hash_with_lnurl_withdraw.to_string(),
+                payment_type: PaymentType::Received,
+                payment_time: 1000,
+                amount_msat: 100,
+                fee_msat: 20,
+                status: PaymentStatus::Complete,
+                error: None,
+                description: Some("desc".to_string()),
+                details: PaymentDetails::Ln {
+                    data: LnPaymentDetails {
+                        payment_hash: payment_hash_with_lnurl_withdraw.to_string(),
+                        label: "label".to_string(),
+                        destination_pubkey: "pubey".to_string(),
+                        payment_preimage: "2222".to_string(),
+                        keysend: true,
+                        bolt11: "bolt11".to_string(),
+                        lnurl_success_action: None,
+                        lnurl_pay_domain: None,
+                        lnurl_pay_comment: None,
+                        lnurl_metadata: None,
+                        ln_address: None,
+                        lnurl_withdraw_endpoint: Some(lnurl_withdraw_url.to_string()),
+                        swap_info: None,
+                        reverse_swap_info: None,
+                        pending_expiration_block: None,
+                        open_channel_bolt11: None,
+                    },
+                },
+                metadata: None,
+            },
+            Payment {
+                id: hex::encode(payment_hash_with_swap_info.clone()),
+                payment_type: PaymentType::Received,
+                payment_time: 999,
+                amount_msat: 50_000,
+                fee_msat: 20,
+                status: PaymentStatus::Complete,
+                error: None,
+                description: Some("desc".to_string()),
+                details: PaymentDetails::Ln {
+                    data: LnPaymentDetails {
+                        payment_hash: hex::encode(payment_hash_with_swap_info),
+                        label: "label".to_string(),
+                        destination_pubkey: "pubkey".to_string(),
+                        payment_preimage: "3333".to_string(),
+                        keysend: false,
+                        bolt11: "swap_bolt11".to_string(),
+                        lnurl_success_action: None,
+                        lnurl_pay_domain: None,
+                        lnurl_pay_comment: None,
+                        lnurl_metadata: None,
+                        ln_address: None,
+                        lnurl_withdraw_endpoint: None,
+                        swap_info: Some(swap_info.clone()),
+                        reverse_swap_info: None,
+                        pending_expiration_block: None,
+                        open_channel_bolt11: None,
+                    },
+                },
+                metadata: None,
+            },
+            Payment {
+                id: hex::encode(payment_hash_with_rev_swap_info.clone()),
+                payment_type: PaymentType::Sent,
+                payment_time: 998,
+                amount_msat: 100_000,
+                fee_msat: 200,
+                status: PaymentStatus::Complete,
+                error: None,
+                description: Some("desc".to_string()),
+                details: PaymentDetails::Ln {
+                    data: LnPaymentDetails {
+                        payment_hash: hex::encode(payment_hash_with_rev_swap_info),
+                        label: "label".to_string(),
+                        destination_pubkey: "pubkey".to_string(),
+                        payment_preimage: hex::encode(rev_swap_preimage),
+                        keysend: false,
+                        bolt11: "swap_bolt11".to_string(),
+                        lnurl_success_action: None,
+                        lnurl_metadata: None,
+                        lnurl_pay_domain: None,
+                        lnurl_pay_comment: None,
+                        ln_address: None,
+                        lnurl_withdraw_endpoint: None,
+                        swap_info: None,
+                        reverse_swap_info: Some(rev_swap_info.clone()),
+                        pending_expiration_block: None,
+                        open_channel_bolt11: None,
+                    },
+                },
+                metadata: None,
+            },
+            Payment {
+                id: payment_hash_with_lnurl_domain.to_string(),
+                payment_type: PaymentType::Sent,
+                payment_time: 998,
+                amount_msat: 100,
+                fee_msat: 20,
+                status: PaymentStatus::Complete,
+                error: None,
+                description: None,
+                details: PaymentDetails::Ln {
+                    data: LnPaymentDetails {
+                        payment_hash: payment_hash_with_lnurl_domain.to_string(),
+                        label: "label".to_string(),
+                        destination_pubkey: "pubey".to_string(),
+                        payment_preimage: "payment_preimage".to_string(),
+                        keysend: true,
+                        bolt11: "bolt11".to_string(),
+                        lnurl_success_action: None,
+                        lnurl_pay_domain: Some(test_lnurl_pay_domain.to_string()),
+                        lnurl_pay_comment: Some(test_lnurl_pay_comment.to_string()),
+                        lnurl_metadata: Some(lnurl_metadata.to_string()),
+                        ln_address: None,
+                        lnurl_withdraw_endpoint: None,
+                        swap_info: None,
+                        reverse_swap_info: None,
+                        pending_expiration_block: None,
+                        open_channel_bolt11: None,
+                    },
+                },
+                metadata: None,
+            },
+        ];
+        let failed_txs = [Payment {
+            id: "125".to_string(),
+            payment_type: PaymentType::Sent,
+            payment_time: 2000,
+            amount_msat: 1000,
+            fee_msat: 0,
+            status: PaymentStatus::Failed,
             error: None,
             description: Some("desc".to_string()),
             details: PaymentDetails::Ln {
                 data: LnPaymentDetails {
-                    payment_hash: payment_hash_with_lnurl_withdraw.to_string(),
+                    payment_hash: "125".to_string(),
                     label: "label".to_string(),
                     destination_pubkey: "pubey".to_string(),
-                    payment_preimage: "2222".to_string(),
+                    payment_preimage: "4444".to_string(),
                     keysend: true,
                     bolt11: "bolt11".to_string(),
                     lnurl_success_action: None,
@@ -641,99 +779,6 @@ fn test_ln_transactions() -> PersistResult<(), Box<dyn std::error::Error>> {
                     lnurl_pay_comment: None,
                     lnurl_metadata: None,
                     ln_address: None,
-                    lnurl_withdraw_endpoint: Some(lnurl_withdraw_url.to_string()),
-                    swap_info: None,
-                    reverse_swap_info: None,
-                    pending_expiration_block: None,
-                    open_channel_bolt11: None,
-                },
-            },
-            metadata: None,
-        },
-        Payment {
-            id: hex::encode(payment_hash_with_swap_info.clone()),
-            payment_type: PaymentType::Received,
-            payment_time: 999,
-            amount_msat: 50_000,
-            fee_msat: 20,
-            status: PaymentStatus::Complete,
-            error: None,
-            description: Some("desc".to_string()),
-            details: PaymentDetails::Ln {
-                data: LnPaymentDetails {
-                    payment_hash: hex::encode(payment_hash_with_swap_info),
-                    label: "label".to_string(),
-                    destination_pubkey: "pubkey".to_string(),
-                    payment_preimage: "3333".to_string(),
-                    keysend: false,
-                    bolt11: "swap_bolt11".to_string(),
-                    lnurl_success_action: None,
-                    lnurl_pay_domain: None,
-                    lnurl_pay_comment: None,
-                    lnurl_metadata: None,
-                    ln_address: None,
-                    lnurl_withdraw_endpoint: None,
-                    swap_info: Some(swap_info.clone()),
-                    reverse_swap_info: None,
-                    pending_expiration_block: None,
-                    open_channel_bolt11: None,
-                },
-            },
-            metadata: None,
-        },
-        Payment {
-            id: hex::encode(payment_hash_with_rev_swap_info.clone()),
-            payment_type: PaymentType::Sent,
-            payment_time: 998,
-            amount_msat: 100_000,
-            fee_msat: 200,
-            status: PaymentStatus::Complete,
-            error: None,
-            description: Some("desc".to_string()),
-            details: PaymentDetails::Ln {
-                data: LnPaymentDetails {
-                    payment_hash: hex::encode(payment_hash_with_rev_swap_info),
-                    label: "label".to_string(),
-                    destination_pubkey: "pubkey".to_string(),
-                    payment_preimage: hex::encode(rev_swap_preimage),
-                    keysend: false,
-                    bolt11: "swap_bolt11".to_string(),
-                    lnurl_success_action: None,
-                    lnurl_metadata: None,
-                    lnurl_pay_domain: None,
-                    lnurl_pay_comment: None,
-                    ln_address: None,
-                    lnurl_withdraw_endpoint: None,
-                    swap_info: None,
-                    reverse_swap_info: Some(rev_swap_info.clone()),
-                    pending_expiration_block: None,
-                    open_channel_bolt11: None,
-                },
-            },
-            metadata: None,
-        },
-        Payment {
-            id: payment_hash_with_lnurl_domain.to_string(),
-            payment_type: PaymentType::Sent,
-            payment_time: 998,
-            amount_msat: 100,
-            fee_msat: 20,
-            status: PaymentStatus::Complete,
-            error: None,
-            description: None,
-            details: PaymentDetails::Ln {
-                data: LnPaymentDetails {
-                    payment_hash: payment_hash_with_lnurl_domain.to_string(),
-                    label: "label".to_string(),
-                    destination_pubkey: "pubey".to_string(),
-                    payment_preimage: "payment_preimage".to_string(),
-                    keysend: true,
-                    bolt11: "bolt11".to_string(),
-                    lnurl_success_action: None,
-                    lnurl_pay_domain: Some(test_lnurl_pay_domain.to_string()),
-                    lnurl_pay_comment: Some(test_lnurl_pay_comment.to_string()),
-                    lnurl_metadata: Some(lnurl_metadata.to_string()),
-                    ln_address: None,
                     lnurl_withdraw_endpoint: None,
                     swap_info: None,
                     reverse_swap_info: None,
@@ -742,259 +787,229 @@ fn test_ln_transactions() -> PersistResult<(), Box<dyn std::error::Error>> {
                 },
             },
             metadata: None,
-        },
-    ];
-    let failed_txs = [Payment {
-        id: "125".to_string(),
-        payment_type: PaymentType::Sent,
-        payment_time: 2000,
-        amount_msat: 1000,
-        fee_msat: 0,
-        status: PaymentStatus::Failed,
-        error: None,
-        description: Some("desc".to_string()),
-        details: PaymentDetails::Ln {
-            data: LnPaymentDetails {
-                payment_hash: "125".to_string(),
-                label: "label".to_string(),
-                destination_pubkey: "pubey".to_string(),
-                payment_preimage: "4444".to_string(),
-                keysend: true,
-                bolt11: "bolt11".to_string(),
-                lnurl_success_action: None,
+        }];
+        let storage = SqliteStorage::new(test_utils::create_test_sql_dir());
+        storage.init()?;
+        storage.insert_or_update_payments(&txs, false)?;
+        storage.insert_or_update_payments(&failed_txs, false)?;
+        storage.insert_payment_external_info(
+            payment_hash_with_lnurl_success_action,
+            PaymentExternalInfo {
+                lnurl_pay_success_action: Some(sa.clone()),
+                lnurl_pay_domain: None,
+                lnurl_pay_comment: None,
+                lnurl_metadata: Some(lnurl_metadata.to_string()),
+                ln_address: Some(test_ln_address.to_string()),
+                lnurl_withdraw_endpoint: None,
+                attempted_amount_msat: None,
+                attempted_error: None,
+            },
+        )?;
+        storage.insert_payment_external_info(
+            payment_hash_with_lnurl_withdraw,
+            PaymentExternalInfo {
+                lnurl_pay_success_action: None,
                 lnurl_pay_domain: None,
                 lnurl_pay_comment: None,
                 lnurl_metadata: None,
                 ln_address: None,
-                lnurl_withdraw_endpoint: None,
-                swap_info: None,
-                reverse_swap_info: None,
-                pending_expiration_block: None,
-                open_channel_bolt11: None,
+                lnurl_withdraw_endpoint: Some(lnurl_withdraw_url.to_string()),
+                attempted_amount_msat: None,
+                attempted_error: None,
             },
-        },
-        metadata: None,
-    }];
-    let storage = SqliteStorage::new(test_utils::create_test_sql_dir());
-    storage.init()?;
-    storage.insert_or_update_payments(&txs, false)?;
-    storage.insert_or_update_payments(&failed_txs, false)?;
-    storage.insert_payment_external_info(
-        payment_hash_with_lnurl_success_action,
-        PaymentExternalInfo {
-            lnurl_pay_success_action: Some(sa.clone()),
-            lnurl_pay_domain: None,
-            lnurl_pay_comment: None,
-            lnurl_metadata: Some(lnurl_metadata.to_string()),
-            ln_address: Some(test_ln_address.to_string()),
-            lnurl_withdraw_endpoint: None,
-            attempted_amount_msat: None,
-            attempted_error: None,
-        },
-    )?;
-    storage.insert_payment_external_info(
-        payment_hash_with_lnurl_withdraw,
-        PaymentExternalInfo {
-            lnurl_pay_success_action: None,
-            lnurl_pay_domain: None,
-            lnurl_pay_comment: None,
-            lnurl_metadata: None,
-            ln_address: None,
-            lnurl_withdraw_endpoint: Some(lnurl_withdraw_url.to_string()),
-            attempted_amount_msat: None,
-            attempted_error: None,
-        },
-    )?;
-    storage.insert_swap(&swap_info)?;
-    storage.update_swap_bolt11(
-        swap_info.bitcoin_address.clone(),
-        swap_info.bolt11.clone().unwrap(),
-    )?;
-    storage.insert_payment_external_info(
-        payment_hash_with_lnurl_domain,
-        PaymentExternalInfo {
-            lnurl_pay_success_action: None,
-            lnurl_pay_domain: Some(test_lnurl_pay_domain.to_string()),
-            lnurl_pay_comment: Some(test_lnurl_pay_comment.to_string()),
-            lnurl_metadata: Some(lnurl_metadata.to_string()),
-            ln_address: None,
-            lnurl_withdraw_endpoint: None,
-            attempted_amount_msat: None,
-            attempted_error: None,
-        },
-    )?;
-    storage.insert_reverse_swap(&full_ref_swap_info)?;
-    storage.update_reverse_swap_status("rev_swap_id", &ReverseSwapStatus::CompletedConfirmed)?;
-    storage.update_reverse_swap_lockup_txid("rev_swap_id", Some("lockup_txid".to_string()))?;
-    storage.update_reverse_swap_claim_txid("rev_swap_id", Some("claim_txid".to_string()))?;
+        )?;
+        storage.insert_swap(&swap_info)?;
+        storage.update_swap_bolt11(
+            swap_info.bitcoin_address.clone(),
+            swap_info.bolt11.clone().unwrap(),
+        )?;
+        storage.insert_payment_external_info(
+            payment_hash_with_lnurl_domain,
+            PaymentExternalInfo {
+                lnurl_pay_success_action: None,
+                lnurl_pay_domain: Some(test_lnurl_pay_domain.to_string()),
+                lnurl_pay_comment: Some(test_lnurl_pay_comment.to_string()),
+                lnurl_metadata: Some(lnurl_metadata.to_string()),
+                ln_address: None,
+                lnurl_withdraw_endpoint: None,
+                attempted_amount_msat: None,
+                attempted_error: None,
+            },
+        )?;
+        storage.insert_reverse_swap(&full_ref_swap_info)?;
+        storage
+            .update_reverse_swap_status("rev_swap_id", &ReverseSwapStatus::CompletedConfirmed)?;
+        storage.update_reverse_swap_lockup_txid("rev_swap_id", Some("lockup_txid".to_string()))?;
+        storage.update_reverse_swap_claim_txid("rev_swap_id", Some("claim_txid".to_string()))?;
 
-    // retrieve all
-    let retrieve_txs = storage.list_payments(ListPaymentsRequest::default())?;
-    assert_eq!(retrieve_txs.len(), 5);
-    assert_eq!(retrieve_txs, txs);
+        // retrieve all
+        let retrieve_txs = storage.list_payments(ListPaymentsRequest::default())?;
+        assert_eq!(retrieve_txs.len(), 5);
+        assert_eq!(retrieve_txs, txs);
 
-    //test only sent
-    let retrieve_txs = storage.list_payments(ListPaymentsRequest {
-        filters: Some(vec![
-            PaymentTypeFilter::Sent,
-            PaymentTypeFilter::ClosedChannel,
-        ]),
-        ..Default::default()
-    })?;
-    assert_eq!(retrieve_txs.len(), 3);
-    assert_eq!(retrieve_txs[0], txs[0]);
-    assert_eq!(retrieve_txs[1], txs[3]);
-    assert!(
-        matches!( &retrieve_txs[0].details, PaymentDetails::Ln {data: LnPaymentDetails {lnurl_success_action, ..}} if lnurl_success_action == &Some(sa))
-    );
-    assert!(
-        matches!( &retrieve_txs[0].details, PaymentDetails::Ln {data: LnPaymentDetails {lnurl_pay_domain, ln_address, ..}} if lnurl_pay_domain.is_none() && ln_address == &Some(test_ln_address.to_string()))
-    );
-    assert!(
-        matches!( &retrieve_txs[2].details, PaymentDetails::Ln {data: LnPaymentDetails {lnurl_pay_domain, ln_address, ..}} if lnurl_pay_domain == &Some(test_lnurl_pay_domain.to_string()) && ln_address.is_none())
-    );
-    assert!(
-        matches!( &retrieve_txs[1].details, PaymentDetails::Ln {data: LnPaymentDetails {reverse_swap_info: rev_swap, ..}} if rev_swap == &Some(rev_swap_info))
-    );
-
-    //test only received
-    let retrieve_txs = storage.list_payments(ListPaymentsRequest {
-        filters: Some(vec![PaymentTypeFilter::Received]),
-        ..Default::default()
-    })?;
-    assert_eq!(retrieve_txs.len(), 2);
-    assert_eq!(retrieve_txs[0], txs[1]);
-    assert_eq!(retrieve_txs[1], txs[2]);
-    assert!(
-        matches!( &retrieve_txs[1].details, PaymentDetails::Ln {data: LnPaymentDetails {swap_info: swap, ..}} if swap == &Some(swap_info))
-    );
-
-    storage.insert_or_update_payments(&txs, false)?;
-    let retrieve_txs = storage.list_payments(ListPaymentsRequest::default())?;
-    assert_eq!(retrieve_txs.len(), 5);
-    assert_eq!(retrieve_txs, txs);
-
-    storage.insert_open_channel_payment_info("123", 150, "")?;
-    let retrieve_txs = storage.list_payments(ListPaymentsRequest::default())?;
-    assert_eq!(retrieve_txs[0].fee_msat, 50);
-
-    // test all with failures
-    let retrieve_txs = storage.list_payments(ListPaymentsRequest {
-        include_failures: Some(true),
-        ..Default::default()
-    })?;
-    assert_eq!(retrieve_txs.len(), 6);
-
-    // test sent with failures
-    let retrieve_txs = storage.list_payments(ListPaymentsRequest {
-        filters: Some(vec![
-            PaymentTypeFilter::Sent,
-            PaymentTypeFilter::ClosedChannel,
-        ]),
-        include_failures: Some(true),
-        ..Default::default()
-    })?;
-    assert_eq!(retrieve_txs.len(), 4);
-
-    // test limit
-    let retrieve_txs = storage.list_payments(ListPaymentsRequest {
-        include_failures: Some(false),
-        limit: Some(1),
-        ..Default::default()
-    })?;
-    assert_eq!(retrieve_txs.len(), 1);
-
-    // test offset
-    let retrieve_txs = storage.list_payments(ListPaymentsRequest {
-        include_failures: Some(false),
-        offset: Some(1),
-        limit: Some(1),
-        ..Default::default()
-    })?;
-    assert_eq!(retrieve_txs.len(), 1);
-    assert_eq!(retrieve_txs[0].id, payment_hash_with_lnurl_withdraw);
-
-    // test json metadata validation
-    assert!(storage
-        .set_payment_external_metadata(
-            payment_hash_with_lnurl_withdraw.to_string(),
-            r#"{ "malformed: true }"#.to_string()
-        )
-        .is_err());
-
-    // test metadata set and filter
-    let test_json = r#"{"supportsBoolean":true,"supportsInt":10,"supportsString":"supports string","supportsNested":{"value":[1,2]}}"#;
-    let test_json_filters = Some(vec![
-        MetadataFilter {
-            json_path: "supportsBoolean".to_string(),
-            json_value: "true".to_string(),
-        },
-        MetadataFilter {
-            json_path: "supportsInt".to_string(),
-            json_value: "10".to_string(),
-        },
-        MetadataFilter {
-            json_path: "supportsString".to_string(),
-            json_value: r#""supports string""#.to_string(),
-        },
-        MetadataFilter {
-            json_path: "supportsNested.value".to_string(),
-            json_value: "[1,2]".to_string(),
-        },
-    ]);
-
-    storage.set_payment_external_metadata(
-        payment_hash_with_lnurl_withdraw.to_string(),
-        test_json.to_string(),
-    )?;
-
-    let retrieve_txs = storage.list_payments(ListPaymentsRequest {
-        metadata_filters: test_json_filters,
-        ..Default::default()
-    })?;
-    assert_eq!(retrieve_txs.len(), 1);
-    assert_eq!(retrieve_txs[0].id, payment_hash_with_lnurl_withdraw);
-    assert_eq!(retrieve_txs[0].metadata, Some(test_json.to_string()),);
-
-    // test open_channel_bolt11
-    storage.insert_open_channel_payment_info(
-        payment_hash_with_lnurl_withdraw,
-        150,
-        "original_invoice",
-    )?;
-
-    let open_channel_bolt11 = storage
-        .get_open_channel_bolt11_by_hash(payment_hash_with_lnurl_withdraw)?
-        .unwrap();
-    assert_eq!(open_channel_bolt11, "original_invoice");
-
-    let open_channel_bolt11 = storage.get_open_channel_bolt11_by_hash("non existing hash")?;
-    assert_eq!(open_channel_bolt11, None);
-
-    let retrieve_txs = storage.list_payments(ListPaymentsRequest {
-        filters: Some(vec![PaymentTypeFilter::Received]),
-        ..Default::default()
-    })?;
-
-    let filtered_txs: Vec<&Payment> = retrieve_txs
-        .iter()
-        .filter(|p| {
-            if let PaymentDetails::Ln { data } = &p.details {
-                return data.open_channel_bolt11 == Some("original_invoice".to_string());
-            }
-            false
-        })
-        .collect();
-
-    assert_eq!(filtered_txs.len(), 1);
-    assert_eq!(filtered_txs[0].id, payment_hash_with_lnurl_withdraw);
-    assert!(matches!(filtered_txs[0].details, PaymentDetails::Ln { .. }));
-    if let PaymentDetails::Ln { data } = &filtered_txs[0].details {
-        assert_eq!(
-            data.open_channel_bolt11,
-            Some("original_invoice".to_string())
+        //test only sent
+        let retrieve_txs = storage.list_payments(ListPaymentsRequest {
+            filters: Some(vec![
+                PaymentTypeFilter::Sent,
+                PaymentTypeFilter::ClosedChannel,
+            ]),
+            ..Default::default()
+        })?;
+        assert_eq!(retrieve_txs.len(), 3);
+        assert_eq!(retrieve_txs[0], txs[0]);
+        assert_eq!(retrieve_txs[1], txs[3]);
+        assert!(
+            matches!( &retrieve_txs[0].details, PaymentDetails::Ln {data: LnPaymentDetails {lnurl_success_action, ..}} if lnurl_success_action == &Some(sa))
         );
-    }
+        assert!(
+            matches!( &retrieve_txs[0].details, PaymentDetails::Ln {data: LnPaymentDetails {lnurl_pay_domain, ln_address, ..}} if lnurl_pay_domain.is_none() && ln_address == &Some(test_ln_address.to_string()))
+        );
+        assert!(
+            matches!( &retrieve_txs[2].details, PaymentDetails::Ln {data: LnPaymentDetails {lnurl_pay_domain, ln_address, ..}} if lnurl_pay_domain == &Some(test_lnurl_pay_domain.to_string()) && ln_address.is_none())
+        );
+        assert!(
+            matches!( &retrieve_txs[1].details, PaymentDetails::Ln {data: LnPaymentDetails {reverse_swap_info: rev_swap, ..}} if rev_swap == &Some(rev_swap_info))
+        );
 
-    Ok(())
+        //test only received
+        let retrieve_txs = storage.list_payments(ListPaymentsRequest {
+            filters: Some(vec![PaymentTypeFilter::Received]),
+            ..Default::default()
+        })?;
+        assert_eq!(retrieve_txs.len(), 2);
+        assert_eq!(retrieve_txs[0], txs[1]);
+        assert_eq!(retrieve_txs[1], txs[2]);
+        assert!(
+            matches!( &retrieve_txs[1].details, PaymentDetails::Ln {data: LnPaymentDetails {swap_info: swap, ..}} if swap == &Some(swap_info))
+        );
+
+        storage.insert_or_update_payments(&txs, false)?;
+        let retrieve_txs = storage.list_payments(ListPaymentsRequest::default())?;
+        assert_eq!(retrieve_txs.len(), 5);
+        assert_eq!(retrieve_txs, txs);
+
+        storage.insert_open_channel_payment_info("123", 150, "")?;
+        let retrieve_txs = storage.list_payments(ListPaymentsRequest::default())?;
+        assert_eq!(retrieve_txs[0].fee_msat, 50);
+
+        // test all with failures
+        let retrieve_txs = storage.list_payments(ListPaymentsRequest {
+            include_failures: Some(true),
+            ..Default::default()
+        })?;
+        assert_eq!(retrieve_txs.len(), 6);
+
+        // test sent with failures
+        let retrieve_txs = storage.list_payments(ListPaymentsRequest {
+            filters: Some(vec![
+                PaymentTypeFilter::Sent,
+                PaymentTypeFilter::ClosedChannel,
+            ]),
+            include_failures: Some(true),
+            ..Default::default()
+        })?;
+        assert_eq!(retrieve_txs.len(), 4);
+
+        // test limit
+        let retrieve_txs = storage.list_payments(ListPaymentsRequest {
+            include_failures: Some(false),
+            limit: Some(1),
+            ..Default::default()
+        })?;
+        assert_eq!(retrieve_txs.len(), 1);
+
+        // test offset
+        let retrieve_txs = storage.list_payments(ListPaymentsRequest {
+            include_failures: Some(false),
+            offset: Some(1),
+            limit: Some(1),
+            ..Default::default()
+        })?;
+        assert_eq!(retrieve_txs.len(), 1);
+        assert_eq!(retrieve_txs[0].id, payment_hash_with_lnurl_withdraw);
+
+        // test json metadata validation
+        assert!(storage
+            .set_payment_external_metadata(
+                payment_hash_with_lnurl_withdraw.to_string(),
+                r#"{ "malformed: true }"#.to_string()
+            )
+            .is_err());
+
+        // test metadata set and filter
+        let test_json = r#"{"supportsBoolean":true,"supportsInt":10,"supportsString":"supports string","supportsNested":{"value":[1,2]}}"#;
+        let test_json_filters = Some(vec![
+            MetadataFilter {
+                json_path: "supportsBoolean".to_string(),
+                json_value: "true".to_string(),
+            },
+            MetadataFilter {
+                json_path: "supportsInt".to_string(),
+                json_value: "10".to_string(),
+            },
+            MetadataFilter {
+                json_path: "supportsString".to_string(),
+                json_value: r#""supports string""#.to_string(),
+            },
+            MetadataFilter {
+                json_path: "supportsNested.value".to_string(),
+                json_value: "[1,2]".to_string(),
+            },
+        ]);
+
+        storage.set_payment_external_metadata(
+            payment_hash_with_lnurl_withdraw.to_string(),
+            test_json.to_string(),
+        )?;
+
+        let retrieve_txs = storage.list_payments(ListPaymentsRequest {
+            metadata_filters: test_json_filters,
+            ..Default::default()
+        })?;
+        assert_eq!(retrieve_txs.len(), 1);
+        assert_eq!(retrieve_txs[0].id, payment_hash_with_lnurl_withdraw);
+        assert_eq!(retrieve_txs[0].metadata, Some(test_json.to_string()),);
+
+        // test open_channel_bolt11
+        storage.insert_open_channel_payment_info(
+            payment_hash_with_lnurl_withdraw,
+            150,
+            "original_invoice",
+        )?;
+
+        let open_channel_bolt11 = storage
+            .get_open_channel_bolt11_by_hash(payment_hash_with_lnurl_withdraw)?
+            .unwrap();
+        assert_eq!(open_channel_bolt11, "original_invoice");
+
+        let open_channel_bolt11 = storage.get_open_channel_bolt11_by_hash("non existing hash")?;
+        assert_eq!(open_channel_bolt11, None);
+
+        let retrieve_txs = storage.list_payments(ListPaymentsRequest {
+            filters: Some(vec![PaymentTypeFilter::Received]),
+            ..Default::default()
+        })?;
+
+        let filtered_txs: Vec<&Payment> = retrieve_txs
+            .iter()
+            .filter(|p| {
+                if let PaymentDetails::Ln { data } = &p.details {
+                    return data.open_channel_bolt11 == Some("original_invoice".to_string());
+                }
+                false
+            })
+            .collect();
+
+        assert_eq!(filtered_txs.len(), 1);
+        assert_eq!(filtered_txs[0].id, payment_hash_with_lnurl_withdraw);
+        assert!(matches!(filtered_txs[0].details, PaymentDetails::Ln { .. }));
+        if let PaymentDetails::Ln { data } = &filtered_txs[0].details {
+            assert_eq!(
+                data.open_channel_bolt11,
+                Some("original_invoice".to_string())
+            );
+        }
+
+        Ok(())
+    }
 }

--- a/libs/sdk-core/src/persist/transactions.rs
+++ b/libs/sdk-core/src/persist/transactions.rs
@@ -317,6 +317,7 @@ impl SqliteStorage {
     }
 
     /// Look up a modified open channel bolt11 by hash.
+    #[allow(unused)]
     pub(crate) fn get_open_channel_bolt11_by_hash(
         &self,
         hash: &str,
@@ -804,7 +805,7 @@ fn test_ln_transactions() -> PersistResult<(), Box<dyn std::error::Error>> {
             attempted_error: None,
         },
     )?;
-    storage.insert_swap(swap_info.clone())?;
+    storage.insert_swap(&swap_info)?;
     storage.update_swap_bolt11(
         swap_info.bitcoin_address.clone(),
         swap_info.bolt11.clone().unwrap(),

--- a/libs/sdk-core/src/swap_in/error.rs
+++ b/libs/sdk-core/src/swap_in/error.rs
@@ -2,7 +2,7 @@ use std::time::SystemTimeError;
 
 use gl_client::{bitcoin, lightning_invoice::ParseOrSemanticError};
 use hex::FromHexError;
-use secp256k1::musig::MusigSignError;
+use secp256k1::musig::{MusigSignError, MusigTweakErr};
 use thiserror::Error;
 
 use crate::{
@@ -154,6 +154,18 @@ impl From<GetPaymentRequestError> for ReceiveSwapError {
 impl From<FromHexError> for ReceiveSwapError {
     fn from(_value: FromHexError) -> Self {
         Self::generic("could not convert from hex")
+    }
+}
+
+impl From<MusigTweakErr> for ReceiveSwapError {
+    fn from(value: MusigTweakErr) -> Self {
+        ReceiveSwapError::Taproot(value.to_string())
+    }
+}
+
+impl From<secp256k1::scalar::OutOfRangeError> for ReceiveSwapError {
+    fn from(value: secp256k1::scalar::OutOfRangeError) -> Self {
+        ReceiveSwapError::Taproot(value.to_string())
     }
 }
 

--- a/libs/sdk-core/src/swap_in/error.rs
+++ b/libs/sdk-core/src/swap_in/error.rs
@@ -221,3 +221,9 @@ impl From<anyhow::Error> for GetPaymentRequestError {
         Self::Generic(e.to_string())
     }
 }
+
+impl From<PersistError> for GetPaymentRequestError {
+    fn from(e: PersistError) -> Self {
+        Self::Generic(e.to_string())
+    }
+}

--- a/libs/sdk-core/src/swap_in/error.rs
+++ b/libs/sdk-core/src/swap_in/error.rs
@@ -21,6 +21,8 @@ pub enum ReceiveSwapError {
     NodeStateNotFound,
     #[error("No utxos found")]
     NoUtxos,
+    #[error("Utxos are still timelocked")]
+    UtxosTimelocked,
     #[error("Payment error: {0}")]
     PaymentError(String),
     #[error("Swap not found: {0}")]

--- a/libs/sdk-core/src/swap_in/error.rs
+++ b/libs/sdk-core/src/swap_in/error.rs
@@ -1,49 +1,209 @@
-use crate::{error::SdkError, persist::error::PersistError};
+use std::time::SystemTimeError;
 
-pub type SwapResult<T, E = SwapError> = Result<T, E>;
+use gl_client::{bitcoin, lightning_invoice::ParseOrSemanticError};
+use hex::FromHexError;
+use secp256k1::musig::MusigSignError;
+use thiserror::Error;
 
-#[derive(Debug, thiserror::Error)]
-pub enum SwapError {
+use crate::{
+    error::{ReceivePaymentError, SdkError},
+    node_api::NodeError,
+    persist::error::PersistError,
+};
+
+#[derive(Debug, Error)]
+pub enum ReceiveSwapError {
     #[error("{0}")]
     Generic(String),
-
-    #[error(transparent)]
-    Persistance(#[from] PersistError),
-
-    #[error("{0}")]
+    #[error("Invalid address type")]
+    InvalidAddressType,
+    #[error("Node state not found")]
+    NodeStateNotFound,
+    #[error("No utxos found")]
+    NoUtxos,
+    #[error("Payment error: {0}")]
+    PaymentError(String),
+    #[error("Swap not found: {0}")]
+    SwapNotFound(String),
+    #[error("Output value for refund would be below dust")]
+    OutputValueBelowDust,
+    #[error("Persist error: {0}")]
+    Persist(PersistError),
+    #[error("Service connectivity error: {0}")]
     ServiceConnectivity(String),
-
-    #[error("{0}")]
+    #[error("Missing opening fee params")]
+    MissingOpeningFeeParams,
+    #[error("Taproot error: {0}")]
+    Taproot(String),
+    #[error("Unsupported swap limits: {0}")]
     UnsupportedSwapLimits(String),
 }
 
-impl SwapError {
-    pub(crate) fn generic(err: &str) -> Self {
-        Self::Generic(err.to_string())
+impl ReceiveSwapError {
+    pub fn generic(msg: impl Into<String>) -> Self {
+        Self::Generic(msg.into())
     }
 
-    pub(crate) fn unsupported_swap_limits(err: &str) -> Self {
-        Self::UnsupportedSwapLimits(err.to_string())
+    pub fn unsupported_swap_limits(msg: impl Into<String>) -> Self {
+        Self::UnsupportedSwapLimits(msg.into())
+    }
+}
+pub type ReceiveSwapResult<T, E = ReceiveSwapError> = Result<T, E>;
+
+impl From<bitcoin::hashes::hex::Error> for ReceiveSwapError {
+    fn from(e: bitcoin::hashes::hex::Error) -> Self {
+        Self::Generic(e.to_string())
     }
 }
 
-impl From<anyhow::Error> for SwapError {
-    fn from(err: anyhow::Error) -> Self {
-        Self::Generic(err.to_string())
+impl From<bitcoin::util::address::Error> for ReceiveSwapError {
+    fn from(e: bitcoin::util::address::Error) -> Self {
+        Self::Generic(e.to_string())
     }
 }
 
-impl From<SdkError> for SwapError {
-    fn from(value: SdkError) -> Self {
-        match value {
-            SdkError::Generic { err } => Self::Generic(err),
-            SdkError::ServiceConnectivity { err } => Self::ServiceConnectivity(err),
+impl From<PersistError> for ReceiveSwapError {
+    fn from(e: PersistError) -> Self {
+        Self::Persist(e)
+    }
+}
+
+impl From<SdkError> for ReceiveSwapError {
+    fn from(e: SdkError) -> Self {
+        match e {
+            SdkError::Generic { err } => ReceiveSwapError::Generic(err),
+            SdkError::ServiceConnectivity { err } => ReceiveSwapError::ServiceConnectivity(err),
         }
     }
 }
 
-impl From<tonic::Status> for SwapError {
-    fn from(status: tonic::Status) -> Self {
-        Self::Generic(sdk_common::tonic_wrap::Status(status).to_string())
+impl From<bitcoin::util::sighash::Error> for ReceiveSwapError {
+    fn from(e: bitcoin::util::sighash::Error) -> Self {
+        Self::Generic(e.to_string())
+    }
+}
+
+impl From<secp256k1::musig::ParseError> for ReceiveSwapError {
+    fn from(e: secp256k1::musig::ParseError) -> Self {
+        Self::Taproot(e.to_string())
+    }
+}
+
+impl From<MusigSignError> for ReceiveSwapError {
+    fn from(e: MusigSignError) -> Self {
+        Self::Taproot(e.to_string())
+    }
+}
+
+impl From<secp256k1::Error> for ReceiveSwapError {
+    fn from(e: secp256k1::Error) -> Self {
+        Self::Taproot(e.to_string())
+    }
+}
+
+impl From<bitcoin::secp256k1::Error> for ReceiveSwapError {
+    fn from(e: bitcoin::secp256k1::Error) -> Self {
+        Self::Taproot(e.to_string())
+    }
+}
+
+impl From<bitcoin::util::taproot::TaprootBuilderError> for ReceiveSwapError {
+    fn from(e: bitcoin::util::taproot::TaprootBuilderError) -> Self {
+        Self::Taproot(e.to_string())
+    }
+}
+
+impl From<bitcoin::util::taproot::TaprootBuilder> for ReceiveSwapError {
+    fn from(_e: bitcoin::util::taproot::TaprootBuilder) -> Self {
+        Self::Taproot("Could not finalize taproot spend info".to_string())
+    }
+}
+
+impl From<anyhow::Error> for ReceiveSwapError {
+    fn from(e: anyhow::Error) -> Self {
+        Self::Generic(e.to_string())
+    }
+}
+
+impl From<SystemTimeError> for ReceiveSwapError {
+    fn from(e: SystemTimeError) -> Self {
+        Self::Generic(e.to_string())
+    }
+}
+
+impl From<GetPaymentRequestError> for ReceiveSwapError {
+    fn from(value: GetPaymentRequestError) -> Self {
+        match value {
+            GetPaymentRequestError::NeedsNewFeeParams => {
+                ReceiveSwapError::generic("Opening fee params are no longer valid")
+            }
+            GetPaymentRequestError::InvoiceAlreadyExists => {
+                ReceiveSwapError::generic("Failed to create invoice. Invoice already exists")
+            }
+            GetPaymentRequestError::ServiceConnectivity(msg) => {
+                ReceiveSwapError::ServiceConnectivity(msg)
+            }
+            GetPaymentRequestError::Generic(msg) => ReceiveSwapError::Generic(msg),
+            GetPaymentRequestError::MissingOpeningFeeParams => {
+                ReceiveSwapError::MissingOpeningFeeParams
+            }
+        }
+    }
+}
+
+impl From<FromHexError> for ReceiveSwapError {
+    fn from(_value: FromHexError) -> Self {
+        Self::generic("could not convert from hex")
+    }
+}
+
+#[derive(Clone, Debug, Error)]
+pub(super) enum GetPaymentRequestError {
+    #[error("Needs new fee params")]
+    NeedsNewFeeParams,
+    #[error("Invoice already exists")]
+    InvoiceAlreadyExists,
+    #[error("Service connectivity error: {0}")]
+    ServiceConnectivity(String),
+    #[error("{0}")]
+    Generic(String),
+    #[error("Missing opening fee params")]
+    MissingOpeningFeeParams,
+}
+impl GetPaymentRequestError {
+    pub fn generic(msg: impl Into<String>) -> Self {
+        Self::Generic(msg.into())
+    }
+}
+
+impl From<ParseOrSemanticError> for GetPaymentRequestError {
+    fn from(e: ParseOrSemanticError) -> Self {
+        Self::Generic(e.to_string())
+    }
+}
+
+impl From<NodeError> for GetPaymentRequestError {
+    fn from(e: NodeError) -> Self {
+        Self::Generic(e.to_string())
+    }
+}
+
+impl From<ReceivePaymentError> for GetPaymentRequestError {
+    fn from(e: ReceivePaymentError) -> Self {
+        match e {
+            ReceivePaymentError::InvoicePreimageAlreadyExists { err: _ } => {
+                GetPaymentRequestError::InvoiceAlreadyExists
+            }
+            ReceivePaymentError::ServiceConnectivity { err } => {
+                GetPaymentRequestError::ServiceConnectivity(err)
+            }
+            _ => GetPaymentRequestError::Generic(e.to_string()),
+        }
+    }
+}
+
+impl From<anyhow::Error> for GetPaymentRequestError {
+    fn from(e: anyhow::Error) -> Self {
+        Self::Generic(e.to_string())
     }
 }

--- a/libs/sdk-core/src/swap_in/mod.rs
+++ b/libs/sdk-core/src/swap_in/mod.rs
@@ -1,2 +1,5 @@
 pub(crate) mod error;
 pub(crate) mod swap;
+pub(crate) mod taproot_server;
+
+pub(crate) use taproot_server::TaprootSwapperAPI;

--- a/libs/sdk-core/src/swap_in/mod.rs
+++ b/libs/sdk-core/src/swap_in/mod.rs
@@ -1,5 +1,10 @@
-pub(crate) mod error;
-pub(crate) mod swap;
-pub(crate) mod taproot_server;
+mod error;
+mod segwit;
+mod segwit_server;
+mod swap;
+mod taproot;
+mod taproot_server;
 
+pub(crate) use error::ReceiveSwapError;
+pub(crate) use swap::{create_swap_keys, BTCReceiveSwap, SwapChainData, SwapChainInfo};
 pub(crate) use taproot_server::TaprootSwapperAPI;

--- a/libs/sdk-core/src/swap_in/mod.rs
+++ b/libs/sdk-core/src/swap_in/mod.rs
@@ -6,5 +6,7 @@ mod taproot;
 mod taproot_server;
 
 pub(crate) use error::ReceiveSwapError;
-pub(crate) use swap::{create_swap_keys, BTCReceiveSwap, SwapChainData, SwapChainInfo};
+pub(crate) use swap::{
+    create_swap_keys, BTCReceiveSwap, BTCReceiveSwapParameters, SwapChainData, SwapChainInfo,
+};
 pub(crate) use taproot_server::TaprootSwapperAPI;

--- a/libs/sdk-core/src/swap_in/segwit.rs
+++ b/libs/sdk-core/src/swap_in/segwit.rs
@@ -141,7 +141,7 @@ impl SegwitReceiveSwap {
         Ok(tx)
     }
 
-    pub async fn get_swap_payment(&self, payment_request: String) -> ReceiveSwapResult<()> {
+    pub async fn payout_swap(&self, payment_request: String) -> ReceiveSwapResult<()> {
         self.swapper_api
             .complete_swap(payment_request)
             .await

--- a/libs/sdk-core/src/swap_in/segwit.rs
+++ b/libs/sdk-core/src/swap_in/segwit.rs
@@ -1,0 +1,178 @@
+use std::sync::Arc;
+
+use gl_client::bitcoin::{
+    blockdata::{opcodes, script::Builder},
+    consensus::serialize,
+    secp256k1::{Message, Secp256k1, SecretKey},
+    util::sighash::SighashCache,
+    Address, EcdsaSighashType, PackedLockTime, Script, Transaction, TxIn, TxOut, Witness,
+};
+use ripemd::{Digest, Ripemd160};
+
+use crate::{SwapInfo, SwapperAPI};
+
+use super::{
+    error::{ReceiveSwapError, ReceiveSwapResult},
+    swap::{compute_tx_fee, SwapOutput},
+};
+
+pub(super) struct SegwitReceiveSwap {
+    swapper_api: Arc<dyn SwapperAPI>,
+}
+
+impl SegwitReceiveSwap {
+    pub fn new(swapper_api: Arc<dyn SwapperAPI>) -> Self {
+        Self { swapper_api }
+    }
+
+    pub fn payout_blocks_left(
+        &self,
+        swap_info: &SwapInfo,
+        min_confirmation: u32,
+        current_tip: u32,
+    ) -> u32 {
+        let confirmations = current_tip.saturating_sub(min_confirmation);
+        (swap_info.lock_height as u32).saturating_sub(confirmations)
+    }
+
+    pub fn create_fake_refund_tx(
+        &self,
+        _swap_info: &SwapInfo,
+        utxos: &[SwapOutput],
+        destination_address: &Address,
+    ) -> ReceiveSwapResult<Transaction> {
+        Ok(Transaction {
+            version: 2,
+            lock_time: PackedLockTime::ZERO,
+            input: utxos
+                .iter()
+                .map(|utxo| {
+                    Ok(TxIn {
+                        witness: Witness::from_vec(vec![
+                            [1; 73].to_vec(),
+                            Vec::new(),
+                            [1; 100].to_vec(),
+                        ]),
+                        ..utxo.try_into()?
+                    })
+                })
+                .collect::<Result<_, ReceiveSwapError>>()?,
+            output: vec![TxOut {
+                value: 0,
+                script_pubkey: destination_address.script_pubkey(),
+            }],
+        })
+    }
+
+    pub fn create_refund_tx(
+        &self,
+        swap_info: &SwapInfo,
+        utxos: &[SwapOutput],
+        destination_address: &Address,
+        sat_per_vbyte: u32,
+    ) -> ReceiveSwapResult<Transaction> {
+        let weight = self
+            .create_fake_refund_tx(swap_info, utxos, destination_address)?
+            .weight();
+        let fee = compute_tx_fee(weight, sat_per_vbyte);
+        let value: u64 = utxos
+            .iter()
+            .map(|utxo| utxo.amount_sat)
+            .sum::<u64>()
+            .saturating_sub(fee);
+        if value == 0 {
+            return Err(ReceiveSwapError::OutputValueBelowDust);
+        }
+
+        let lock_time = utxos.iter().fold(0, |accum, item| {
+            let confirmed_height = item.confirmed_at_height.unwrap_or(0);
+            if accum >= confirmed_height + (swap_info.lock_height as u32) {
+                accum
+            } else {
+                confirmed_height + (swap_info.lock_height as u32)
+            }
+        });
+
+        let input_script = create_submarine_swap_script(
+            &swap_info.payment_hash,
+            &swap_info.swapper_public_key,
+            &swap_info.public_key,
+            swap_info.lock_height,
+        )?;
+
+        let mut tx = Transaction {
+            version: 2,
+            lock_time: PackedLockTime(lock_time),
+            input: utxos
+                .iter()
+                .map(|utxo| utxo.try_into())
+                .collect::<Result<_, _>>()?,
+            output: vec![TxOut {
+                value,
+                script_pubkey: destination_address.script_pubkey(),
+            }],
+        };
+
+        let scpt = Secp256k1::signing_only();
+        let cloned_tx = tx.clone();
+        let mut signer = SighashCache::new(&cloned_tx);
+        for (input_index, input) in tx.input.iter_mut().enumerate() {
+            let sig = signer.segwit_signature_hash(
+                input_index,
+                &input_script,
+                utxos[input_index].amount_sat,
+                EcdsaSighashType::All,
+            )?;
+            let msg = Message::from_slice(&sig[..])?;
+            let secret_key = SecretKey::from_slice(&swap_info.private_key)?;
+            let sig = scpt.sign_ecdsa(&msg, &secret_key);
+
+            let mut sigvec = sig.serialize_der().to_vec();
+            sigvec.push(EcdsaSighashType::All as u8);
+
+            let witness: Vec<Vec<u8>> = vec![sigvec, vec![], serialize(&input_script)];
+
+            let w = Witness::from_vec(witness);
+            input.witness = w;
+        }
+
+        Ok(tx)
+    }
+
+    pub async fn get_swap_payment(
+        &self,
+        _swap_info: &SwapInfo,
+        payment_request: String,
+    ) -> ReceiveSwapResult<()> {
+        self.swapper_api
+            .complete_swap(payment_request)
+            .await
+            .map_err(|e| ReceiveSwapError::PaymentError(e.to_string()))
+    }
+}
+
+fn create_submarine_swap_script(
+    payment_hash: &[u8],
+    swapper_pub_key: &[u8],
+    payer_pub_key: &[u8],
+    lock_height: i64,
+) -> anyhow::Result<Script> {
+    let mut hasher = Ripemd160::new();
+    hasher.update(payment_hash);
+    let result = hasher.finalize();
+
+    Ok(Builder::new()
+        .push_opcode(opcodes::all::OP_HASH160)
+        .push_slice(&result)
+        .push_opcode(opcodes::all::OP_EQUAL)
+        .push_opcode(opcodes::all::OP_IF)
+        .push_slice(swapper_pub_key)
+        .push_opcode(opcodes::all::OP_ELSE)
+        .push_int(lock_height)
+        .push_opcode(opcodes::all::OP_CSV)
+        .push_opcode(opcodes::all::OP_DROP)
+        .push_slice(payer_pub_key)
+        .push_opcode(opcodes::all::OP_ENDIF)
+        .push_opcode(opcodes::all::OP_CHECKSIG)
+        .into_script())
+}

--- a/libs/sdk-core/src/swap_in/segwit.rs
+++ b/libs/sdk-core/src/swap_in/segwit.rs
@@ -40,7 +40,6 @@ impl SegwitReceiveSwap {
 
     pub fn create_fake_refund_tx(
         &self,
-        _swap_info: &SwapInfo,
         utxos: &[SwapOutput],
         destination_address: &Address,
     ) -> ReceiveSwapResult<Transaction> {
@@ -75,7 +74,7 @@ impl SegwitReceiveSwap {
         sat_per_vbyte: u32,
     ) -> ReceiveSwapResult<Transaction> {
         let weight = self
-            .create_fake_refund_tx(swap_info, utxos, destination_address)?
+            .create_fake_refund_tx(utxos, destination_address)?
             .weight();
         let fee = compute_tx_fee(weight, sat_per_vbyte);
         let value: u64 = utxos

--- a/libs/sdk-core/src/swap_in/segwit.rs
+++ b/libs/sdk-core/src/swap_in/segwit.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use gl_client::bitcoin::{
     blockdata::{opcodes, script::Builder},
-    consensus::serialize,
     secp256k1::{Message, Secp256k1, SecretKey},
     util::sighash::SighashCache,
     Address, EcdsaSighashType, PackedLockTime, Script, Sequence, Transaction, TxIn, TxOut, Witness,
@@ -137,7 +136,7 @@ impl SegwitReceiveSwap {
             let mut sigvec = sig.serialize_der().to_vec();
             sigvec.push(EcdsaSighashType::All as u8);
 
-            let witness: Vec<Vec<u8>> = vec![sigvec, vec![], serialize(&input_script)];
+            let witness: Vec<Vec<u8>> = vec![sigvec, vec![], input_script.to_bytes()];
 
             let w = Witness::from_vec(witness);
             input.witness = w;

--- a/libs/sdk-core/src/swap_in/segwit.rs
+++ b/libs/sdk-core/src/swap_in/segwit.rs
@@ -16,6 +16,9 @@ use super::{
     swap::{compute_tx_fee, SwapOutput},
 };
 
+const MAX_ECDSA_SIGNATURE_SIZE: usize = 73;
+const SEGWIT_SWAP_SCRIPT_SIZE: usize = 100;
+
 pub(super) struct SegwitReceiveSwap {
     swapper_api: Arc<dyn SwapperAPI>,
 }
@@ -49,9 +52,9 @@ impl SegwitReceiveSwap {
                 .map(|utxo| {
                     Ok(TxIn {
                         witness: Witness::from_vec(vec![
-                            [1; 73].to_vec(),
+                            [1; MAX_ECDSA_SIGNATURE_SIZE].to_vec(),
                             Vec::new(),
-                            [1; 100].to_vec(),
+                            [1; SEGWIT_SWAP_SCRIPT_SIZE].to_vec(),
                         ]),
                         ..utxo.try_into()?
                     })

--- a/libs/sdk-core/src/swap_in/segwit.rs
+++ b/libs/sdk-core/src/swap_in/segwit.rs
@@ -17,7 +17,7 @@ use super::{
 };
 
 const MAX_ECDSA_SIGNATURE_SIZE: usize = 73;
-const SEGWIT_SWAP_SCRIPT_SIZE: usize = 100;
+const SEGWIT_SWAP_SCRIPT_SIZE: usize = 101;
 
 pub(super) struct SegwitReceiveSwap {
     swapper_api: Arc<dyn SwapperAPI>,

--- a/libs/sdk-core/src/swap_in/segwit.rs
+++ b/libs/sdk-core/src/swap_in/segwit.rs
@@ -142,11 +142,7 @@ impl SegwitReceiveSwap {
         Ok(tx)
     }
 
-    pub async fn get_swap_payment(
-        &self,
-        _swap_info: &SwapInfo,
-        payment_request: String,
-    ) -> ReceiveSwapResult<()> {
+    pub async fn get_swap_payment(&self, payment_request: String) -> ReceiveSwapResult<()> {
         self.swapper_api
             .complete_swap(payment_request)
             .await

--- a/libs/sdk-core/src/swap_in/segwit_server.rs
+++ b/libs/sdk-core/src/swap_in/segwit_server.rs
@@ -2,6 +2,7 @@ use sdk_common::{grpc::GetSwapPaymentRequest, prelude::BreezServer, with_connect
 
 use crate::SwapperAPI;
 
+#[cfg_attr(test, mockall::automock)]
 #[tonic::async_trait]
 impl SwapperAPI for BreezServer {
     async fn complete_swap(&self, bolt11: String) -> anyhow::Result<()> {

--- a/libs/sdk-core/src/swap_in/segwit_server.rs
+++ b/libs/sdk-core/src/swap_in/segwit_server.rs
@@ -1,0 +1,21 @@
+use sdk_common::{grpc::GetSwapPaymentRequest, prelude::BreezServer, with_connection_retry};
+
+use crate::SwapperAPI;
+
+#[tonic::async_trait]
+impl SwapperAPI for BreezServer {
+    async fn complete_swap(&self, bolt11: String) -> anyhow::Result<()> {
+        let mut client = self.get_swapper_client().await;
+        let req = GetSwapPaymentRequest {
+            payment_request: bolt11,
+        };
+        let resp = with_connection_retry!(client.get_swap_payment(req.clone()))
+            .await?
+            .into_inner();
+
+        match resp.swap_error() {
+            crate::grpc::get_swap_payment_reply::SwapError::NoError => Ok(()),
+            err => Err(anyhow::anyhow!(err.as_str_name())),
+        }
+    }
+}

--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -96,7 +96,14 @@ impl SwapChainData {
     pub fn utxos(&self) -> Vec<SwapOutput> {
         self.outputs
             .iter()
-            .filter(|o| o.spend.is_none())
+            .filter(|o| {
+                let spend = match &o.spend {
+                    Some(spend) => spend,
+                    None => return true,
+                };
+
+                spend.confirmed_at_height.is_none()
+            })
             .cloned()
             .collect()
     }

--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -666,6 +666,12 @@ impl BTCReceiveSwap {
             return SwapStatus::Completed;
         }
 
+        // If there are utxos, but they all have unconfirmed spends, they are refundable.
+        // If the spends were confirmed, they wouldn't be utxos at all.
+        if chain_data.utxos().iter().all(|utxo| utxo.spend.is_some()) {
+            return SwapStatus::Refundable;
+        }
+
         let payout_blocks_left = match address_type {
             SwapAddressType::Segwit => {
                 self.segwit
@@ -1225,8 +1231,9 @@ mod tests {
             transactions::MockCompletedPaymentStorage,
         },
         swap_in::{
-            swap::SwapOutput, taproot_server::MockTaprootSwapperAPI, BTCReceiveSwap,
-            BTCReceiveSwapParameters,
+            swap::{SwapOutput, SwapSpend},
+            taproot_server::MockTaprootSwapperAPI,
+            BTCReceiveSwap, BTCReceiveSwapParameters,
         },
         test_utils::{
             MockBreezServer, MockChainService, MockNodeAPI, MockReceiver, MockSwapperAPI,
@@ -1647,5 +1654,57 @@ mod tests {
         )
         .await;
         assert_eq!(result.status, SwapStatus::Refundable);
+
+        let result = test_swap_state_transition(
+            &swap,
+            &SwapChainData {
+                outputs: vec![SwapOutput {
+                    address: swap.bitcoin_address.clone(),
+                    tx_id: "tx1".to_string(),
+                    output_index: 0,
+                    amount_sat: 1_000_000,
+                    confirmed_at_height: Some(1),
+                    spend: Some(SwapSpend {
+                        confirmed_at_height: None,
+                        block_hash: None,
+                        tx_id: "tx1".to_string(),
+                        output_index: 0,
+                        spending_tx_id: "tx2".to_string(),
+                        spending_input_index: 0,
+                    }),
+                    ..Default::default()
+                }],
+            },
+            None,
+            1,
+        )
+        .await;
+        assert_eq!(result.status, SwapStatus::Refundable);
+
+        let result = test_swap_state_transition(
+            &swap,
+            &SwapChainData {
+                outputs: vec![SwapOutput {
+                    address: swap.bitcoin_address.clone(),
+                    tx_id: "tx1".to_string(),
+                    output_index: 0,
+                    amount_sat: 1_000_000,
+                    confirmed_at_height: Some(1),
+                    spend: Some(SwapSpend {
+                        confirmed_at_height: Some(1),
+                        block_hash: Some("hash".to_string()),
+                        tx_id: "tx1".to_string(),
+                        output_index: 0,
+                        spending_tx_id: "tx2".to_string(),
+                        spending_input_index: 0,
+                    }),
+                    ..Default::default()
+                }],
+            },
+            None,
+            1,
+        )
+        .await;
+        assert_eq!(result.status, SwapStatus::Completed);
     }
 }

--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -87,10 +87,9 @@ pub(crate) struct SwapChainData {
 
 impl SwapChainData {
     pub fn confirmed_utxos(&self) -> Vec<SwapOutput> {
-        self.outputs
-            .iter()
-            .filter(|o| o.spend.is_none() && o.confirmed_at_height.is_some())
-            .cloned()
+        self.utxos()
+            .into_iter()
+            .filter(|u| u.confirmed_at_height.is_some())
             .collect()
     }
 

--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -404,6 +404,7 @@ impl BTCReceiveSwap {
         &self,
         req: PrepareRefundRequest,
     ) -> ReceiveSwapResult<PrepareRefundResponse> {
+        let current_tip = self.chain_service.current_tip().await?;
         let address_type = parse_address(&req.swap_address)?;
         let swap_info = self
             .swap_storage
@@ -422,7 +423,7 @@ impl BTCReceiveSwap {
             }
         };
 
-        let mut utxos: Vec<_> = chain_data.confirmed_utxos();
+        let mut utxos = refundable_utxos(&swap_info, &chain_data, current_tip, &address_type);
         if utxos.is_empty() {
             return Err(ReceiveSwapError::NoUtxos);
         }

--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -446,12 +446,10 @@ impl BTCReceiveSwap {
             },
         }?;
 
-        let weight = tx.weight() as u32;
-        let fee = (weight as u64)
-            .saturating_mul(req.sat_per_vbyte as u64)
-            .saturating_mul(WITNESS_SCALE_FACTOR as u64);
+        let weight = tx.weight();
+        let fee = compute_tx_fee(weight, req.sat_per_vbyte);
         Ok(PrepareRefundResponse {
-            refund_tx_weight: weight,
+            refund_tx_weight: weight as u32,
             refund_tx_fee_sat: fee,
         })
     }

--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -1,191 +1,226 @@
-use std::str::FromStr;
-use std::sync::{Arc, Mutex};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::{collections::HashMap, sync::Arc};
 
-use anyhow::{anyhow, Result};
+use gl_client::{
+    bitcoin::{
+        blockdata::constants::WITNESS_SCALE_FACTOR,
+        consensus::encode,
+        hashes::sha256,
+        secp256k1::{Message, PublicKey, Secp256k1, SecretKey},
+        Address, AddressType, Network, OutPoint, Script, Sequence, TxIn, Witness,
+    },
+    lightning_invoice::Bolt11Invoice,
+};
 use rand::Rng;
-use ripemd::{Digest, Ripemd160};
-use sdk_common::grpc::{AddFundInitRequest, GetSwapPaymentRequest};
-use sdk_common::prelude::BreezServer;
-use sdk_common::with_connection_retry;
-use tokio::sync::broadcast;
+use sdk_common::ensure_sdk;
+use serde::{Deserialize, Serialize};
+use tokio::sync::{broadcast, Mutex};
 
-use crate::bitcoin::blockdata::constants::WITNESS_SCALE_FACTOR;
-use crate::bitcoin::blockdata::opcodes;
-use crate::bitcoin::blockdata::script::Builder;
-use crate::bitcoin::consensus::encode;
-use crate::bitcoin::hashes::sha256;
-use crate::bitcoin::psbt::serialize::Serialize;
-use crate::bitcoin::secp256k1::{Message, PublicKey, Secp256k1, SecretKey};
-use crate::bitcoin::util::sighash::SighashCache;
-use crate::bitcoin::{
-    Address, EcdsaSighashType, Script, Sequence, Transaction, TxIn, TxOut, Witness,
-};
-use crate::breez_services::{BreezEvent, OpenChannelParams, Receiver};
-use crate::chain::{get_total_incoming_txs, get_utxos, AddressUtxos, ChainService};
-use crate::error::ReceivePaymentError;
-use crate::models::{Swap, SwapInfo, SwapStatus, SwapperAPI};
-use crate::node_api::NodeAPI;
-use crate::persist::error::PersistResult;
-use crate::persist::swap::SwapChainInfo;
-use crate::swap_in::error::SwapError;
-use crate::ListSwapsRequest;
 use crate::{
-    models::OpeningFeeParams, PrepareRefundRequest, PrepareRefundResponse, ReceivePaymentRequest,
-    RefundRequest, RefundResponse, SWAP_PAYMENT_FEE_EXPIRY_SECONDS,
+    breez_services::{OpenChannelParams, Receiver},
+    chain::ChainService,
+    error::ReceivePaymentError,
+    node_api::{FetchBolt11Result, NodeAPI},
+    persist::{db::SqliteStorage, error::PersistResult},
+    BreezEvent, ListSwapsRequest, OpeningFeeParams, PrepareRefundRequest, PrepareRefundResponse,
+    ReceivePaymentRequest, RefundRequest, RefundResponse, SwapInfo, SwapStatus, SwapperAPI,
 };
 
-use super::error::SwapResult;
+use super::{
+    error::{GetPaymentRequestError, ReceiveSwapError, ReceiveSwapResult},
+    segwit::SegwitReceiveSwap,
+    taproot::TaprootReceiveSwap,
+    TaprootSwapperAPI,
+};
 
-#[tonic::async_trait]
-impl SwapperAPI for BreezServer {
-    async fn create_swap(
-        &self,
-        hash: Vec<u8>,
-        payer_pubkey: Vec<u8>,
-        node_id: String,
-    ) -> SwapResult<Swap> {
-        let mut client = self.get_swapper_client().await;
+const EXPIRY_SECONDS_PER_BLOCK: u32 = 600;
+const MIN_INVOICE_EXPIRY_SECONDS: u64 = 1800;
+const MIN_OPENING_FEE_PARAMS_VALIDITY_SECONDS: u32 = 1800;
 
-        let req = AddFundInitRequest {
-            hash: hash.clone(),
-            pubkey: payer_pubkey.clone(),
-            node_id,
-            notification_token: "".to_string(),
-            version: 1,
-        };
+pub(crate) fn create_swap_keys() -> anyhow::Result<SwapKeys> {
+    let priv_key = rand::thread_rng().gen::<[u8; 32]>().to_vec();
+    let preimage = rand::thread_rng().gen::<[u8; 32]>().to_vec();
+    Ok(SwapKeys { priv_key, preimage })
+}
 
-        let result = with_connection_retry!(client.add_fund_init(req.clone()))
-            .await?
-            .into_inner();
-        Ok(Swap {
-            bitcoin_address: result.address,
-            swapper_pubkey: result.pubkey,
-            lock_height: result.lock_height,
-            swapper_min_payable: result.min_allowed_deposit,
-            swapper_max_payable: result.max_allowed_deposit,
-            error_message: result.error_message,
-            required_reserve: result.required_reserve,
-        })
+pub(crate) struct SwapKeys {
+    pub(crate) priv_key: Vec<u8>,
+    pub(crate) preimage: Vec<u8>,
+}
+
+impl SwapKeys {
+    pub(crate) fn secret_key(&self) -> anyhow::Result<SecretKey> {
+        Ok(SecretKey::from_slice(&self.priv_key)?)
     }
 
-    async fn complete_swap(&self, bolt11: String) -> Result<()> {
-        let mut client = self.get_swapper_client().await;
-        let req = GetSwapPaymentRequest {
-            payment_request: bolt11,
-        };
-        let resp = with_connection_retry!(client.get_swap_payment(req.clone()))
-            .await?
-            .into_inner();
+    pub(crate) fn public_key(&self) -> anyhow::Result<PublicKey> {
+        Ok(PublicKey::from_secret_key(
+            &Secp256k1::new(),
+            &self.secret_key()?,
+        ))
+    }
 
-        match resp.swap_error() {
-            crate::grpc::get_swap_payment_reply::SwapError::NoError => Ok(()),
-            err => Err(anyhow!("Failed to complete swap: {}", err.as_str_name())),
+    pub(crate) fn preimage_hash_bytes(&self) -> Vec<u8> {
+        Message::from_hashed_data::<sha256::Hash>(&self.preimage[..])
+            .as_ref()
+            .to_vec()
+    }
+}
+
+enum SwapAddressType {
+    Segwit,
+    Taproot,
+}
+
+#[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct SwapChainData {
+    pub outputs: Vec<SwapOutput>,
+}
+
+impl SwapChainData {
+    pub fn confirmed_utxos(&self) -> Vec<SwapOutput> {
+        self.outputs
+            .iter()
+            .filter(|o| o.spend.is_none() && o.confirmed_at_height.is_some())
+            .cloned()
+            .collect()
+    }
+
+    pub fn utxos(&self) -> Vec<SwapOutput> {
+        self.outputs
+            .iter()
+            .filter(|o| o.spend.is_none())
+            .cloned()
+            .collect()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct SwapOutput {
+    pub address: String,
+    pub amount_sat: u64,
+    pub tx_id: String,
+    pub output_index: u32,
+    pub confirmed_at_height: Option<u32>,
+    pub block_hash: Option<String>,
+    pub spend: Option<SwapSpend>,
+}
+
+impl TryInto<TxIn> for &SwapOutput {
+    type Error = ReceiveSwapError;
+
+    fn try_into(self) -> Result<TxIn, Self::Error> {
+        Ok(TxIn {
+            previous_output: OutPoint {
+                txid: self.tx_id.parse()?,
+                vout: self.output_index,
+            },
+            script_sig: Script::default(),
+            sequence: Sequence::default(),
+            witness: Witness::default(),
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct SwapSpend {
+    pub tx_id: String,
+    pub output_index: u32,
+    pub spending_tx_id: String,
+    pub spending_input_index: u32,
+    pub confirmed_at_height: Option<u32>,
+    pub block_hash: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SwapChainInfo {
+    pub(crate) unconfirmed_sats: u64,
+    pub(crate) unconfirmed_tx_ids: Vec<String>,
+    pub(crate) confirmed_sats: u64,
+    pub(crate) confirmed_tx_ids: Vec<String>,
+    pub(crate) confirmed_at: Option<u32>,
+    pub(crate) total_incoming_txs: u64,
+}
+
+impl From<SwapChainData> for SwapChainInfo {
+    fn from(value: SwapChainData) -> Self {
+        SwapChainInfo {
+            unconfirmed_sats: value
+                .outputs
+                .iter()
+                .filter(|o| o.spend.is_none() && o.confirmed_at_height.is_none())
+                .map(|o| o.amount_sat)
+                .sum(),
+            unconfirmed_tx_ids: value
+                .outputs
+                .iter()
+                .filter(|o| o.spend.is_none() && o.confirmed_at_height.is_none())
+                .map(|o| o.tx_id.clone())
+                .collect(),
+            confirmed_sats: value
+                .outputs
+                .iter()
+                .filter(|o| o.spend.is_none() && o.confirmed_at_height.is_some())
+                .map(|o| o.amount_sat)
+                .sum(),
+            confirmed_tx_ids: value
+                .outputs
+                .iter()
+                .filter(|o| o.spend.is_none() && o.confirmed_at_height.is_some())
+                .map(|o| o.tx_id.clone())
+                .collect(),
+            confirmed_at: value
+                .outputs
+                .iter()
+                .filter_map(|o| o.confirmed_at_height)
+                .min(),
+            total_incoming_txs: value.outputs.len() as u64,
         }
     }
 }
 
-/// This struct is responsible for handling on-chain funds with lightning payments.
-/// It uses internally an implementation of SwapperAPI that represents the actually swapper service.
 pub(crate) struct BTCReceiveSwap {
-    network: crate::bitcoin::Network,
-    node_api: Arc<dyn NodeAPI>,
-    swapper_api: Arc<dyn SwapperAPI>,
-    persister: Arc<crate::persist::db::SqliteStorage>,
     chain_service: Arc<dyn ChainService>,
-    payment_receiver: Arc<dyn Receiver>,
     current_tip: Mutex<u32>,
+    node_api: Arc<dyn NodeAPI>,
+    payment_receiver: Arc<dyn Receiver>,
+    persister: Arc<SqliteStorage>,
+    segwit: SegwitReceiveSwap,
     status_changes_notifier: broadcast::Sender<BreezEvent>,
+    taproot: TaprootReceiveSwap,
 }
 
 impl BTCReceiveSwap {
     pub(crate) fn new(
-        network: crate::bitcoin::Network,
-        node_api: Arc<dyn NodeAPI>,
-        swapper_api: Arc<dyn SwapperAPI>,
-        persister: Arc<crate::persist::db::SqliteStorage>,
         chain_service: Arc<dyn ChainService>,
+        network: Network,
+        node_api: Arc<dyn NodeAPI>,
         payment_receiver: Arc<dyn Receiver>,
+        persister: Arc<SqliteStorage>,
+        segwit_swapper_api: Arc<dyn SwapperAPI>,
+        taproot_swapper_api: Arc<dyn TaprootSwapperAPI>,
     ) -> Self {
-        let (status_changes_notifier, _) = broadcast::channel::<BreezEvent>(100);
-        Self {
-            network,
-            node_api,
-            swapper_api,
-            persister,
+        BTCReceiveSwap {
             chain_service,
-            payment_receiver,
-            status_changes_notifier,
             current_tip: Mutex::new(0),
+            node_api,
+            payment_receiver,
+            persister,
+            segwit: SegwitReceiveSwap::new(segwit_swapper_api),
+            status_changes_notifier: broadcast::channel(100).0,
+            taproot: TaprootReceiveSwap::new(network, taproot_swapper_api),
         }
     }
+}
 
-    pub(crate) fn subscribe_status_changes(&self) -> broadcast::Receiver<BreezEvent> {
-        self.status_changes_notifier.subscribe()
-    }
-
-    fn emit_swap_updated(&self, bitcoin_address: &str) -> PersistResult<()> {
-        let swap_info = self
-            .persister
-            .get_swap_info_by_address(bitcoin_address.to_string())?
-            .ok_or_else(|| anyhow!(format!("swap address {} was not found", bitcoin_address)))?;
-        self.status_changes_notifier
-            .send(BreezEvent::SwapUpdated { details: swap_info })
-            .map_err(anyhow::Error::msg)?;
-        Ok(())
-    }
-
-    /// Listening to events is required in order to:
-    /// * Refresh on-chain status of swap addresses.
-    /// * Refresh lighting status of swap addresses, e.g lookup for corresponding lightning payment
-    /// * Redeem funds related to swap addresses, e.g when on chain funds are discovered use the SwapperAPI to
-    ///   req payment by passing bolt11 invoice.
-    pub(crate) async fn on_event(&self, e: BreezEvent) -> Result<()> {
-        match e {
-            BreezEvent::NewBlock { block: tip } => {
-                debug!("got chain event {:?}", e);
-                self.set_tip(tip);
-                _ = self.execute_pending_swaps(tip).await;
-            }
-
-            // When invoice is paid we lookup for a swap that matches the same hash.
-            // In case we find one, we update its paid amount.
-            BreezEvent::InvoicePaid { details } => {
-                debug!("swap InvoicePaid event!");
-                let hash_raw = hex::decode(details.payment_hash.clone())?;
-                let swap_info = self.persister.get_swap_info_by_hash(&hash_raw)?;
-                if let Some(swap_info) = swap_info {
-                    let payment = self
-                        .persister
-                        .get_completed_payment_by_hash(&details.payment_hash)?;
-                    if let Some(payment) = payment {
-                        let paid_amount = payment.amount_msat;
-                        let new_status = swap_info.with_paid_amount(paid_amount, self.tip()).status;
-                        self.persister.update_swap_paid_amount(
-                            swap_info.clone().bitcoin_address,
-                            paid_amount,
-                            new_status,
-                        )?;
-                        self.emit_swap_updated(&swap_info.bitcoin_address)?;
-                    }
-                }
-            }
-            _ => {} // skip events were are not interested in
-        }
-
-        Ok(())
-    }
-
-    /// Create a [SwapInfo] that represents the details of an on-going swap.
-    pub(crate) async fn create_swap_address(
+impl BTCReceiveSwap {
+    pub(crate) async fn create_swap(
         &self,
-        channel_opening_fees: OpeningFeeParams,
-    ) -> SwapResult<SwapInfo> {
+        opening_fee_params: OpeningFeeParams,
+    ) -> ReceiveSwapResult<SwapInfo> {
         let node_state = self
             .persister
             .get_node_state()?
-            .ok_or(SwapError::generic("Node info not found"))?;
-
+            .ok_or(ReceiveSwapError::NodeStateNotFound)?;
         // Calculate max_allowed_deposit based on absolute max and current node state
         let fn_max_allowed_deposit = |max_allowed_deposit_abs: i64| {
             std::cmp::min(
@@ -194,150 +229,570 @@ impl BTCReceiveSwap {
             )
         };
 
-        // check first that we don't already have an unused swap
-        if let Some(unused_swap) = self.list_unused()?.first().cloned() {
-            info!("Found unused swap when trying to create new swap address");
-            let bitcoin_address = unused_swap.bitcoin_address.clone();
-
-            // Check max_allowed_deposit and, if it changed, persist and validate changes
-            let current_max = fn_max_allowed_deposit(unused_swap.max_swapper_payable);
-            let res_swap = match current_max == unused_swap.max_allowed_deposit {
-                true => unused_swap,
-                false => {
-                    info!("max_allowed_deposit for this swap has changed, updating it");
-                    let mut new_swap = unused_swap.clone();
-
-                    new_swap.max_allowed_deposit = current_max;
-                    new_swap.validate_swap_limits()?;
-                    self.persister
-                        .update_swap_max_allowed_deposit(bitcoin_address.clone(), current_max)?;
-                    new_swap
-                }
+        let unused_swaps = self.list_unused()?;
+        let unused_swap = unused_swaps.into_iter().find(|s| {
+            let address_type = match parse_address(&s.bitcoin_address) {
+                Ok(address_type) => address_type,
+                Err(_) => return false,
             };
+            matches!(address_type, SwapAddressType::Taproot)
+        });
+        if let Some(mut unused_swap) = unused_swap {
+            // Check max_allowed_deposit and, if it changed, persist and validate changes
+            let old_max_allowed_deposit = unused_swap.max_allowed_deposit;
+            unused_swap.max_allowed_deposit =
+                fn_max_allowed_deposit(unused_swap.max_swapper_payable);
+            if unused_swap.max_allowed_deposit != old_max_allowed_deposit {
+                info!("max_allowed_deposit for this swap has changed, updating it");
+                validate_swap_limits(&unused_swap)?;
+                self.persister.update_swap_max_allowed_deposit(
+                    &unused_swap.bitcoin_address,
+                    unused_swap.max_allowed_deposit,
+                )?;
+            }
 
             self.persister
-                .update_swap_fees(bitcoin_address, channel_opening_fees)?;
-            return Ok(res_swap);
+                .update_swap_fees(&unused_swap.bitcoin_address, &opening_fee_params)?;
+
+            return Ok(unused_swap);
         }
 
-        // create fresh swap keys
-        let swap_keys = create_swap_keys()?;
-        let pubkey = swap_keys.public_key_bytes()?;
-        let hash = swap_keys.preimage_hash_bytes();
-
-        // use swap API to fetch a new swap address
-        let swap_reply = self
-            .swapper_api
-            .create_swap(hash.clone(), pubkey.clone(), node_state.id.clone())
+        let swap_info = self
+            .taproot
+            .create_swap(&node_state, opening_fee_params)
             .await?;
-        info!("created swap address {}", swap_reply.bitcoin_address);
-        // calculate the submarine swap script
-        let our_script = create_submarine_swap_script(
-            hash.clone(),
-            swap_reply.swapper_pubkey.clone(),
-            pubkey.clone(),
-            swap_reply.lock_height,
-        )?;
-
-        let address = Address::p2wsh(&our_script, self.network);
-        let address_str = address.to_string();
-
-        // Ensure our address generation match the service
-        if address_str != swap_reply.bitcoin_address {
-            return Err(SwapError::Generic(format!("Wrong address: {address_str}")));
-        }
-
-        let swap_info = SwapInfo {
-            bitcoin_address: swap_reply.bitcoin_address,
-            created_at: SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_secs() as i64,
-            lock_height: swap_reply.lock_height,
-            payment_hash: hash.clone(),
-            preimage: swap_keys.preimage,
-            private_key: swap_keys.priv_key.to_vec(),
-            public_key: pubkey.clone(),
-            swapper_public_key: swap_reply.swapper_pubkey.clone(),
-            script: our_script.as_bytes().to_vec(),
-            bolt11: None,
-            paid_msat: 0,
-            unconfirmed_sats: 0,
-            confirmed_sats: 0,
-            total_incoming_txs: 0,
-            refund_tx_ids: Vec::new(),
-            confirmed_tx_ids: Vec::new(),
-            unconfirmed_tx_ids: Vec::new(),
-            status: SwapStatus::Initial,
-            min_allowed_deposit: swap_reply.swapper_min_payable,
-            max_allowed_deposit: fn_max_allowed_deposit(swap_reply.swapper_max_payable),
-            max_swapper_payable: swap_reply.swapper_max_payable,
-            last_redeem_error: None,
-            channel_opening_fees: Some(channel_opening_fees),
-            confirmed_at: None,
-        };
-        swap_info.validate_swap_limits()?;
-
-        // persist the swap info
-        self.persister.insert_swap(swap_info.clone())?;
+        self.persister.insert_swap(&swap_info)?;
         Ok(swap_info)
     }
 
-    fn list_unused(&self) -> Result<Vec<SwapInfo>> {
-        Ok(self.persister.list_swaps(ListSwapsRequest {
-            status: Some(SwapStatus::unused()),
-            ..Default::default()
-        })?)
+    pub(crate) fn list_swaps(&self, req: ListSwapsRequest) -> ReceiveSwapResult<Vec<SwapInfo>> {
+        Ok(self.persister.list_swaps(req)?)
     }
 
-    pub(crate) fn list_in_progress(&self) -> Result<Vec<SwapInfo>> {
-        Ok(self.persister.list_swaps(ListSwapsRequest {
+    pub(crate) fn list_in_progress_swaps(&self) -> ReceiveSwapResult<Vec<SwapInfo>> {
+        self.list_swaps(ListSwapsRequest {
             status: Some(SwapStatus::in_progress()),
             ..Default::default()
-        })?)
+        })
     }
 
-    pub fn list_monitored(&self) -> Result<Vec<SwapInfo>> {
-        Ok(self.persister.list_swaps(ListSwapsRequest {
+    pub fn list_monitored(&self) -> ReceiveSwapResult<Vec<SwapInfo>> {
+        self.list_swaps(ListSwapsRequest {
             status: Some(SwapStatus::monitored()),
             ..Default::default()
-        })?)
-    }
-
-    pub(crate) fn list_refundables(&self) -> Result<Vec<SwapInfo>> {
-        Ok(self.persister.list_swaps(ListSwapsRequest {
-            status: Some(SwapStatus::refundable()),
-            ..Default::default()
-        })?)
+        })
     }
 
     #[allow(dead_code)]
-    pub(crate) fn list_redeemables(&self) -> Result<Vec<SwapInfo>> {
+    pub(crate) fn list_redeemables(&self) -> ReceiveSwapResult<Vec<SwapInfo>> {
         Ok(self.persister.list_swaps(ListSwapsRequest {
             status: Some(SwapStatus::redeemable()),
             ..Default::default()
         })?)
     }
 
-    pub(crate) fn get_swap_info(&self, address: String) -> Result<Option<SwapInfo>> {
-        Ok(self.persister.get_swap_info_by_address(address)?)
+    pub(crate) fn list_refundables(&self) -> ReceiveSwapResult<Vec<SwapInfo>> {
+        self.list_swaps(ListSwapsRequest {
+            status: Some(SwapStatus::refundable()),
+            ..Default::default()
+        })
     }
 
-    fn get_swap_info_ok(&self, address: String) -> Result<SwapInfo> {
-        self.get_swap_info(address.clone())?
-            .ok_or_else(|| anyhow!(format!("Swap address {} was not found", address)))
+    pub(crate) fn list_unused(&self) -> ReceiveSwapResult<Vec<SwapInfo>> {
+        self.list_swaps(ListSwapsRequest {
+            status: Some(SwapStatus::unused()),
+            ..Default::default()
+        })
     }
 
-    pub(crate) async fn rescan_swaps(&self, tip: u32) -> Result<()> {
+    pub(crate) async fn on_event(&self, e: BreezEvent) -> ReceiveSwapResult<()> {
+        match e {
+            BreezEvent::NewBlock { block: tip } => {
+                debug!("got chain event {:?}", e);
+                self.set_tip(tip).await;
+                _ = self.execute_pending_swaps(tip).await;
+            }
+
+            // When invoice is paid we lookup for a swap that matches the same hash.
+            // In case we find one, we update its paid amount.
+            BreezEvent::InvoicePaid { details } => {
+                debug!("swap InvoicePaid event!");
+                let hash_raw = hex::decode(&details.payment_hash)?;
+                let mut swap_info = match self.persister.get_swap_info_by_hash(&hash_raw)? {
+                    Some(swap_info) => swap_info,
+                    None => return Ok(()),
+                };
+
+                let payment = match self
+                    .persister
+                    .get_completed_payment_by_hash(&details.payment_hash)?
+                {
+                    Some(payment) => payment,
+                    None => return Ok(()),
+                };
+
+                let current_tip = self.tip().await;
+                let chain_data = self
+                    .persister
+                    .get_swap_chain_data(&swap_info.bitcoin_address)?;
+                swap_info.paid_msat = payment.amount_msat;
+                let address = parse_address(&swap_info.bitcoin_address)?;
+                let new_status =
+                    self.calculate_status(&swap_info, &address, &chain_data, current_tip);
+                self.persister
+                    .update_swap_paid_amount(&swap_info.bitcoin_address, swap_info.paid_msat)?;
+                self.persister
+                    .set_swap_status(&swap_info.bitcoin_address, &new_status)?;
+                self.emit_swap_updated(&swap_info.bitcoin_address)?;
+            }
+            _ => {} // skip events were are not interested in
+        }
+
+        Ok(())
+    }
+
+    pub(crate) async fn prepare_refund(
+        &self,
+        req: PrepareRefundRequest,
+    ) -> ReceiveSwapResult<PrepareRefundResponse> {
+        let address_type = parse_address(&req.swap_address)?;
+        let swap_info = self
+            .persister
+            .get_swap_info_by_address(&req.swap_address)?
+            .ok_or(ReceiveSwapError::SwapNotFound("".to_string()))?;
+        let chain_data = match self.persister.get_swap_chain_data(&req.swap_address)? {
+            Some(chain_data) => chain_data,
+            None => {
+                let chain_data = self.fetch_swap_onchain_data(&swap_info).await?;
+                self.persister.set_swap_chain_data(
+                    &req.swap_address,
+                    &chain_data,
+                    &chain_data.clone().into(),
+                )?;
+                chain_data
+            }
+        };
+
+        let mut utxos: Vec<_> = chain_data.confirmed_utxos();
+        if utxos.is_empty() {
+            return Err(ReceiveSwapError::NoUtxos);
+        }
+
+        // Sort UTXOs for deterministic transactions
+        utxos.sort_by(|a, b| {
+            a.tx_id
+                .cmp(&b.tx_id)
+                .then(a.output_index.cmp(&b.output_index))
+        });
+
+        let destination_address = req.to_address.parse()?;
+        let tx = match address_type {
+            SwapAddressType::Segwit => {
+                self.segwit
+                    .create_fake_refund_tx(&swap_info, &utxos, &destination_address)
+            }
+            SwapAddressType::Taproot => match req.unilateral {
+                Some(true) => self.taproot.create_fake_unilateral_refund_tx(
+                    &swap_info,
+                    &utxos,
+                    &destination_address,
+                ),
+                _ => self.taproot.create_fake_cooperative_refund_tx(
+                    &swap_info,
+                    &utxos,
+                    &destination_address,
+                ),
+            },
+        }?;
+
+        let weight = tx.weight() as u32;
+        let fee = (weight as u64)
+            .saturating_mul(req.sat_per_vbyte as u64)
+            .saturating_mul(WITNESS_SCALE_FACTOR as u64);
+        Ok(PrepareRefundResponse {
+            refund_tx_weight: weight,
+            refund_tx_fee_sat: fee,
+        })
+    }
+
+    pub(crate) async fn refund(&self, req: RefundRequest) -> ReceiveSwapResult<RefundResponse> {
+        let address_type = parse_address(&req.swap_address)?;
+        let swap_info = self
+            .persister
+            .get_swap_info_by_address(&req.swap_address)?
+            .ok_or(ReceiveSwapError::SwapNotFound("".to_string()))?;
+        let chain_data = match self.persister.get_swap_chain_data(&req.swap_address)? {
+            Some(chain_data) => chain_data,
+            None => {
+                let chain_data = self.fetch_swap_onchain_data(&swap_info).await?;
+                self.persister.set_swap_chain_data(
+                    &req.swap_address,
+                    &chain_data,
+                    &chain_data.clone().into(),
+                )?;
+                chain_data
+            }
+        };
+        let mut utxos: Vec<_> = chain_data
+            .outputs
+            .into_iter()
+            .filter(|o| o.spend.is_none())
+            .collect();
+        if utxos.is_empty() {
+            return Err(ReceiveSwapError::NoUtxos);
+        }
+
+        // Sort UTXOs for deterministic transactions
+        utxos.sort_by(|a, b| {
+            a.tx_id
+                .cmp(&b.tx_id)
+                .then(a.output_index.cmp(&b.output_index))
+        });
+
+        let destination_address = req.to_address.parse()?;
+        let tx = match address_type {
+            SwapAddressType::Segwit => self.segwit.create_refund_tx(
+                &swap_info,
+                &utxos,
+                &destination_address,
+                req.sat_per_vbyte,
+            ),
+            SwapAddressType::Taproot => match req.unilateral {
+                Some(true) => self.taproot.create_unilateral_refund_tx(
+                    &swap_info,
+                    &utxos,
+                    &destination_address,
+                    req.sat_per_vbyte,
+                ),
+                _ => {
+                    self.taproot
+                        .create_cooperative_refund_tx(
+                            &swap_info,
+                            &utxos,
+                            &destination_address,
+                            req.sat_per_vbyte,
+                        )
+                        .await
+                }
+            },
+        }?;
+
+        let refund_tx = encode::serialize(&tx);
+        info!("broadcasting refund tx {:?}", hex::encode(&refund_tx));
+        let tx_id = self.chain_service.broadcast_transaction(refund_tx).await?;
+        self.persister
+            .insert_swap_refund_tx_ids(swap_info.bitcoin_address, tx_id.clone())?;
+        self.emit_swap_updated(&req.swap_address)?;
+
+        Ok(RefundResponse {
+            refund_tx_id: tx_id,
+        })
+    }
+
+    pub(crate) async fn redeem_swap(&self, address: String) -> ReceiveSwapResult<()> {
+        let swap_info = self
+            .persister
+            .get_swap_info_by_address(&address)?
+            .ok_or(ReceiveSwapError::SwapNotFound("".to_string()))?;
+        let address_type = parse_address(&address)?;
+
+        let current_tip = self.chain_service.current_tip().await?;
+
+        // TODO: Handle NeedsNewFeeParams here.
+        let (payment_request, is_new_payment_request) =
+            self.get_payment_request(&swap_info, current_tip).await?;
+        self.persister
+            .update_swap_bolt11(swap_info.bitcoin_address.clone(), payment_request.clone())?;
+        if is_new_payment_request {
+            self.emit_swap_updated(&swap_info.bitcoin_address.clone())?;
+        }
+
+        let resp = match address_type {
+            SwapAddressType::Segwit => {
+                self.segwit
+                    .get_swap_payment(&swap_info, payment_request)
+                    .await
+            }
+            SwapAddressType::Taproot => {
+                self.taproot
+                    .get_swap_payment(&swap_info, payment_request)
+                    .await
+            }
+        };
+
+        let message = match resp {
+            Ok(_) => {
+                // Nothing to do here. Swap updated event will be emitted by the invoice paid event.
+                return Ok(());
+            }
+            Err(err) => match err {
+                ReceiveSwapError::PaymentError(err) => err,
+                _ => return Err(err),
+            },
+        };
+
+        debug!("Error getting paid for swap: {}", message);
+        self.persister
+            .update_swap_redeem_error(swap_info.bitcoin_address.clone(), message.clone())?;
+        self.emit_swap_updated(&swap_info.bitcoin_address)?;
+        Err(ReceiveSwapError::PaymentError(message))
+    }
+
+    pub(crate) async fn rescan_monitored_swaps(&self, tip: u32) -> ReceiveSwapResult<()> {
+        self.refresh_swaps(
+            self.persister.list_swaps(ListSwapsRequest {
+                status: Some(SwapStatus::monitored()),
+                ..Default::default()
+            })?,
+            tip,
+        )
+        .await
+    }
+
+    pub(crate) async fn rescan_swap(&self, address: &str, tip: u32) -> ReceiveSwapResult<()> {
+        let swap = self
+            .persister
+            .get_swap_info_by_address(address)?
+            .ok_or(ReceiveSwapError::SwapNotFound("".to_string()))?;
+        self.refresh_swaps(vec![swap], tip).await
+    }
+
+    pub(crate) async fn rescan_swaps(&self, tip: u32) -> ReceiveSwapResult<()> {
         self.refresh_swaps(self.persister.list_swaps(ListSwapsRequest::default())?, tip)
             .await
     }
 
-    pub(crate) async fn rescan_monitored_swaps(&self, tip: u32) -> Result<()> {
-        self.refresh_swaps(self.list_monitored()?, tip).await
+    pub(crate) fn subscribe_status_changes(&self) -> broadcast::Receiver<BreezEvent> {
+        self.status_changes_notifier.subscribe()
+    }
+}
+
+/// ReceiveSwapper private functions
+impl BTCReceiveSwap {
+    fn calculate_status(
+        &self,
+        swap_info: &SwapInfo,
+        address_type: &SwapAddressType,
+        chain_data: &Option<SwapChainData>,
+        current_tip: u32,
+    ) -> SwapStatus {
+        let chain_data = match chain_data {
+            Some(cd) => cd,
+            None => {
+                return self.calculate_status_without_chain_data(
+                    swap_info,
+                    address_type,
+                    current_tip,
+                )
+            }
+        };
+
+        // No unconfirmed or confirmed outputs at all means initial state.
+        if chain_data.outputs.is_empty() {
+            return SwapStatus::Initial;
+        }
+
+        // Get the minimum confirmation height. If there are no confirmed outputs yet, we are waiting for confirmation.
+        let min_confirmation = match chain_data
+            .outputs
+            .iter()
+            .filter_map(|o| o.confirmed_at_height)
+            .min()
+        {
+            Some(min) => min,
+            None => return SwapStatus::WaitingConfirmation,
+        };
+
+        // If none of the outputs are unspent, confirmed or unconfirmed, the swap is completed.
+        if chain_data.utxos().is_empty() {
+            return SwapStatus::Completed;
+        }
+
+        let payout_blocks_left = match address_type {
+            SwapAddressType::Segwit => {
+                self.segwit
+                    .payout_blocks_left(swap_info, min_confirmation, current_tip)
+            }
+            SwapAddressType::Taproot => {
+                self.taproot
+                    .payout_blocks_left(swap_info, min_confirmation, current_tip)
+            }
+        };
+
+        // If there are blocks left to be paid out and the swap was not redeemed yet, it is redeemable.
+        if payout_blocks_left > 0 && swap_info.paid_msat == 0 {
+            return SwapStatus::Redeemable;
+        }
+
+        // The swap is not redeemable. And there are confirmed or unconfirmed outputs.
+
+        // Deduce the paid outputs by assuming the first confirmed outputs are the ones belonging to the payment.
+        let mut all_outputs = chain_data.outputs.clone();
+        all_outputs.sort_by(|a, b| a.confirmed_at_height.cmp(&b.confirmed_at_height));
+        let mut sum = 0;
+        let paid_outputs: Vec<_> = all_outputs
+            .iter()
+            .take_while(|o| {
+                if sum >= swap_info.paid_msat {
+                    return false;
+                }
+
+                sum += o.amount_sat * 1000;
+                true
+            })
+            .collect();
+
+        let refundable_utxos: Vec<_> = chain_data
+            .utxos()
+            .into_iter()
+            .filter(|o| {
+                paid_outputs
+                    .iter()
+                    .all(|po| po.tx_id != o.tx_id || po.output_index != o.output_index)
+            })
+            .collect();
+
+        if refundable_utxos.is_empty() {
+            return SwapStatus::Completed;
+        }
+
+        SwapStatus::Refundable
     }
 
-    pub(crate) async fn execute_pending_swaps(&self, tip: u32) -> Result<()> {
+    fn calculate_status_without_chain_data(
+        &self,
+        swap_info: &SwapInfo,
+        address_type: &SwapAddressType,
+        current_tip: u32,
+    ) -> SwapStatus {
+        let mut passed_timelock = false;
+        if let Some(confirmed_at) = swap_info.confirmed_at {
+            let payout_blocks_left = match address_type {
+                SwapAddressType::Segwit => {
+                    self.segwit
+                        .payout_blocks_left(swap_info, confirmed_at, current_tip)
+                }
+                SwapAddressType::Taproot => {
+                    self.taproot
+                        .payout_blocks_left(swap_info, confirmed_at, current_tip)
+                }
+            };
+            passed_timelock = payout_blocks_left == 0;
+        }
+
+        // In case timelock has passed we can only be in the Refundable or Completed state.
+        if passed_timelock {
+            return match swap_info.confirmed_sats {
+                0 => SwapStatus::Completed,
+                // This is to make sure we don't consider refundable in case we only have one transaction which was already
+                // paid by the swapper.
+                _ => match (swap_info.paid_msat, swap_info.total_incoming_txs) {
+                    (paid, 1) if paid > 0 => SwapStatus::Completed,
+                    _ => SwapStatus::Refundable,
+                },
+            };
+        }
+
+        match (
+            swap_info.confirmed_at,
+            swap_info.unconfirmed_sats,
+            swap_info.confirmed_sats,
+            swap_info.paid_msat,
+        ) {
+            // We have confirmation and both uconfirmed and confirmed balance are zero then we are done
+            (Some(_), 0, 0, _) => SwapStatus::Completed,
+            // We got lightning payment so we are in redeemed state.
+            (_, _, _, paid) if paid > 0 => SwapStatus::Redeemed,
+            // We have positive confirmed balance then we should redeem the funds.
+            (_, _, confirmed, _) if confirmed > 0 => SwapStatus::Redeemable,
+            // We have positive unconfirmed balance then we are waiting for confirmation.
+            (_, unconfirmed, _, _) if unconfirmed > 0 => SwapStatus::WaitingConfirmation,
+            _ => SwapStatus::Initial,
+        }
+    }
+
+    async fn check_existing_payment_request(
+        &self,
+        swap_info: &SwapInfo,
+        bolt11_result: FetchBolt11Result,
+    ) -> Result<Option<String>, GetPaymentRequestError> {
+        let invoice: Bolt11Invoice = bolt11_result.bolt11.parse()?;
+        let invoice_expires_at = match invoice.expires_at() {
+            Some(expires_at) => expires_at,
+            None => {
+                debug!(
+                    "Existing swap payment request has invalid expiry. Recreating payment request."
+                );
+                self.node_api.delete_invoice(bolt11_result.bolt11).await?;
+                return Ok(None);
+            }
+        };
+        if invoice_expires_at.as_secs() < MIN_INVOICE_EXPIRY_SECONDS {
+            debug!("Existing swap payment request has expired / will expire soon. Recreating payment request.");
+            self.node_api.delete_invoice(bolt11_result.bolt11).await?;
+            return Ok(None);
+        }
+        let invoice_amount_msat =
+            invoice
+                .amount_milli_satoshis()
+                .ok_or(GetPaymentRequestError::generic(
+                    "Found swap invoice without amount",
+                ))?;
+        let amount_msat = bolt11_result
+            .payer_amount_msat
+            .unwrap_or(invoice_amount_msat);
+        if amount_msat != swap_info.confirmed_sats * 1000 {
+            debug!("Existing swap payment request amount is no longer correct. Recreating payment request.");
+            self.node_api.delete_invoice(bolt11_result.bolt11).await?;
+            return Ok(None);
+        }
+
+        if let Some(payer_amount_msat) = bolt11_result.payer_amount_msat {
+            // This is an open channel invoice, so liquidity won't be an issue.
+            // TODO: Validate opening_fee_params validity.
+            // TODO: Fetch opening_fee_params belonging to the invoice
+            let opening_fee_params = swap_info
+                .channel_opening_fees
+                .clone()
+                .ok_or(GetPaymentRequestError::MissingOpeningFeeParams)?;
+            let wrapped_invoice = self
+                .payment_receiver
+                .wrap_node_invoice(
+                    &bolt11_result.bolt11,
+                    Some(OpenChannelParams {
+                        payer_amount_msat,
+                        opening_fee_params,
+                    }),
+                    None,
+                )
+                .await?;
+            return Ok(Some(wrapped_invoice));
+        }
+
+        // This is not an open channel invoice, check liquidity.
+        if self.payment_receiver.open_channel_needed(amount_msat)? {
+            debug!("Existing swap payment request is not an open channel invoice, but liquidity is no longer sufficient. Recreating payment request.");
+            self.node_api.delete_invoice(bolt11_result.bolt11).await?;
+            return Ok(None);
+        }
+
+        Ok(Some(bolt11_result.bolt11))
+    }
+
+    fn emit_swap_updated(&self, bitcoin_address: &str) -> PersistResult<()> {
+        let swap_info = self
+            .persister
+            .get_swap_info_by_address(bitcoin_address)?
+            .ok_or_else(|| {
+                anyhow::anyhow!(format!("swap address {} was not found", bitcoin_address))
+            })?;
+        self.status_changes_notifier
+            .send(BreezEvent::SwapUpdated { details: swap_info })
+            .map_err(anyhow::Error::msg)?;
+        Ok(())
+    }
+
+    async fn execute_pending_swaps(&self, tip: u32) -> ReceiveSwapResult<()> {
         // first refresh all swaps we monitor
         self.refresh_swaps(self.list_monitored()?, tip).await?;
 
@@ -349,1124 +804,299 @@ impl BTCReceiveSwap {
 
             match self.redeem_swap(swap_address.clone()).await {
                 Ok(_) => info!("succeed to redeem swap {swap_address}: {bolt11}"),
-                Err(err) => {
-                    error!("failed to redeem swap {err:?}: {swap_address} {bolt11}");
-                    self.persister
-                        .update_swap_redeem_error(swap_address.clone(), err.to_string())?;
-                    self.emit_swap_updated(&swap_address)?;
+                Err(err) => error!("failed to redeem swap {err:?}: {swap_address} {bolt11}"),
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn fetch_swap_onchain_data(&self, swap: &SwapInfo) -> ReceiveSwapResult<SwapChainData> {
+        let txs = self
+            .chain_service
+            .address_transactions(swap.bitcoin_address.clone())
+            .await?;
+
+        let mut outputs = HashMap::new();
+
+        // Collect all outputs that were sent to the swap address
+        for tx in &txs {
+            for (output_index, vout) in tx.vout.iter().enumerate() {
+                if vout.scriptpubkey_address != swap.bitcoin_address {
+                    continue;
+                }
+
+                let output = SwapOutput {
+                    address: swap.bitcoin_address.clone(),
+                    amount_sat: vout.value,
+                    tx_id: tx.txid.clone(),
+                    output_index: output_index as u32,
+                    confirmed_at_height: tx.status.block_height,
+                    block_hash: tx.status.block_hash.clone(),
+                    spend: None,
+                };
+
+                let outpoint = format!("{}:{}", tx.txid, output_index);
+                outputs.insert(outpoint, output);
+            }
+        }
+
+        // Collect all spends of the swap outputs
+        for tx in &txs {
+            for (input_index, vin) in tx.vin.iter().enumerate() {
+                let outpoint = format!("{}:{}", vin.txid, vin.vout);
+                if let Some(output) = outputs.get_mut(&outpoint) {
+                    output.spend = Some(SwapSpend {
+                        tx_id: vin.txid.clone(),
+                        output_index: vin.vout,
+                        spending_tx_id: tx.txid.clone(),
+                        spending_input_index: input_index as u32,
+                        confirmed_at_height: tx.status.block_height,
+                        block_hash: tx.status.block_hash.clone(),
+                    });
                 }
             }
         }
 
+        let chain_data = SwapChainData {
+            outputs: outputs.into_values().collect(),
+        };
+
+        Ok(chain_data)
+    }
+
+    async fn get_payment_request(
+        &self,
+        swap: &SwapInfo,
+        blocks: u32,
+    ) -> Result<(String, bool), GetPaymentRequestError> {
+        match self.get_payment_request_inner(swap, blocks).await {
+            Ok(s) => return Ok(s),
+            Err(e) => match e {
+                GetPaymentRequestError::InvoiceAlreadyExists => {}
+                _ => return Err(e),
+            },
+        }
+
+        debug!("Retrying to get payment request because invoice already existed.");
+        // Retry getting the payment request once if it returned 'Invoice already exists' on the first try.
+        self.get_payment_request_inner(swap, blocks).await
+    }
+
+    async fn get_payment_request_inner(
+        &self,
+        swap_info: &SwapInfo,
+        blocks: u32,
+    ) -> Result<(String, bool), GetPaymentRequestError> {
+        let maybe_bolt11_result = self
+            .node_api
+            .fetch_bolt11(swap_info.payment_hash.clone())
+            .await?;
+        let accepted_opening_fee_params = swap_info
+            .channel_opening_fees
+            .as_ref()
+            .ok_or(GetPaymentRequestError::MissingOpeningFeeParams)?;
+        let initial_fee_params_valid =
+            accepted_opening_fee_params.valid_for(MIN_OPENING_FEE_PARAMS_VALIDITY_SECONDS)?;
+        let opening_fee_params = match initial_fee_params_valid {
+            true => Some(accepted_opening_fee_params.clone()),
+            false => None,
+        };
+
+        // If a payment was requested before, the could be an existing invoice.
+        // Validate the existing invoice, it may need to be recreated.
+        if let Some(bolt11_result) = maybe_bolt11_result {
+            let maybe_bolt11 = self
+                .check_existing_payment_request(swap_info, bolt11_result)
+                .await?;
+            if let Some(bolt11) = maybe_bolt11 {
+                return Ok((bolt11, false));
+            }
+        };
+
+        let amount_msat = swap_info.confirmed_sats * 1000;
+        // Note that if the accepted opening fee params is no longer valid, a new one will be issued by the
+        // receive_payment function. It is checked in the response.
+        let receive_resp = self
+            .payment_receiver
+            .receive_payment(ReceivePaymentRequest {
+                // TODO: Substract fees here once swapper supports them.
+                amount_msat,
+                cltv: Some(144),
+                description: format!("taproot swap {}", swap_info.bitcoin_address),
+                expiry: Some(blocks.saturating_mul(EXPIRY_SECONDS_PER_BLOCK)),
+                opening_fee_params,
+                preimage: Some(swap_info.preimage.clone()),
+                use_description_hash: None,
+            })
+            .await;
+        match receive_resp {
+            Ok(resp) => {
+                if let Some(opening_fee_params) = resp.opening_fee_params {
+                    if opening_fee_params.get_channel_fees_msat_for(amount_msat)
+                        > accepted_opening_fee_params.get_channel_fees_msat_for(amount_msat)
+                    {
+                        return Err(GetPaymentRequestError::NeedsNewFeeParams);
+                    }
+                }
+
+                // TODO: Save the new opening_fee_params? Like 'last' opening_fee_params?
+                return Ok((resp.ln_invoice.bolt11, true));
+            }
+            Err(e) => match e {
+                ReceivePaymentError::InvoicePreimageAlreadyExists { err: _ } => {
+                    debug!("Tried to create swap invoice, but invoice preimage already exists.")
+                }
+                _ => return Err(e.into()),
+            },
+        };
+
+        // Ending up here means the invoice already exists, even though it was checked above.
+        // Retry this whole operation again if this is the first try.
+        Err(GetPaymentRequestError::InvoiceAlreadyExists)
+    }
+
+    async fn refresh_swap(&self, swap_info: &SwapInfo, current_tip: u32) -> ReceiveSwapResult<()> {
+        let (mut new_swap_info, new_chain_data) =
+            match self.refresh_swap_onchain_data(swap_info).await {
+                Ok((s, cd)) => (s, cd),
+                Err(e) => {
+                    error!(
+                        "failed to refresh swap onchain status for address {}: {}",
+                        swap_info.bitcoin_address, e
+                    );
+                    (swap_info.clone(), None)
+                }
+            };
+
+        new_swap_info = match self.refresh_swap_payment_data(&new_swap_info).await {
+            Ok(s) => s,
+            Err(e) => {
+                error!(
+                    "failed to refresh swap payment status for address {}: {}",
+                    swap_info.bitcoin_address, e
+                );
+                new_swap_info
+            }
+        };
+
+        if &new_swap_info != swap_info {
+            let address = parse_address(&swap_info.bitcoin_address)?;
+            let status = self.calculate_status(swap_info, &address, &new_chain_data, current_tip);
+            self.persister
+                .set_swap_status(&swap_info.bitcoin_address, &status)?;
+            self.emit_swap_updated(&swap_info.bitcoin_address)?;
+        }
+
         Ok(())
     }
 
-    async fn refresh_swaps(&self, swaps: Vec<SwapInfo>, tip: u32) -> Result<()> {
+    async fn refresh_swaps(&self, swaps: Vec<SwapInfo>, tip: u32) -> ReceiveSwapResult<()> {
         for s in swaps {
-            let address = s.bitcoin_address.clone();
-            let result = self
-                .refresh_swap_on_chain_status(address.clone(), tip)
-                .await;
-            if let Err(err) = result {
-                error!("failed to refresh swap status for address {address}: {err}")
-            }
+            self.refresh_swap(&s, tip).await?;
         }
         Ok(())
     }
 
-    /// refreshes the on-chain status of the swap. This method updates the following information
-    /// on a SwapInfo and save it to the persistent storage:
-    /// confirmed_sats - the number of unspent satoshis that were sent to this address
-    /// confirmed_txs - all utxo that are sent to this address
-    /// swap_status - Either Initial or Expired.
-    pub(crate) async fn refresh_swap_on_chain_status(
+    async fn refresh_swap_onchain_data(
         &self,
-        bitcoin_address: String,
-        current_tip: u32,
-    ) -> Result<SwapInfo> {
-        let mut swap_info = self
+        swap_info: &SwapInfo,
+    ) -> ReceiveSwapResult<(SwapInfo, Option<SwapChainData>)> {
+        let existing_chain_data = self
             .persister
-            .get_swap_info_by_address(bitcoin_address.clone())?
-            .ok_or_else(|| {
-                anyhow!(format!(
-                    "swap address {} was not found",
-                    bitcoin_address.clone()
-                ))
-            })?;
-        let txs = self
-            .chain_service
-            .address_transactions(bitcoin_address.clone())
-            .await?;
-        let optional_confirmed_block = txs
-            .clone()
-            .into_iter()
-            .filter_map(|t| t.status.block_height)
-            .filter(|height| *height > 0)
-            .min();
-        let utxos = get_utxos(bitcoin_address.clone(), txs.clone(), false)?;
-        let total_incoming_txs = get_total_incoming_txs(bitcoin_address.clone(), txs);
-
-        debug!(
-            "updating swap on-chain info {:?}: confirmed_sats={:?} refund_tx_ids={:?}, confirmed_tx_ids={:?}",
-            bitcoin_address.clone(), utxos.confirmed_sats(), swap_info.refund_tx_ids, utxos.confirmed_tx_ids(),
-        );
-
-        let payment = self
-            .persister
-            .get_completed_payment_by_hash(&hex::encode(swap_info.payment_hash.clone()))?;
-        if let Some(payment) = payment {
-            debug!(
-                "found payment for hash {:?}, {:?}",
-                &hex::encode(swap_info.payment_hash.clone()),
-                payment
-            );
-            let amount_msat = payment.amount_msat;
-            swap_info = swap_info.with_paid_amount(amount_msat, current_tip);
-            self.persister.update_swap_paid_amount(
-                bitcoin_address.clone(),
-                amount_msat,
-                swap_info.status.clone(),
+            .get_swap_chain_data(&swap_info.bitcoin_address)?;
+        let new_chain_data = match self.fetch_swap_onchain_data(swap_info).await {
+            Ok(d) => d,
+            Err(e) => {
+                error!(
+                    "failed to refresh swap onchain status for address {}: {}",
+                    swap_info.bitcoin_address, e
+                );
+                return Ok((swap_info.clone(), existing_chain_data));
+            }
+        };
+        let changed = match existing_chain_data {
+            Some(e) => e != new_chain_data,
+            None => true,
+        };
+        let chain_info = new_chain_data.clone().into();
+        if changed {
+            self.persister.set_swap_chain_data(
+                &swap_info.bitcoin_address,
+                &new_chain_data,
+                &chain_info,
             )?;
         }
-
-        let chain_info = SwapChainInfo {
-            unconfirmed_sats: utxos.unconfirmed_sats(),
-            unconfirmed_tx_ids: utxos.unconfirmed_tx_ids(),
-            confirmed_sats: utxos.confirmed_sats(),
-            confirmed_tx_ids: utxos.confirmed_tx_ids(),
-            confirmed_at: optional_confirmed_block,
-            total_incoming_txs,
-        };
-        let status = swap_info
-            .with_chain_info(chain_info.clone(), current_tip)
-            .status;
-        let updated = self
-            .persister
-            .update_swap_chain_info(bitcoin_address, chain_info, status)?;
-        self.emit_swap_updated(&swap_info.bitcoin_address)?;
-        Ok(updated)
-    }
-
-    /// redeem_swap executes the final step of receiving lightning payment
-    /// in exchange for the on chain funds.
-    pub(crate) async fn redeem_swap(&self, bitcoin_address: String) -> Result<()> {
-        let swap_info = self
-            .persister
-            .get_swap_info_by_address(bitcoin_address.clone())?
-            .ok_or_else(|| anyhow!(format!("swap address {bitcoin_address} was not found")))?;
-
-        let bolt11 = match swap_info.bolt11 {
-            Some(known_bolt11) => known_bolt11,
-            None => {
-                // No invoice known for this swap, we try to create one
-                let create_invoice_res = self
-                    .payment_receiver
-                    .receive_payment(ReceivePaymentRequest {
-                        amount_msat: swap_info.confirmed_sats * 1_000,
-                        description: String::from("Bitcoin Transfer"),
-                        preimage: Some(swap_info.preimage),
-                        opening_fee_params: swap_info.channel_opening_fees.clone(),
-                        use_description_hash: Some(false),
-                        expiry: Some(SWAP_PAYMENT_FEE_EXPIRY_SECONDS),
-                        cltv: None,
-                    })
-                    .await;
-
-                let new_bolt11 = match create_invoice_res {
-                    // Extract created invoice
-                    Ok(create_invoice_response) => create_invoice_response.ln_invoice.bolt11,
-
-                    // If settling the invoice failed on a different device (for example because the
-                    // swap was initiated there), then the unsettled invoice exists on the GL node.
-                    // Trying to create the invoice here will fail because we're using the same preimage.
-                    // In this case, fetch the invoice from GL instead of creating it.
-                    Err(ReceivePaymentError::InvoicePreimageAlreadyExists { .. }) => {
-                        // Try first to fetch the invoice from our persistent storage as it could be a modified one.
-                        let payment_hash = hex::encode(&swap_info.payment_hash);
-                        let open_channel_bolt11 = self
-                            .persister
-                            .get_open_channel_bolt11_by_hash(payment_hash.as_str())?;
-                        match open_channel_bolt11 {
-                            Some(bolt11) => bolt11,
-                            None => {
-                                let res = self
-                                    .node_api
-                                    .fetch_bolt11(swap_info.payment_hash)
-                                    .await?
-                                    .ok_or(anyhow!(
-                                        "Preimage already known, but invoice not found"
-                                    ))?;
-                                self.payment_receiver.wrap_node_invoice(
-                                    &res.bolt11,
-                                    match res.payer_amount_msat {
-                                        Some(payer_amount_msat) => Some(OpenChannelParams{
-                                            payer_amount_msat,
-                                            opening_fee_params: swap_info.channel_opening_fees.ok_or(anyhow!(
-                                                "Preimage already known, invoice found, missing opening_fee_params"
-                                            ))?,
-                                        }),
-                                        None => None,
-                                    },
-                                    None,
-                                ).await.map_err(|e|anyhow!(
-                                    "Preimage already known, invoice found, failed to ensure route hint: {:?}", e
-                                ))?
-                            }
-                        }
-                    }
-
-                    // In all other cases: throw error
-                    Err(err) => return Err(anyhow!("Failed to create invoice: {err}")),
-                };
-
-                // If we have a new invoice, created or fetched from GL, associate it with the swap
-                self.persister
-                    .update_swap_bolt11(bitcoin_address, new_bolt11.clone())?;
-                self.emit_swap_updated(&swap_info.bitcoin_address)?;
-                new_bolt11
-            }
-        };
-
-        // Asking the service to initiate the lightning payment.
-        self.swapper_api.complete_swap(bolt11).await
-    }
-
-    pub(crate) async fn prepare_refund_swap(
-        &self,
-        req: PrepareRefundRequest,
-    ) -> Result<PrepareRefundResponse> {
-        let swap_info = self.get_swap_info_ok(req.swap_address.clone())?;
-
-        let utxos = self.get_address_utxos(req.swap_address).await?;
-
-        let refund_tx = prepare_refund_tx(&utxos, req.to_address, swap_info.lock_height as u32)?;
-
-        let refund_tx_weight = compute_refund_tx_weight(&refund_tx);
-        let refund_tx_fee_sat = compute_tx_fee(refund_tx_weight, req.sat_per_vbyte);
-        Ok(PrepareRefundResponse {
-            refund_tx_weight,
-            refund_tx_fee_sat,
-        })
-    }
-
-    // refund_swap is the user way to receive on-chain refund for failed swaps.
-    pub(crate) async fn refund_swap(&self, req: RefundRequest) -> Result<RefundResponse> {
-        let swap_info = self.get_swap_info_ok(req.swap_address.clone())?;
-
-        let utxos = self.get_address_utxos(req.swap_address.clone()).await?;
-
-        let script = create_submarine_swap_script(
-            swap_info.payment_hash,
-            swap_info.swapper_public_key,
-            swap_info.public_key,
-            swap_info.lock_height,
-        )?;
-        let refund_tx = create_refund_tx(
-            utxos.clone(),
-            swap_info.private_key,
-            req.to_address,
-            swap_info.lock_height as u32,
-            &script,
-            req.sat_per_vbyte,
-        )?;
-        info!("broadcasting refund tx {}", hex::encode(&refund_tx));
-        let tx_id = self.chain_service.broadcast_transaction(refund_tx).await?;
-
-        self.persister
-            .insert_swap_refund_tx_ids(swap_info.bitcoin_address, tx_id.clone())?;
-        self.emit_swap_updated(&req.swap_address)?;
-
-        Ok(RefundResponse {
-            refund_tx_id: tx_id,
-        })
-    }
-
-    async fn get_address_utxos(&self, address: String) -> Result<AddressUtxos> {
-        let transactions = self
-            .chain_service
-            .address_transactions(address.clone())
-            .await?;
-        get_utxos(address, transactions, false)
-    }
-
-    fn set_tip(&self, tip: u32) {
-        let mut current_tip = self.current_tip.lock().unwrap();
-        *current_tip = tip;
-    }
-
-    fn tip(&self) -> u32 {
-        let current_tip = self.current_tip.lock().unwrap();
-        *current_tip
-    }
-}
-
-pub(crate) struct SwapKeys {
-    pub(crate) priv_key: Vec<u8>,
-    pub(crate) preimage: Vec<u8>,
-}
-
-impl SwapKeys {
-    pub(crate) fn secret_key(&self) -> Result<SecretKey> {
-        Ok(SecretKey::from_slice(&self.priv_key)?)
-    }
-
-    pub(crate) fn public_key(&self) -> Result<PublicKey> {
-        Ok(PublicKey::from_secret_key(
-            &Secp256k1::new(),
-            &self.secret_key()?,
+        Ok((
+            SwapInfo {
+                confirmed_at: chain_info.confirmed_at,
+                confirmed_sats: chain_info.confirmed_sats,
+                confirmed_tx_ids: chain_info.confirmed_tx_ids,
+                total_incoming_txs: chain_info.total_incoming_txs,
+                unconfirmed_sats: chain_info.unconfirmed_sats,
+                unconfirmed_tx_ids: chain_info.unconfirmed_tx_ids,
+                ..swap_info.clone()
+            },
+            Some(new_chain_data),
         ))
     }
 
-    pub(crate) fn public_key_bytes(&self) -> Result<Vec<u8>> {
-        Ok(self.public_key()?.serialize().to_vec())
-    }
+    async fn refresh_swap_payment_data(&self, swap_info: &SwapInfo) -> ReceiveSwapResult<SwapInfo> {
+        let payment = self
+            .persister
+            .get_completed_payment_by_hash(&hex::encode(swap_info.payment_hash.clone()))?;
+        let payment = match payment {
+            Some(p) => p,
+            None => return Ok(swap_info.clone()),
+        };
+        debug!(
+            "found payment for hash {:?}, {:?}",
+            &hex::encode(swap_info.payment_hash.clone()),
+            payment
+        );
+        let amount_msat = payment.amount_msat;
+        let swap_info = SwapInfo {
+            paid_msat: amount_msat,
+            ..swap_info.clone()
+        };
 
-    pub(crate) fn preimage_hash_bytes(&self) -> Vec<u8> {
-        Message::from_hashed_data::<sha256::Hash>(&self.preimage[..])
-            .as_ref()
-            .to_vec()
-    }
-}
-
-pub(crate) fn create_swap_keys() -> Result<SwapKeys> {
-    let priv_key = rand::thread_rng().gen::<[u8; 32]>().to_vec();
-    let preimage = rand::thread_rng().gen::<[u8; 32]>().to_vec();
-    Ok(SwapKeys { priv_key, preimage })
-}
-
-pub(crate) fn create_submarine_swap_script(
-    invoice_hash: Vec<u8>,
-    swapper_pub_key: Vec<u8>,
-    payer_pub_key: Vec<u8>,
-    lock_height: i64,
-) -> Result<Script> {
-    let mut hasher = Ripemd160::new();
-    hasher.update(invoice_hash);
-    let result = hasher.finalize();
-
-    Ok(Builder::new()
-        .push_opcode(opcodes::all::OP_HASH160)
-        .push_slice(&result[..])
-        .push_opcode(opcodes::all::OP_EQUAL)
-        .push_opcode(opcodes::all::OP_IF)
-        .push_slice(&swapper_pub_key[..])
-        .push_opcode(opcodes::all::OP_ELSE)
-        .push_int(lock_height)
-        .push_opcode(opcodes::all::OP_CSV)
-        .push_opcode(opcodes::all::OP_DROP)
-        .push_slice(&payer_pub_key[..])
-        .push_opcode(opcodes::all::OP_ENDIF)
-        .push_opcode(opcodes::all::OP_CHECKSIG)
-        .into_script())
-}
-
-fn compute_refund_tx_weight(tx: &Transaction) -> u32 {
-    #[allow(clippy::identity_op)] // Allow "+ 0" term in sum below for clarity
-    let refund_witness_input_size: u32 = 1 + 1 + 73 + 1 + 0 + 1 + 100;
-    tx.strippedsize() as u32 * WITNESS_SCALE_FACTOR as u32
-        + refund_witness_input_size * tx.input.len() as u32
-}
-
-fn compute_tx_fee(tx_weight: u32, sat_per_vbyte: u32) -> u64 {
-    (tx_weight * sat_per_vbyte / WITNESS_SCALE_FACTOR as u32) as u64
-}
-
-/// Prepare the refund transaction that is to be used by the user in case where the swap has
-/// expired
-fn prepare_refund_tx(
-    utxos: &AddressUtxos,
-    to_address: String,
-    lock_delay: u32,
-) -> Result<Transaction> {
-    if utxos.confirmed.is_empty() {
-        return Err(anyhow!("Must have at least one input"));
-    }
-
-    let lock_time = utxos.confirmed.iter().fold(0, |accum, item| {
-        let confirmed_height = item.block_height.unwrap();
-        if accum >= confirmed_height + lock_delay {
-            accum
-        } else {
-            confirmed_height + lock_delay
+        if amount_msat != swap_info.paid_msat {
+            self.persister
+                .update_swap_paid_amount(&swap_info.bitcoin_address, amount_msat)?;
         }
-    });
 
-    let confirmed_amount: u64 = utxos
-        .confirmed
-        .iter()
-        .fold(0, |accum, item| accum + item.value);
-
-    // create the tx inputs
-    let txins: Vec<TxIn> = utxos
-        .confirmed
-        .iter()
-        .map(|utxo| TxIn {
-            previous_output: utxo.out,
-            script_sig: Script::new(),
-            sequence: Sequence(lock_delay),
-            witness: Witness::default(),
+        Ok(SwapInfo {
+            paid_msat: amount_msat,
+            ..swap_info.clone()
         })
-        .collect();
+    }
 
-    // create the tx outputs
-    let btc_address = Address::from_str(&to_address)?;
-    let tx_out: Vec<TxOut> = vec![TxOut {
-        value: confirmed_amount,
-        script_pubkey: btc_address.payload.script_pubkey(),
-    }];
+    async fn set_tip(&self, tip: u32) {
+        *self.current_tip.lock().await = tip;
+    }
 
-    // construct the transaction
-    let tx = Transaction {
-        version: 2,
-        lock_time: crate::bitcoin::PackedLockTime(lock_time),
-        input: txins,
-        output: tx_out,
-    };
-
-    Ok(tx)
+    async fn tip(&self) -> u32 {
+        *self.current_tip.lock().await
+    }
 }
 
-/// Creating the refund transaction that is to be used by the user in case where the swap has
-/// expired.
-fn create_refund_tx(
-    utxos: AddressUtxos,
-    private_key: Vec<u8>,
-    to_address: String,
-    lock_delay: u32,
-    input_script: &Script,
-    sat_per_vbyte: u32,
-) -> Result<Vec<u8>> {
-    info!("creating refund tx sat_per_vbyte {}", sat_per_vbyte);
-
-    let mut tx = prepare_refund_tx(&utxos, to_address, lock_delay)?;
-
-    let tx_weight = compute_refund_tx_weight(&tx);
-    let fees = compute_tx_fee(tx_weight, sat_per_vbyte);
-
-    if fees >= tx.output[0].value {
-        return Err(anyhow!("Insufficient funds to pay fees"));
+fn parse_address(address: &str) -> ReceiveSwapResult<SwapAddressType> {
+    let address: Address = address.parse()?;
+    match address.address_type() {
+        Some(AddressType::P2tr) => Ok(SwapAddressType::Taproot),
+        Some(AddressType::P2wsh) => Ok(SwapAddressType::Segwit),
+        _ => Err(ReceiveSwapError::InvalidAddressType),
     }
-    tx.output[0].value -= fees;
-
-    let scpt = Secp256k1::signing_only();
-
-    // go over all inputs and sign them
-    let mut signed_inputs: Vec<TxIn> = Vec::new();
-    for (index, input) in tx.input.iter().enumerate() {
-        let mut signer = SighashCache::new(&tx);
-        let sig = signer.segwit_signature_hash(
-            index,
-            input_script,
-            utxos.confirmed[index].value,
-            EcdsaSighashType::All,
-        )?;
-        let msg = Message::from_slice(&sig[..])?;
-        let secret_key = SecretKey::from_slice(private_key.as_slice())?;
-        let sig = scpt.sign_ecdsa(&msg, &secret_key);
-
-        let mut sigvec = sig.serialize_der().to_vec();
-        sigvec.push(EcdsaSighashType::All as u8);
-
-        let witness: Vec<Vec<u8>> = vec![sigvec, vec![], input_script.serialize()];
-
-        let mut signed_input = input.clone();
-        let w = Witness::from_vec(witness);
-        signed_input.witness = w;
-        signed_inputs.push(signed_input);
-    }
-    tx.input = signed_inputs;
-
-    //tx.output[0].value = confirmed_amount;
-    Ok(encode::serialize(&tx))
 }
 
-#[cfg(test)]
-mod tests {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    use std::{sync::Arc, vec};
-
-    use anyhow::Result;
-
-    use crate::chain::{AddressUtxos, Utxo};
-    use crate::persist::swap::SwapChainInfo;
-    use crate::swap_in::swap::{compute_refund_tx_weight, compute_tx_fee, prepare_refund_tx};
-    use crate::test_utils::{get_test_ofp, MockNodeAPI};
-    use crate::{
-        bitcoin::consensus::deserialize,
-        bitcoin::hashes::{hex::FromHex, sha256},
-        bitcoin::{
-            secp256k1::{Message, PublicKey, Secp256k1, SecretKey},
-            OutPoint, Transaction, Txid,
-        },
-        breez_services::tests::get_dummy_node_state,
-        chain::{ChainService, OnchainTx},
-        models::*,
-        persist::db::SqliteStorage,
-        test_utils::{
-            create_test_config, create_test_persister, MockChainService, MockReceiver,
-            MockSwapperAPI,
-        },
-        BreezEvent,
-    };
-
-    use super::{create_refund_tx, create_submarine_swap_script, get_utxos, BTCReceiveSwap};
-
-    #[test]
-    fn test_build_swap_script() -> Result<()> {
-        // swap payer private/public key pair
-        // swap payer public key
-        let secp = Secp256k1::new();
-        let private_key = SecretKey::from_slice(&hex::decode(
-            "1ab3fe9f94ff1332d6f198484c3677832d1162781f86ce85f6d7587fa97f0330",
-        )?)?;
-        let pub_key = PublicKey::from_secret_key(&secp, &private_key)
-            .serialize()
-            .to_vec();
-
-        // Another pair for preimage/hash
-        let preimage =
-            hex::decode("4bedf04d0e1ed625e8863163e26abe4e1e6e3e9e5a25fa28cf4fe89500aadd46")?;
-        let hash = Message::from_hashed_data::<sha256::Hash>(&preimage[..])
-            .as_ref()
-            .to_vec();
-
-        // refund lock height
-        let lock_height = 288;
-
-        // swapper pubkey
-        let swapper_pubkey =
-            hex::decode("02b7952870655802bf863fd180de26ceec466d5454da949b159da8c1bf0cb3fe88")?;
-
-        let expected_address = "bc1qwxgj02vc9esa32ylkrqnhmvcamwtd95wndxqpdwk4mh9pj4629uqcjwv8l";
-
-        // create the script
-        let script = create_submarine_swap_script(hash, swapper_pubkey, pub_key, lock_height)?;
-
-        // compare the expected and created script
-        let expected_script = "a91458163502b02967cfb7c0f3859874db702121b5d487632102b7952870655802bf863fd180de26ceec466d5454da949b159da8c1bf0cb3fe8867022001b27521024ad3b16767cf68d59c41b9544e42340959479447a82a5cd24c320e1ce92adb0968ac".to_string();
-        let serialized_script = hex::encode(script.as_bytes());
-        assert_eq!(expected_script, serialized_script);
-
-        // compare the expected and created swap address
-        let address = crate::bitcoin::Address::p2wsh(&script, crate::bitcoin::Network::Bitcoin);
-        let address_str = address.to_string();
-        assert_eq!(address_str, expected_address);
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_get_utxo() -> Result<()> {
-        let swap_address = String::from("35kRn3rF7oDFU1BFRHuQM9txBWBXqipoJ3");
-        let txs: Vec<OnchainTx> = serde_json::from_str(
-            r#"[{"txid":"5e0668bf1cd24f2f8656ee82d4886f5303a06b26838e24b7db73afc59e228985","version":2,"locktime":0,"vin":[{"txid":"07c9d3fbffc20f96ea7c93ef3bcdf346c8a8456c25850ea76be62b24a7cf690c","vout":0,"prevout":{"scriptpubkey":"001465c96c830168b8f0b584294d3b9716bb8584c2d8","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 65c96c830168b8f0b584294d3b9716bb8584c2d8","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bc1qvhykeqcpdzu0pdvy99xnh9ckhwzcfskct6h6l2","value":263216},"scriptsig":"","scriptsig_asm":"","witness":["3045022100a2f0ac810ce88625890f7e212d175eb1cd6b7c73ffed95a2bec06b38e0b2de060220036675c6a5c89845988cc27e7acba772e7655f2abb0575449471d8323d5900b301","026b815dddaf1687a05349d75d25911c9b6e2381e55ba72148009cfa0a577c89d9"],"is_coinbase":false,"sequence":0},{"txid":"6d6766c283093e2d043ae877bb915175b3d8672a20f0459300267aaab1b5766a","vout":0,"prevout":{"scriptpubkey":"001485b33c1937058ed08b5b122e30caf18e67ccb282","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 85b33c1937058ed08b5b122e30caf18e67ccb282","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bc1qskencxfhqk8dpz6mzghrpjh33enuev5zh0mrjw","value":33247},"scriptsig":"","scriptsig_asm":"","witness":["304402200272cac1a312aae2a4ee64150e5b26e611a56509a467176e38c905b632d3ce56022005497d0d3ff14911214cb0fbb22a1aa16830ba669f6ff38723684750ceb4b11a01","0397d3b72557bd2044508ee3b22d1216b3f871c0963500f8c8dc6a143ee7a6a206"],"is_coinbase":false,"sequence":0},{"txid":"81af33ae00a9dadeb83b915b05742e986a470fff7456540e3f018deb94abda0e","vout":1,"prevout":{"scriptpubkey":"001431505647092347abb0e4d2a34f6773b74a999d45","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 31505647092347abb0e4d2a34f6773b74a999d45","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bc1qx9g9v3cfydr6hv8y62357emnka9fn8294e73yl","value":172952},"scriptsig":"","scriptsig_asm":"","witness":["30450221008426c1b3d535f10c7cbccec6be3ea9be3514f3a86bf234584722665325283f35022010b6a617a465d1d7eea45562632f0ab80b0894da44b67fab65191a98fd9d3acb01","0221250914423379d3caf662297e8069621ca2c362cf92107388483929f4d9eb67"],"is_coinbase":false,"sequence":0}],"vout":[{"scriptpubkey":"001459c70c09f22b1bb007439af43b6809d6a2bc31b5","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 59c70c09f22b1bb007439af43b6809d6a2bc31b5","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bc1qt8rscz0j9vdmqp6rnt6rk6qf663tcvd44f6gxa","value":2920},{"scriptpubkey":"00202c404e6e9c4d032267a29a6074c5db9333c6ccae0c9d430ced666316233d8c2f","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_32 2c404e6e9c4d032267a29a6074c5db9333c6ccae0c9d430ced666316233d8c2f","scriptpubkey_type":"v0_p2wsh","scriptpubkey_address":"bc1q93qyum5uf5pjyeaznfs8f3wmjveudn9wpjw5xr8dve33vgea3shs9jhvww","value":442557}],"size":532,"weight":1153,"fee":23938,"status":{"confirmed":true,"block_height":674358,"block_hash":"00000000000000000004c6171622f56692cc480d3c76ecae4355e69699a6ae44","block_time":1615595727}},{"txid":"07c9d3fbffc20f96ea7c93ef3bcdf346c8a8456c25850ea76be62b24a7cf690c","version":2,"locktime":0,"vin":[{"txid":"9332d8d11d81c3b674caff75db5543491e7f22e619ecc034bedf4a007518fe3a","vout":0,"prevout":{"scriptpubkey":"001415f0dad74806b03612687038d4f5bab200afcf8e","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 15f0dad74806b03612687038d4f5bab200afcf8e","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bc1qzhcd446gq6crvyngwqudfad6kgq2lnuw9r2a86","value":470675},"scriptsig":"","scriptsig_asm":"","witness":["3045022100f30d84532f96b5e489047174e81394883cd519d427ca8f4facc2366f718cc678022007c083634402f40708c645cd0c1a2757b56de2076ca6ee856e514859381cd93801","02942b44eb4289e3af0aeeb73dfa82b0a5c8a3a06ae85bfd22aa3dcfcd64096462"],"is_coinbase":false,"sequence":0},{"txid":"c62da0c2d1929ab2a2c04d4fbae2a6e4e947f867cba584d1f80c4a1a62f4a75f","vout":1,"prevout":{"scriptpubkey":"0014f0c1d6b471d5e4a483fc146d4220a4e81587bf11","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 f0c1d6b471d5e4a483fc146d4220a4e81587bf11","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bc1q7rqaddr36hj2fqluz3k5yg9yaq2c00c3tw4qy5","value":899778},"scriptsig":"","scriptsig_asm":"","witness":["304402202da0eac25786003181526c4fe1592f982aa8d0f32c642a5103cdebbf4aa8b5a80220750cd6859bfb9a7df8d7c4d79a70e17a6df87f150fe1fdaade4650332ef0f47c01","02ecab80fcfe949633064c25fc33854fd09b8730decdf679db1f429bce201ec685"],"is_coinbase":false,"sequence":0}],"vout":[{"scriptpubkey":"001465c96c830168b8f0b584294d3b9716bb8584c2d8","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 65c96c830168b8f0b584294d3b9716bb8584c2d8","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bc1qvhykeqcpdzu0pdvy99xnh9ckhwzcfskct6h6l2","value":263216},{"scriptpubkey":"00200cea60ae9eea43e64b17ba65a4c17bd3acf9dac307825deda85d5a093181dbc0","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_32 0cea60ae9eea43e64b17ba65a4c17bd3acf9dac307825deda85d5a093181dbc0","scriptpubkey_type":"v0_p2wsh","scriptpubkey_address":"bc1qpn4xpt57afp7vjchhfj6fstm6wk0nkkrq7p9mmdgt4dqjvvpm0qqlxqrns","value":1088924}],"size":383,"weight":881,"fee":18313,"status":{"confirmed":true,"block_height":674357,"block_hash":"00000000000000000008d0d007995a8bc9d60de17bd6b55e28a6e4c6918cb206","block_time":1615594996}}]"#,
-        )?;
-        let utxos = get_utxos(swap_address, txs, true)?;
-        assert_eq!(utxos.confirmed.len(), 0);
-
-        let swap_address = String::from("35kRn3rF7oDFU1BFRHuQM9txBWBXqipoJ3");
-        let txs: Vec<OnchainTx> = serde_json::from_str(r#"[{"txid":"9f13dd16167430c2ccb3b89b5f915a3c836722c486e30505791c9604f1017a99","version":1,"locktime":0,"vin":[{"txid":"3d8e3b3e7ad5a396902f8814a5446139dd55757c6f3fa5fc63e905f1fef00a10","vout":66,"prevout":{"scriptpubkey":"a914b0f4345fad758790048c03d46fccf66b852ec9e387","scriptpubkey_asm":"OP_HASH160 OP_PUSHBYTES_20 b0f4345fad758790048c03d46fccf66b852ec9e3 OP_EQUAL","scriptpubkey_type":"p2sh","scriptpubkey_address":"3HpfPwMTCggpmwMNxebnJB6y8jJP8Y3mdM","value":8832100},"scriptsig":"160014716588545d5a9ddcc2e38802d7382b8fc37e90ba","scriptsig_asm":"OP_PUSHBYTES_22 0014716588545d5a9ddcc2e38802d7382b8fc37e90ba","witness":["30450221008d73700314bd2de9e56256ce0548fe08f220f5c928075a242ca9a7980b0e7f5602202701318e9a6c3ba128dcf915c6c3997928e9870d4023150e6bfb84a783617a1c01","025dddb140932a1247c1cdc2dec534ba2a7647bb03c989a88e6d18117517f388f3"],"is_coinbase":false,"sequence":4294967293,"inner_redeemscript_asm":"OP_0 OP_PUSHBYTES_20 716588545d5a9ddcc2e38802d7382b8fc37e90ba"},{"txid":"9e64ea8118b13871d02d941552fa42af6d079e4e9384aa71a7da747d52cb468b","vout":0,"prevout":{"scriptpubkey":"a914b7969fec4adfad203881f98b6c04dfeeff774f5487","scriptpubkey_asm":"OP_HASH160 OP_PUSHBYTES_20 b7969fec4adfad203881f98b6c04dfeeff774f54 OP_EQUAL","scriptpubkey_type":"p2sh","scriptpubkey_address":"3JRk2EfAr1mjYmXSMf5heBRnA6ym7WFsX1","value":23093207},"scriptsig":"160014d7f0a22aab7bd11dcb977e43f06ecfd6c44b7c2d","scriptsig_asm":"OP_PUSHBYTES_22 0014d7f0a22aab7bd11dcb977e43f06ecfd6c44b7c2d","witness":["30440220368b9584a2837542b600bbce16293811b01d0c5f919d153eb0d6c6716c4357000220379b6f91cb24c3d8193e39acaed2dbb973084bff10aff48059a1086672c5cde401","02074b5af43b526fedea5527edf1d246d1821867f161ebd9ca26295e21aeddb30a"],"is_coinbase":false,"sequence":4294967293,"inner_redeemscript_asm":"OP_0 OP_PUSHBYTES_20 d7f0a22aab7bd11dcb977e43f06ecfd6c44b7c2d"}],"vout":[{"scriptpubkey":"a9142c85a9b818d3cdf89bd3a1057bb21b2c7e64ad6087","scriptpubkey_asm":"OP_HASH160 OP_PUSHBYTES_20 2c85a9b818d3cdf89bd3a1057bb21b2c7e64ad60 OP_EQUAL","scriptpubkey_type":"p2sh","scriptpubkey_address":"35kRn3rF7oDFU1BFRHuQM9txBWBXqipoJ3","value":31461100}],"size":387,"weight":897,"fee":464207,"status":{"confirmed":true,"block_height":764153,"block_hash":"00000000000000000000199349a95526c4f83959f0ef06697048a297f25e7fac","block_time":1669044812}}]"#).unwrap();
-        let utxos = get_utxos(swap_address, txs, true)?;
-        assert_eq!(utxos.confirmed.len(), 1);
-
-        // test mempool transactions
-        let swap_address = String::from("35kRn3rF7oDFU1BFRHuQM9txBWBXqipoJ3");
-        let txs: Vec<OnchainTx> = serde_json::from_str(
-            r#"[{"txid":"9f13dd16167430c2ccb3b89b5f915a3c836722c486e30505791c9604f1017a99","version":1,"locktime":0,"vin":[{"txid":"3d8e3b3e7ad5a396902f8814a5446139dd55757c6f3fa5fc63e905f1fef00a10","vout":66,"prevout":{"scriptpubkey":"a914b0f4345fad758790048c03d46fccf66b852ec9e387","scriptpubkey_asm":"OP_HASH160 OP_PUSHBYTES_20 b0f4345fad758790048c03d46fccf66b852ec9e3 OP_EQUAL","scriptpubkey_type":"p2sh","scriptpubkey_address":"3HpfPwMTCggpmwMNxebnJB6y8jJP8Y3mdM","value":8832100},"scriptsig":"160014716588545d5a9ddcc2e38802d7382b8fc37e90ba","scriptsig_asm":"OP_PUSHBYTES_22 0014716588545d5a9ddcc2e38802d7382b8fc37e90ba","witness":["30450221008d73700314bd2de9e56256ce0548fe08f220f5c928075a242ca9a7980b0e7f5602202701318e9a6c3ba128dcf915c6c3997928e9870d4023150e6bfb84a783617a1c01","025dddb140932a1247c1cdc2dec534ba2a7647bb03c989a88e6d18117517f388f3"],"is_coinbase":false,"sequence":4294967293,"inner_redeemscript_asm":"OP_0 OP_PUSHBYTES_20 716588545d5a9ddcc2e38802d7382b8fc37e90ba"},{"txid":"9e64ea8118b13871d02d941552fa42af6d079e4e9384aa71a7da747d52cb468b","vout":0,"prevout":{"scriptpubkey":"a914b7969fec4adfad203881f98b6c04dfeeff774f5487","scriptpubkey_asm":"OP_HASH160 OP_PUSHBYTES_20 b7969fec4adfad203881f98b6c04dfeeff774f54 OP_EQUAL","scriptpubkey_type":"p2sh","scriptpubkey_address":"3JRk2EfAr1mjYmXSMf5heBRnA6ym7WFsX1","value":23093207},"scriptsig":"160014d7f0a22aab7bd11dcb977e43f06ecfd6c44b7c2d","scriptsig_asm":"OP_PUSHBYTES_22 0014d7f0a22aab7bd11dcb977e43f06ecfd6c44b7c2d","witness":["30440220368b9584a2837542b600bbce16293811b01d0c5f919d153eb0d6c6716c4357000220379b6f91cb24c3d8193e39acaed2dbb973084bff10aff48059a1086672c5cde401","02074b5af43b526fedea5527edf1d246d1821867f161ebd9ca26295e21aeddb30a"],"is_coinbase":false,"sequence":4294967293,"inner_redeemscript_asm":"OP_0 OP_PUSHBYTES_20 d7f0a22aab7bd11dcb977e43f06ecfd6c44b7c2d"}],"vout":[{"scriptpubkey":"a9142c85a9b818d3cdf89bd3a1057bb21b2c7e64ad6087","scriptpubkey_asm":"OP_HASH160 OP_PUSHBYTES_20 2c85a9b818d3cdf89bd3a1057bb21b2c7e64ad60 OP_EQUAL","scriptpubkey_type":"p2sh","scriptpubkey_address":"35kRn3rF7oDFU1BFRHuQM9txBWBXqipoJ3","value":31461100}],"size":387,"weight":897,"fee":464207,"status":{"confirmed":false}}]"#,
-        )?;
-        let utxos = get_utxos(swap_address, txs, true)?;
-        assert_eq!(utxos.confirmed.len(), 0);
-        assert_eq!(utxos.unconfirmed.len(), 1);
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_swap_max_allowed_deposit() -> Result<()> {
-        let chain_service = Arc::new(MockChainService::default());
-        let (swapper, persister) = create_swapper(chain_service.clone())?;
-        let swap_info = swapper
-            .create_swap_address(get_test_ofp(10, 10, true).into())
-            .await?;
-
-        assert_eq!(swap_info.max_swapper_payable, 4_000_000);
-        assert_eq!(swap_info.max_allowed_deposit, 4_000_000);
-
-        // After changing the node's max_receivable_msat, the swap max_allowed_deposit changes as well when the swap is fetched
-        let custom_max_receivable = 1_000_000;
-        let mut dummy_node_state = get_dummy_node_state();
-        dummy_node_state.max_receivable_msat = custom_max_receivable * 1_000;
-        persister.set_node_state(&dummy_node_state)?;
-
-        let swap_info = swapper
-            .create_swap_address(get_test_ofp(10, 10, true).into())
-            .await?;
-        assert_eq!(swap_info.max_swapper_payable, 4_000_000);
-        assert_eq!(swap_info.max_allowed_deposit, custom_max_receivable as i64);
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_swap_statuses() -> Result<()> {
-        let tip = 1000;
-        let chain_service = Arc::new(MockChainService::default());
-        let (swapper, persister) = create_swapper(chain_service.clone())?;
-        let mut swap_info = swapper
-            .create_swap_address(get_test_ofp(10, 10, true).into())
-            .await?;
-
-        // test initial status
-        assert_eq!(swap_info.status, SwapStatus::Initial);
-        assert_eq!(swapper.list_in_progress()?.len(), 0);
-        assert_eq!(swapper.list_monitored()?.len(), 1);
-        assert_eq!(swapper.list_redeemables()?.len(), 0);
-        assert_eq!(swapper.list_refundables()?.len(), 0);
-        assert_eq!(swapper.list_unused()?.len(), 1);
-
-        // test with uncormfirmed tx
-        let chain_info = SwapChainInfo {
-            confirmed_tx_ids: vec![],
-            confirmed_sats: 0,
-            confirmed_at: None,
-            unconfirmed_sats: 5000,
-            unconfirmed_tx_ids: vec!["222".into()],
-            total_incoming_txs: 0,
-        };
-        swap_info = swap_info.with_chain_info(chain_info.clone(), tip);
-        persister.update_swap_chain_info(
-            swap_info.bitcoin_address.clone(),
-            chain_info,
-            swap_info.status.clone(),
-        )?;
-        assert_eq!(swap_info.status, SwapStatus::WaitingConfirmation);
-        assert_eq!(swapper.list_in_progress()?.len(), 1);
-        assert_eq!(swapper.list_monitored()?.len(), 1);
-        assert_eq!(swapper.list_redeemables()?.len(), 0);
-        assert_eq!(swapper.list_refundables()?.len(), 0);
-        assert_eq!(swapper.list_unused()?.len(), 0);
-
-        // test with confirmed tx
-        let chain_info = SwapChainInfo {
-            confirmed_tx_ids: vec!["222".into()],
-            confirmed_sats: 5000,
-            confirmed_at: Some(1000),
-            unconfirmed_sats: 0,
-            unconfirmed_tx_ids: vec![],
-            total_incoming_txs: 1,
-        };
-        swap_info = swap_info.with_chain_info(chain_info.clone(), tip);
-        persister.update_swap_chain_info(
-            swap_info.bitcoin_address.clone(),
-            chain_info,
-            swap_info.status.clone(),
-        )?;
-        assert_eq!(swap_info.status, SwapStatus::Redeemable);
-        assert_eq!(swapper.list_in_progress()?.len(), 1);
-        assert_eq!(swapper.list_monitored()?.len(), 1);
-        assert_eq!(swapper.list_redeemables()?.len(), 1);
-        assert_eq!(swapper.list_refundables()?.len(), 0);
-        assert_eq!(swapper.list_unused()?.len(), 0);
-
-        // test with confirmed and uncofirmed tx
-        let chain_info = SwapChainInfo {
-            confirmed_tx_ids: vec!["222".into()],
-            confirmed_sats: 5000,
-            confirmed_at: Some(1000),
-            unconfirmed_sats: 2000,
-            unconfirmed_tx_ids: vec!["111".into()],
-            total_incoming_txs: 1,
-        };
-        swap_info = swap_info.with_chain_info(chain_info.clone(), tip);
-        persister.update_swap_chain_info(
-            swap_info.bitcoin_address.clone(),
-            chain_info,
-            swap_info.status.clone(),
-        )?;
-        assert_eq!(swap_info.status, SwapStatus::Redeemable);
-        assert_eq!(swapper.list_in_progress()?.len(), 1);
-        assert_eq!(swapper.list_monitored()?.len(), 1);
-        assert_eq!(swapper.list_redeemables()?.len(), 1);
-        assert_eq!(swapper.list_refundables()?.len(), 0);
-        assert_eq!(swapper.list_unused()?.len(), 0);
-
-        // test with paid amount
-        swap_info = swap_info.with_paid_amount(5000000, tip);
-        persister.update_swap_paid_amount(
-            swap_info.bitcoin_address.clone(),
-            5000000,
-            swap_info.status.clone(),
-        )?;
-        assert_eq!(swap_info.status, SwapStatus::Redeemed);
-        assert_eq!(swapper.list_in_progress()?.len(), 0);
-        assert_eq!(swapper.list_monitored()?.len(), 1);
-        assert_eq!(swapper.list_redeemables()?.len(), 0);
-        assert_eq!(swapper.list_refundables()?.len(), 0);
-        assert_eq!(swapper.list_unused()?.len(), 0);
-
-        // test refundable
-        let chain_info = SwapChainInfo {
-            confirmed_tx_ids: vec!["222".into()],
-            confirmed_sats: 5000,
-            confirmed_at: Some(1000),
-            unconfirmed_sats: 2000,
-            unconfirmed_tx_ids: vec!["111".into()],
-            total_incoming_txs: 1,
-        };
-        swap_info = swap_info.with_chain_info(chain_info.clone(), tip + 1000);
-        persister.update_swap_chain_info(
-            swap_info.bitcoin_address.clone(),
-            chain_info,
-            swap_info.status.clone(),
-        )?;
-
-        assert_eq!(swap_info.status, SwapStatus::Refundable);
-        assert_eq!(swapper.list_in_progress()?.len(), 0);
-        assert_eq!(swapper.list_monitored()?.len(), 1);
-        assert_eq!(swapper.list_redeemables()?.len(), 0);
-        assert_eq!(swapper.list_refundables()?.len(), 1);
-        assert_eq!(swapper.list_unused()?.len(), 0);
-
-        // test completed
-        let chain_info = SwapChainInfo {
-            confirmed_tx_ids: vec![],
-            confirmed_sats: 0,
-            confirmed_at: Some(1000),
-            unconfirmed_sats: 0,
-            unconfirmed_tx_ids: vec![],
-            total_incoming_txs: 0,
-        };
-        swap_info = swap_info.with_chain_info(chain_info.clone(), tip + 1000);
-        persister.update_swap_chain_info(
-            swap_info.bitcoin_address.clone(),
-            chain_info,
-            swap_info.status.clone(),
-        )?;
-        assert_eq!(swap_info.status, SwapStatus::Completed);
-        assert_eq!(swapper.list_in_progress()?.len(), 0);
-        assert_eq!(swapper.list_monitored()?.len(), 0);
-        assert_eq!(swapper.list_redeemables()?.len(), 0);
-        assert_eq!(swapper.list_refundables()?.len(), 0);
-        assert_eq!(swapper.list_unused()?.len(), 0);
-
-        Ok(())
-    }
-
-    // 1. User has sent funds to swap address
-    // 2. Swap didn't complete before timeout
-    // Swap should move to Expired status and returned in the refundable list.
-    #[tokio::test]
-    async fn test_expired_swap() -> Result<()> {
-        let chain_service = Arc::new(MockChainService::default());
-        let (mut swapper, _) = create_swapper(chain_service.clone())?;
-        let swap_info = swapper
-            .create_swap_address(get_test_ofp(10, 10, true).into())
-            .await?;
-        assert_eq!(swap_info.confirmed_at, None);
-        // We test the case that a confirmed transaction was detected on chain that
-        // sent funds to this address but the lock timeout has expired.
-        swapper.chain_service = chain_service_with_confirmed_txs(swap_info.clone().bitcoin_address);
-        let mut receiver = swapper.subscribe_status_changes();
-        tokio::spawn(async move {
-            let _ = receiver.recv().await;
-        });
-        swapper
-            .on_event(BreezEvent::NewBlock {
-                block: chain_service.tip + 145,
-            })
-            .await?;
-        let swap = swapper
-            .get_swap_info(swap_info.clone().bitcoin_address)?
-            .unwrap();
-        assert_eq!(swap.refund_tx_ids, Vec::<String>::new());
-        assert_eq!(
-            swap.confirmed_tx_ids,
-            vec!["ec901bcab07df7d475d98fff2933dcb56d57bbdaa029c4142aed93462b6928fe".to_string()]
-        );
-
-        assert_eq!(swap.confirmed_sats, 50000);
-        assert_eq!(swap.confirmed_at.unwrap(), 767637);
-        assert_eq!(swap.paid_msat, 0);
-        assert_eq!(swap.status, SwapStatus::Refundable);
-        assert_eq!(swapper.list_redeemables().unwrap().len(), 0);
-        assert_eq!(swapper.list_refundables().unwrap().len(), 1);
-
-        // broadcast refund transaction
-        let req = RefundRequest {
-            swap_address: swap.bitcoin_address,
-            to_address: String::from("34RQERthXaruAXtW6q1bvrGTeUbqi2Sm1i"),
-            sat_per_vbyte: 1,
-        };
-        let refund_response = swapper.refund_swap(req).await?;
-        let swap = swapper
-            .get_swap_info(swap_info.clone().bitcoin_address)?
-            .unwrap();
-        assert_eq!(swap.status, SwapStatus::Refundable);
-        assert_eq!(swapper.list_redeemables().unwrap().len(), 0);
-        // the swap should be refundable by now
-        let refundables = swapper.list_refundables()?;
-        assert_eq!(refundables.len(), 1);
-        assert_eq!(refundables[0].clone().refund_tx_ids.len(), 1);
-        assert_eq!(
-            refundables[0].clone().refund_tx_ids[0],
-            refund_response.refund_tx_id
-        );
-        Ok(())
-    }
-
-    // 1. User sent funds to swap address
-    // 2. Funds are redeemed in lightning transaction
-    // Swap paid amount is updated and no longer redeemable.
-    #[tokio::test]
-    async fn test_redeem_swap() -> Result<()> {
-        let chain_service = Arc::new(MockChainService::default());
-        let (mut swapper, persister) = create_swapper(chain_service.clone())?;
-        let mut receiver = swapper.subscribe_status_changes();
-        tokio::spawn(async move {
-            let _ = receiver.recv().await;
-        });
-        let swap_info = swapper
-            .create_swap_address(get_test_ofp(10, 10, true).into())
-            .await?;
-
-        // add a payment with the same hash and test that the swapper updates the paid_amount for
-        // the swap.
-        let payment = Payment {
-            id: hex::encode(swap_info.payment_hash.clone()),
-            payment_type: PaymentType::Received,
-            payment_time: 0,
-            amount_msat: 5_000,
-            fee_msat: 0,
-            status: PaymentStatus::Complete,
-            error: None,
-            description: Some("desc".to_string()),
-            details: PaymentDetails::Ln {
-                data: LnPaymentDetails {
-                    payment_hash: hex::encode(swap_info.payment_hash.clone()),
-                    label: "".to_string(),
-                    destination_pubkey: "".to_string(),
-                    payment_preimage: "111".to_string(),
-                    keysend: false,
-                    bolt11: "".to_string(),
-                    lnurl_success_action: None,
-                    lnurl_pay_domain: None,
-                    lnurl_pay_comment: None,
-                    lnurl_metadata: None,
-                    ln_address: None,
-                    lnurl_withdraw_endpoint: None,
-                    swap_info: None,
-                    reverse_swap_info: None,
-                    pending_expiration_block: None,
-                    open_channel_bolt11: None,
-                },
-            },
-            metadata: None,
-        };
-        persister.insert_or_update_payments(&vec![payment.clone()], false)?;
-
-        // We test the case that a confirmed transaction was detected on chain that
-        // sent funds to this address.
-        swapper.chain_service = chain_service_with_confirmed_txs(swap_info.clone().bitcoin_address);
-        swapper
-            .on_event(BreezEvent::NewBlock {
-                block: chain_service.tip + 1,
-            })
-            .await?;
-
-        let swap = swapper
-            .get_swap_info(swap_info.clone().bitcoin_address)?
-            .unwrap();
-        assert_eq!(swap.refund_tx_ids, Vec::<String>::new());
-        assert_eq!(
-            swap.confirmed_tx_ids,
-            vec!["ec901bcab07df7d475d98fff2933dcb56d57bbdaa029c4142aed93462b6928fe".to_string()]
-        );
-        assert_eq!(swap.confirmed_at.unwrap(), 767637);
-
-        assert_eq!(swap.confirmed_sats, 50_000);
-        assert_eq!(swap.paid_msat, 5_000);
-
-        assert_eq!(swapper.list_redeemables().unwrap().len(), 0);
-        assert_eq!(swapper.list_refundables().unwrap().len(), 0);
-
-        // change payment amount and test that the InvoicePaid event triggers updating the
-        // paid_amount of the swap.
-        let mut payment = payment.clone();
-        payment.amount_msat = 2_000;
-        persister.insert_or_update_payments(&vec![payment], false)?;
-        swapper
-            .on_event(BreezEvent::InvoicePaid {
-                details: crate::InvoicePaidDetails {
-                    payment_hash: hex::encode(swap_info.payment_hash.clone()),
-                    bolt11: "".to_string(),
-                    payment: None,
-                },
-            })
-            .await?;
-        let swap = swapper
-            .get_swap_info(swap_info.clone().bitcoin_address)?
-            .unwrap();
-        assert_eq!(swap.paid_msat, 2_000);
-
-        Ok(())
-    }
-
-    // 1. User sent funds to swap address
-    // 2. Funds are redeemed in lightning transaction
-    // Swap paid amount is updated and no longer redeemable.
-    #[tokio::test]
-    async fn test_spent_swap() -> Result<()> {
-        let chain_service = Arc::new(MockChainService::default());
-        let (mut swapper, _) = create_swapper(chain_service.clone())?;
-        let swap_info = swapper
-            .create_swap_address(get_test_ofp(10, 10, true).into())
-            .await?;
-
-        // Once swap is spent on-chain the confirmed_sats would be set to zero again.
-        swapper.chain_service = chain_service_after_spent(swap_info.clone().bitcoin_address);
-        swapper
-            .on_event(BreezEvent::NewBlock {
-                block: chain_service.tip + 1,
-            })
-            .await?;
-
-        let swap = swapper
-            .get_swap_info(swap_info.clone().bitcoin_address)?
-            .unwrap();
-        assert_eq!(swap.refund_tx_ids, Vec::<String>::new());
-        assert_eq!(swap.confirmed_tx_ids, Vec::<String>::new());
-        assert_eq!(swap.confirmed_sats, 0);
-        assert_eq!(swapper.list_redeemables().unwrap().len(), 0);
-        assert_eq!(swapper.list_refundables().unwrap().len(), 0);
-
-        // timeout expired
-        swapper
-            .on_event(BreezEvent::NewBlock {
-                block: chain_service.tip + 145,
-            })
-            .await?;
-
-        let swap = swapper
-            .get_swap_info(swap_info.clone().bitcoin_address)?
-            .unwrap();
-
-        assert_eq!(swap.status, SwapStatus::Completed);
-        assert_eq!(swapper.list_redeemables().unwrap().len(), 0);
-        assert_eq!(swapper.list_refundables().unwrap().len(), 0);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_prepare_refund() -> Result<()> {
-        // test parameters
-        let to_address = String::from("bc1qvhykeqcpdzu0pdvy99xnh9ckhwzcfskct6h6l2");
-        let lock_time = 288;
-
-        let utxos = AddressUtxos {
-            confirmed: vec![Utxo {
-                out: OutPoint {
-                    txid: Txid::from_hex(
-                        "1ab3fe9f94ff1332d6f198484c3677832d1162781f86ce85f6d7587fa97f0330",
-                    )?,
-                    vout: 0,
-                },
-                value: 20000,
-                block_height: Some(700000),
-            }],
-            unconfirmed: vec![],
-        };
-
-        let prepared_refund_tx = prepare_refund_tx(&utxos, to_address, lock_time as u32)?;
-
-        // Get the same `Transaction` used in `test_refund()`
-        let raw_tx_bytes = hex::decode("0200000000010130037fa97f58d7f685ce861f7862112d8377364c4898f1d63213ff949ffeb31a00000000002001000001204e00000000000016001465c96c830168b8f0b584294d3b9716bb8584c2d80347304402203285efcf44640551a56c53bde677988964ef1b4d11182d5d6634096042c320120220227b625f7827993aca5b9d2f4690c5e5fae44d8d42fdd5f3778ba21df8ba7c7b010064a9148a486ff2e31d6158bf39e2608864d63fefd09d5b876321024d4b6cd1361032ca9bd2aeb9d900aa4d45d9ead80ac9423374c451a7254d076667022001b27521031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f68ac80af0a00").unwrap();
-        let tx: Transaction = deserialize(&raw_tx_bytes).unwrap();
-        let weight = Transaction::weight(&tx) as u64;
-
-        let refund_tx_weight = compute_refund_tx_weight(&prepared_refund_tx);
-        assert_eq!(refund_tx_weight, weight as u32);
-
-        let refund_tx_fee_sat = compute_tx_fee(refund_tx_weight, 0);
-        assert_eq!(refund_tx_fee_sat, 0);
-
-        let refund_tx_fee_sat = compute_tx_fee(refund_tx_weight, 1);
-        assert_eq!(refund_tx_fee_sat, weight / 4);
-
-        let refund_tx_fee_sat = compute_tx_fee(refund_tx_weight, 20);
-        assert_eq!(refund_tx_fee_sat, weight * 20 / 4);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_refund() -> Result<()> {
-        // test parameters
-        let payer_priv_key_raw = [1; 32].to_vec();
-        let swapper_priv_key_raw = [2; 32].to_vec();
-        let preimage: [u8; 32] = [3; 32];
-        let to_address = String::from("bc1qvhykeqcpdzu0pdvy99xnh9ckhwzcfskct6h6l2");
-        let lock_time = 288;
-
-        let utxos = AddressUtxos {
-            confirmed: vec![Utxo {
-                out: OutPoint {
-                    txid: Txid::from_hex(
-                        "1ab3fe9f94ff1332d6f198484c3677832d1162781f86ce85f6d7587fa97f0330",
-                    )?,
-                    vout: 0,
-                },
-                value: 20000,
-                block_height: Some(700000),
-            }],
-            unconfirmed: vec![],
-        };
-
-        // payer keys
-        let secp = Secp256k1::new();
-        let payer_private_key = SecretKey::from_slice(&payer_priv_key_raw)?;
-        let payer_pub_key = PublicKey::from_secret_key(&secp, &payer_private_key)
-            .serialize()
-            .to_vec();
-
-        // swapper keys
-        let swapper_private_key = SecretKey::from_slice(&swapper_priv_key_raw)?;
-        let swapper_pub_key = PublicKey::from_secret_key(&secp, &swapper_private_key)
-            .serialize()
-            .to_vec();
-
-        // calculate payment hash
-        let payment_hash = Message::from_hashed_data::<sha256::Hash>(&preimage[..])
-            .as_ref()
-            .to_vec();
-
-        let script =
-            create_submarine_swap_script(payment_hash, swapper_pub_key, payer_pub_key, lock_time)?;
-
-        let refund_tx = create_refund_tx(
-            utxos,
-            payer_priv_key_raw,
-            to_address,
-            lock_time as u32,
-            &script,
-            0,
-        )?;
-
-        /*  We test that the refund transaction looks like this
-           {
-            "addresses": [
-                "bc1qvhykeqcpdzu0pdvy99xnh9ckhwzcfskct6h6l2"
-            ],
-            "block_height": -1,
-            "block_index": -1,
-            "confirmations": 0,
-            "double_spend": false,
-            "fees": 0,
-            "hash": "3f9cf5bef98a0ed82c0ef8e4bd34e3624bbedf60b4cbaae3b1180569d562f2fb",
-            "inputs": [
-                {
-                    "age": 0,
-                    "output_index": 0,
-                    "prev_hash": "1ab3fe9f94ff1332d6f198484c3677832d1162781f86ce85f6d7587fa97f0330",
-                    "script_type": "empty",
-                    "sequence": 288
-                }
-            ],
-            "lock_time": 700288,
-            "opt_in_rbf": true,
-            "outputs": [
-                {
-                    "addresses": [
-                        "bc1qvhykeqcpdzu0pdvy99xnh9ckhwzcfskct6h6l2"
-                    ],
-                    "script": "001465c96c830168b8f0b584294d3b9716bb8584c2d8",
-                    "script_type": "pay-to-witness-pubkey-hash",
-                    "value": 20000
-                }
-            ],
-            "preference": "low",
-            "received": "2022-11-16T10:24:20.100655728Z",
-            "relayed_by": "3.235.183.11",
-            "size": 157,
-            "total": 20000,
-            "ver": 2,
-            "vin_sz": 1,
-            "vout_sz": 1,
-            "vsize": 101
-        }
-        */
-        assert_eq!(hex::encode(refund_tx), "0200000000010130037fa97f58d7f685ce861f7862112d8377364c4898f1d63213ff949ffeb31a00000000002001000001204e00000000000016001465c96c830168b8f0b584294d3b9716bb8584c2d80347304402203285efcf44640551a56c53bde677988964ef1b4d11182d5d6634096042c320120220227b625f7827993aca5b9d2f4690c5e5fae44d8d42fdd5f3778ba21df8ba7c7b010064a9148a486ff2e31d6158bf39e2608864d63fefd09d5b876321024d4b6cd1361032ca9bd2aeb9d900aa4d45d9ead80ac9423374c451a7254d076667022001b27521031b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f68ac80af0a00");
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_create_swap_address_uses_the_current_time() -> Result<()> {
-        let current_time = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs() as i64;
-        let chain_service = Arc::new(MockChainService::default());
-        let (swapper, _) = create_swapper(chain_service.clone())?;
-        let swap_info = swapper
-            .create_swap_address(get_test_ofp(10, 10, true).into())
-            .await?;
-        assert!(swap_info.created_at >= current_time);
-        Ok(())
-    }
-
-    fn create_swapper(
-        chain_service: Arc<dyn ChainService>,
-    ) -> Result<(BTCReceiveSwap, Arc<SqliteStorage>)> {
-        let config = create_test_config();
-        debug!("working = {}", config.working_dir);
-
-        let persister = Arc::new(create_test_persister(config));
-        persister.init()?;
-
-        let dummy_node_state = get_dummy_node_state();
-        persister.set_node_state(&dummy_node_state)?;
-
-        let swapper = BTCReceiveSwap::new(
-            crate::bitcoin::Network::Bitcoin,
-            Arc::new(MockNodeAPI::new(get_dummy_node_state())),
-            Arc::new(MockSwapperAPI {}),
-            persister.clone(),
-            chain_service.clone(),
-            Arc::new(MockReceiver::default()),
-        );
-        Ok((swapper, persister))
-    }
-
-    fn chain_service_with_confirmed_txs(address: String) -> Arc<dyn ChainService> {
-        let confirmed_txs_raw = r#"[{"txid":"ec901bcab07df7d475d98fff2933dcb56d57bbdaa029c4142aed93462b6928fe","version":1,"locktime":767636,"vin":[{"txid":"d4344fc9e7f66b3a1a50d1d76836a157629ba0c6ede093e94f1c809d334c9146","vout":0,"prevout":{"scriptpubkey":"0014cab22290b7adc75f861de820baa97d319c1110a6","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 cab22290b7adc75f861de820baa97d319c1110a6","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bc1qe2ez9y9h4hr4lpsaaqst42taxxwpzy9xlzqt8k","value":209639471},"scriptsig":"","scriptsig_asm":"","witness":["304402202e914c35b75da798f0898c7cfe6ead207aaee41219afd77124fd56971f05d9030220123ce5d124f4635171b7622995dae35e00373a5fbf8117bfdca5e5080ad6554101","02122fa6d20413bb5da5c7e3fb42228be5436b1bd84e29b294bfc200db5eac460e"],"is_coinbase":false,"sequence":4294967293}],"vout":[{"scriptpubkey":"0014b34b7da80e662d1db3fcfbe34b7f4cacc4fac34d","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 b34b7da80e662d1db3fcfbe34b7f4cacc4fac34d","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bc1qkd9hm2qwvck3mvlul035kl6v4nz04s6dmryeq5","value":50000},{"scriptpubkey":"0014f0e2a057d0e60411ac3d7218e29bf9489a59df18","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 f0e2a057d0e60411ac3d7218e29bf9489a59df18","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bc1q7r32q47suczprtpawgvw9xlefzd9nhccyatxvu","value":12140465}],"size":222,"weight":561,"fee":1753,"status":{"confirmed":true,"block_height":767637,"block_hash":"000000000000000000077769f3b2e6a28b9ed688f0d773f9ff2d73c622a2cfac","block_time":1671174562}}]"#;
-        let confirmed_txs = confirmed_txs_raw.replace(
-            "bc1qkd9hm2qwvck3mvlul035kl6v4nz04s6dmryeq5",
-            address.as_str(),
-        );
-        chain_service_with_transactions(address, confirmed_txs)
-    }
-
-    fn chain_service_after_spent(address: String) -> Arc<dyn ChainService> {
-        let txs_raw = r#"[{"txid":"a418e856bb22b6345868dc0b1ac1dd7a6b7fae1d231b275b74172f9584fa0bdf","version":1,"locktime":0,"vin":[{"txid":"ec901bcab07df7d475d98fff2933dcb56d57bbdaa029c4142aed93462b6928fe","vout":0,"prevout":{"scriptpubkey":"0014b34b7da80e662d1db3fcfbe34b7f4cacc4fac34d","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 b34b7da80e662d1db3fcfbe34b7f4cacc4fac34d","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bc1qkd9hm2qwvck3mvlul035kl6v4nz04s6dmryeq5","value":50000},"scriptsig":"","scriptsig_asm":"","witness":["304502210089933e46614114e060d3d681c54af71e3d47f8be8131d9310ef8fe231c060f3302204103910a6790e3a678964df6f0f9ae2107666a91e777bd87f9172a28653e374701","0356f385879fefb8c52758126f6e7b9ac57374c2f73f2ee9047b4c61df0ba390b9"],"is_coinbase":false,"sequence":4294967293},{"txid":"fda3ce37f5fb849502e2027958d51efebd1841cb43bbfdd5f3d354c93a551ef9","vout":0,"prevout":{"scriptpubkey":"00145c7f3b6ceb79d03d5a5397df83f2334394ebdd2c","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 5c7f3b6ceb79d03d5a5397df83f2334394ebdd2c","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bc1qt3lnkm8t08gr6kjnjl0c8u3ngw2whhfvzwsxrg","value":786885},"scriptsig":"","scriptsig_asm":"","witness":["304402200ae5465efe824609f7faf1094cce0195763df52e5409dd9ae0526568bf3bcaa20220103749041a87e082cf95bf1e12c5174881e5e4c55e75ab2db29a68538dbabbad01","03dfd8cc1f72f46d259dc0afc6d756bce551fce2fbf58a9ad36409a1b82a17e64f"],"is_coinbase":false,"sequence":4294967293}],"vout":[{"scriptpubkey":"a9141df45814863edfd6d87457e8f8bd79607a116a8f87","scriptpubkey_asm":"OP_HASH160 OP_PUSHBYTES_20 1df45814863edfd6d87457e8f8bd79607a116a8f OP_EQUAL","scriptpubkey_type":"p2sh","scriptpubkey_address":"34RQERthXaruAXtW6q1bvrGTeUbqi2Sm1i","value":26087585},{"scriptpubkey":"001479001aa5f4b981a0b654c3f834d0573595b0ed53","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 79001aa5f4b981a0b654c3f834d0573595b0ed53","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bc1q0yqp4f05hxq6pdj5c0urf5zhxk2mpm2ndx85za","value":171937413}],"size":372,"weight":837,"fee":259140,"status":{"confirmed":true,"block_height":767637,"block_hash":"000000000000000000077769f3b2e6a28b9ed688f0d773f9ff2d73c622a2cfac","block_time":1671174562}},{"txid":"ec901bcab07df7d475d98fff2933dcb56d57bbdaa029c4142aed93462b6928fe","version":1,"locktime":767636,"vin":[{"txid":"d4344fc9e7f66b3a1a50d1d76836a157629ba0c6ede093e94f1c809d334c9146","vout":0,"prevout":{"scriptpubkey":"0014cab22290b7adc75f861de820baa97d319c1110a6","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 cab22290b7adc75f861de820baa97d319c1110a6","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bc1qe2ez9y9h4hr4lpsaaqst42taxxwpzy9xlzqt8k","value":209639471},"scriptsig":"","scriptsig_asm":"","witness":["304402202e914c35b75da798f0898c7cfe6ead207aaee41219afd77124fd56971f05d9030220123ce5d124f4635171b7622995dae35e00373a5fbf8117bfdca5e5080ad6554101","02122fa6d20413bb5da5c7e3fb42228be5436b1bd84e29b294bfc200db5eac460e"],"is_coinbase":false,"sequence":4294967293}],"vout":[{"scriptpubkey":"0014b34b7da80e662d1db3fcfbe34b7f4cacc4fac34d","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 b34b7da80e662d1db3fcfbe34b7f4cacc4fac34d","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bc1qkd9hm2qwvck3mvlul035kl6v4nz04s6dmryeq5","value":50000},{"scriptpubkey":"0014f0e2a057d0e60411ac3d7218e29bf9489a59df18","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 f0e2a057d0e60411ac3d7218e29bf9489a59df18","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bc1q7r32q47suczprtpawgvw9xlefzd9nhccyatxvu","value":12140465}],"size":222,"weight":561,"fee":1753,"status":{"confirmed":true,"block_height":767637,"block_hash":"000000000000000000077769f3b2e6a28b9ed688f0d773f9ff2d73c622a2cfac","block_time":1671174562}}]"#;
-        let with_spent_txs = txs_raw.replace(
-            "bc1qkd9hm2qwvck3mvlul035kl6v4nz04s6dmryeq5",
-            address.as_str(),
-        );
-        chain_service_with_transactions(address, with_spent_txs)
-    }
-
-    fn chain_service_with_transactions(
-        address: String,
-        transactions: String,
-    ) -> Arc<dyn ChainService> {
-        let mut chain_service = MockChainService::default();
-        let spent_txs_json: Vec<OnchainTx> = serde_json::from_str(&transactions).unwrap();
-        chain_service.address_to_transactions.clear();
-        chain_service
-            .address_to_transactions
-            .insert(address, spent_txs_json);
-
-        Arc::new(chain_service)
-    }
+pub(super) fn compute_tx_fee(tx_weight: usize, sat_per_vbyte: u32) -> u64 {
+    (tx_weight as u32 * sat_per_vbyte / WITNESS_SCALE_FACTOR as u32) as u64
+}
+
+fn validate_swap_limits(swap_info: &SwapInfo) -> ReceiveSwapResult<()> {
+    ensure_sdk!(
+        swap_info.max_allowed_deposit >= swap_info.min_allowed_deposit,
+        ReceiveSwapError::unsupported_swap_limits("No allowed deposit amounts")
+    );
+    Ok(())
 }

--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -538,12 +538,8 @@ impl BTCReceiveSwap {
         }
 
         let resp = match address_type {
-            SwapAddressType::Segwit => self.segwit.get_swap_payment(payment_request).await,
-            SwapAddressType::Taproot => {
-                self.taproot
-                    .get_swap_payment(&swap_info, payment_request)
-                    .await
-            }
+            SwapAddressType::Segwit => self.segwit.payout_swap(payment_request).await,
+            SwapAddressType::Taproot => self.taproot.payout_swap(&swap_info, payment_request).await,
         };
 
         let message = match resp {

--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -74,6 +74,7 @@ impl SwapKeys {
     }
 }
 
+#[derive(Eq, PartialEq)]
 enum SwapAddressType {
     Segwit,
     Taproot,
@@ -669,6 +670,15 @@ impl BTCReceiveSwap {
         // If there are utxos, but they all have unconfirmed spends, they are refundable.
         // If the spends were confirmed, they wouldn't be utxos at all.
         if chain_data.utxos().iter().all(|utxo| utxo.spend.is_some()) {
+            return SwapStatus::Refundable;
+        }
+
+        if address_type == &SwapAddressType::Taproot
+            && chain_data
+                .confirmed_utxos()
+                .iter()
+                .any(|utxo| utxo.amount_sat > swap_info.max_allowed_deposit as u64)
+        {
             return SwapStatus::Refundable;
         }
 

--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -994,7 +994,7 @@ impl BTCReceiveSwap {
                 // TODO: Substract fees here once swapper supports them.
                 amount_msat,
                 cltv: Some(144),
-                description: format!("taproot swap {}", swap_info.bitcoin_address),
+                description: String::from("Bitcoin Transfer"),
                 expiry: Some(blocks.saturating_mul(EXPIRY_SECONDS_PER_BLOCK)),
                 opening_fee_params,
                 preimage: Some(swap_info.preimage.clone()),

--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -539,11 +539,7 @@ impl BTCReceiveSwap {
         }
 
         let resp = match address_type {
-            SwapAddressType::Segwit => {
-                self.segwit
-                    .get_swap_payment(&swap_info, payment_request)
-                    .await
-            }
+            SwapAddressType::Segwit => self.segwit.get_swap_payment(payment_request).await,
             SwapAddressType::Taproot => {
                 self.taproot
                     .get_swap_payment(&swap_info, payment_request)

--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -1529,12 +1529,12 @@ mod tests {
     }
 
     async fn test_swap_state_transitions(swap: &SwapInfo) {
-        let result = test_swap_state_transition(&swap, &SwapChainData::default(), None, 1).await;
+        let result = test_swap_state_transition(swap, &SwapChainData::default(), None, 1).await;
         assert_eq!(result.status, SwapStatus::Initial);
 
         // Initial swap output is pending confirmation
         let result = test_swap_state_transition(
-            &swap,
+            swap,
             &SwapChainData {
                 outputs: vec![SwapOutput {
                     address: swap.bitcoin_address.clone(),
@@ -1552,7 +1552,7 @@ mod tests {
 
         // Initial swap output is confirmed
         let result = test_swap_state_transition(
-            &swap,
+            swap,
             &SwapChainData {
                 outputs: vec![SwapOutput {
                     address: swap.bitcoin_address.clone(),
@@ -1570,7 +1570,7 @@ mod tests {
 
         // Initial swap output is confirmed, but timelock expired
         let result = test_swap_state_transition(
-            &swap,
+            swap,
             &SwapChainData {
                 outputs: vec![SwapOutput {
                     address: swap.bitcoin_address.clone(),
@@ -1588,7 +1588,7 @@ mod tests {
 
         // Initial swap output is confirmed and was just paid. Also timelock expired.
         let result = test_swap_state_transition(
-            &swap,
+            swap,
             &SwapChainData {
                 outputs: vec![SwapOutput {
                     address: swap.bitcoin_address.clone(),
@@ -1609,7 +1609,7 @@ mod tests {
 
         // Initial swap output has a confirmed spend.
         let result = test_swap_state_transition(
-            &swap,
+            swap,
             &SwapChainData {
                 outputs: vec![SwapOutput {
                     address: swap.bitcoin_address.clone(),

--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -894,6 +894,9 @@ impl BTCReceiveSwap {
         Ok(chain_data)
     }
 
+    /// Gets or creates a payment request for the current swap, given the passed timeout in blocks.
+    /// The first return value is the payment request, the second a value indicating whether this payment
+    /// request was newly created.
     async fn get_payment_request(
         &self,
         swap: &SwapInfo,
@@ -912,6 +915,9 @@ impl BTCReceiveSwap {
         self.get_payment_request_inner(swap, blocks).await
     }
 
+    /// Gets or creates a payment request for the current swap, given the passed timeout in blocks.
+    /// The first return value is the payment request, the second a value indicating whether this payment
+    /// request was newly created.
     async fn get_payment_request_inner(
         &self,
         swap_info: &SwapInfo,

--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -830,6 +830,7 @@ impl BTCReceiveSwap {
             .ok_or_else(|| {
                 anyhow::anyhow!(format!("swap address {} was not found", bitcoin_address))
             })?;
+        debug!("Emitting swap updated event");
         self.status_changes_notifier
             .send(BreezEvent::SwapUpdated { details: swap_info })
             .map_err(anyhow::Error::msg)?;

--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -418,10 +418,9 @@ impl BTCReceiveSwap {
 
         let destination_address = req.to_address.parse()?;
         let tx = match address_type {
-            SwapAddressType::Segwit => {
-                self.segwit
-                    .create_fake_refund_tx(&swap_info, &utxos, &destination_address)
-            }
+            SwapAddressType::Segwit => self
+                .segwit
+                .create_fake_refund_tx(&utxos, &destination_address),
             SwapAddressType::Taproot => match req.unilateral {
                 Some(true) => self.taproot.create_fake_unilateral_refund_tx(
                     &swap_info,

--- a/libs/sdk-core/src/swap_in/taproot.rs
+++ b/libs/sdk-core/src/swap_in/taproot.rs
@@ -80,7 +80,7 @@ impl TaprootReceiveSwap {
             &claim_pubkey.serialize(),
             &refund_pubkey.serialize(),
             claim_script,
-            refund_script,
+            refund_script.clone(),
         )?;
         let expected_address =
             Address::p2tr_tweaked(taproot_spend_info.output_key(), self.network).to_string();
@@ -120,7 +120,7 @@ impl TaprootReceiveSwap {
             private_key: keys.priv_key,
             public_key: refund_pubkey.serialize().to_vec(),
             refund_tx_ids: Vec::new(),
-            script: Vec::new(), // TODO: Set script
+            script: refund_script.to_bytes(),
             payment_hash,
             status: SwapStatus::Initial,
             swapper_public_key: resp.claim_pubkey,

--- a/libs/sdk-core/src/swap_in/taproot.rs
+++ b/libs/sdk-core/src/swap_in/taproot.rs
@@ -1,0 +1,481 @@
+use std::{
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use gl_client::bitcoin::{
+    self,
+    blockdata::{
+        opcodes::all::{OP_CHECKSIG, OP_CHECKSIGVERIFY, OP_CSV, OP_EQUALVERIFY, OP_HASH160},
+        script,
+    },
+    consensus::serialize,
+    hashes::{ripemd160, Hash},
+    secp256k1::{Message, PublicKey, SecretKey},
+    util::{
+        sighash::{Prevouts, SighashCache},
+        taproot::{LeafVersion, TapLeafHash, TaprootBuilder, TaprootSpendInfo},
+    },
+    Address, Network, PackedLockTime, SchnorrSighashType, Script, Sequence, Transaction, TxIn,
+    TxOut, Witness, XOnlyPublicKey,
+};
+use rand::Rng;
+use sdk_common::tonic_wrap;
+use secp256k1::musig::{
+    MusigAggNonce, MusigKeyAggCache, MusigPartialSignature, MusigPubNonce, MusigSecRand,
+    MusigSession,
+};
+
+use crate::{NodeState, OpeningFeeParams, SwapInfo, SwapStatus};
+
+use super::{
+    error::{ReceiveSwapError, ReceiveSwapResult},
+    swap::{compute_tx_fee, create_swap_keys, SwapOutput},
+    taproot_server::TaprootSwapperAPI,
+};
+
+const PAYOUT_VALIDITY_BLOCKS: u32 = 360;
+
+pub(super) struct TaprootReceiveSwap {
+    musig_secp: secp256k1::Secp256k1<secp256k1::All>,
+    network: Network,
+    secp: bitcoin::secp256k1::Secp256k1<bitcoin::secp256k1::All>,
+    swapper_api: Arc<dyn TaprootSwapperAPI>,
+}
+
+impl TaprootReceiveSwap {
+    pub fn new(network: Network, swapper_api: Arc<dyn TaprootSwapperAPI>) -> Self {
+        Self {
+            musig_secp: secp256k1::Secp256k1::new(),
+            network,
+            secp: bitcoin::secp256k1::Secp256k1::new(),
+            swapper_api,
+        }
+    }
+
+    pub async fn create_swap(
+        &self,
+        node_state: &NodeState,
+        opening_fee_params: OpeningFeeParams,
+    ) -> ReceiveSwapResult<SwapInfo> {
+        let keys = create_swap_keys()?;
+        let refund_pubkey = keys.public_key()?;
+        let payment_hash = keys.preimage_hash_bytes();
+        let resp = self
+            .swapper_api
+            .create_swap(payment_hash.clone(), refund_pubkey.serialize().to_vec())
+            .await?;
+
+        let claim_pubkey = PublicKey::from_slice(&resp.claim_pubkey)
+            .map_err(|_| ReceiveSwapError::generic("Received invalid claim pubkey from server"))?;
+        let (x_only_claim_pubkey, _) = claim_pubkey.x_only_public_key();
+        let (x_only_refund_pubkey, _) = refund_pubkey.x_only_public_key();
+        let claim_script = claim_script(&x_only_claim_pubkey, &payment_hash);
+        let refund_script = refund_script(&x_only_refund_pubkey, resp.lock_time);
+
+        let taproot_spend_info = self.taproot_spend_info(
+            &claim_pubkey.serialize(),
+            &refund_pubkey.serialize(),
+            claim_script,
+            refund_script,
+        )?;
+        let expected_address =
+            Address::p2tr_tweaked(taproot_spend_info.output_key(), self.network).to_string();
+        if resp.address != expected_address {
+            return Err(ReceiveSwapError::generic(
+                "Received invalid taproot swap address from server",
+            ));
+        }
+
+        let parameters = match resp.parameters {
+            Some(parameters) => parameters,
+            None => {
+                return Err(ReceiveSwapError::generic(
+                    "missing parameters in create_swap response",
+                ))
+            }
+        };
+
+        let swap_info = SwapInfo {
+            bitcoin_address: resp.address,
+            bolt11: None,
+            channel_opening_fees: Some(opening_fee_params),
+            confirmed_at: None,
+            confirmed_sats: 0,
+            confirmed_tx_ids: Vec::new(),
+            created_at: SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs() as i64,
+            last_redeem_error: None,
+            lock_height: resp.lock_time as i64,
+            max_allowed_deposit: std::cmp::min(
+                node_state.max_receivable_msat / 1000,
+                parameters.max_swap_amount_sat,
+            ) as i64,
+            max_swapper_payable: parameters.max_swap_amount_sat as i64,
+            min_allowed_deposit: parameters.min_swap_amount_sat as i64,
+            paid_msat: 0,
+            preimage: keys.preimage,
+            private_key: keys.priv_key,
+            public_key: refund_pubkey.serialize().to_vec(),
+            refund_tx_ids: Vec::new(),
+            script: Vec::new(), // TODO: Set script
+            payment_hash,
+            status: SwapStatus::Initial,
+            swapper_public_key: resp.claim_pubkey,
+            total_incoming_txs: 0,
+            unconfirmed_sats: 0,
+            unconfirmed_tx_ids: Vec::new(),
+        };
+
+        Ok(swap_info)
+    }
+
+    pub fn payout_blocks_left(
+        &self,
+        swap_info: &SwapInfo,
+        min_confirmation: u32,
+        current_tip: u32,
+    ) -> u32 {
+        let confirmations = current_tip.saturating_sub(min_confirmation);
+        PAYOUT_VALIDITY_BLOCKS
+            .min(swap_info.lock_height as u32)
+            .saturating_sub(confirmations)
+    }
+
+    pub fn create_fake_cooperative_refund_tx(
+        &self,
+        _swap_info: &SwapInfo,
+        utxos: &[SwapOutput],
+        destination_address: &Address,
+    ) -> ReceiveSwapResult<Transaction> {
+        Ok(Transaction {
+            version: 2,
+            lock_time: PackedLockTime::ZERO,
+            input: utxos
+                .iter()
+                .map(|utxo| {
+                    Ok(TxIn {
+                        witness: Witness::from_vec(vec![[1; 64].to_vec()]),
+                        ..utxo.try_into()?
+                    })
+                })
+                .collect::<Result<_, ReceiveSwapError>>()?,
+            output: vec![TxOut {
+                value: 0,
+                script_pubkey: destination_address.script_pubkey(),
+            }],
+        })
+    }
+
+    pub fn create_fake_unilateral_refund_tx(
+        &self,
+        _swap_info: &SwapInfo,
+        utxos: &[SwapOutput],
+        destination_address: &Address,
+    ) -> ReceiveSwapResult<Transaction> {
+        Ok(Transaction {
+            version: 2,
+            lock_time: PackedLockTime::ZERO,
+            input: utxos
+                .iter()
+                .map(|utxo| {
+                    Ok(TxIn {
+                        witness: Witness::from_vec(vec![
+                            [1; 64].to_vec(),
+                            [1; 65].to_vec(),
+                            [1; 37].to_vec(),
+                        ]),
+                        ..utxo.try_into()?
+                    })
+                })
+                .collect::<Result<_, ReceiveSwapError>>()?,
+            output: vec![TxOut {
+                value: 0,
+                script_pubkey: destination_address.script_pubkey(),
+            }],
+        })
+    }
+
+    pub async fn create_cooperative_refund_tx(
+        &self,
+        swap_info: &SwapInfo,
+        utxos: &[SwapOutput],
+        destination_address: &Address,
+        sat_per_vbyte: u32,
+    ) -> ReceiveSwapResult<Transaction> {
+        let weight = self
+            .create_fake_cooperative_refund_tx(swap_info, utxos, destination_address)?
+            .weight();
+        let fee = compute_tx_fee(weight, sat_per_vbyte);
+        let value: u64 = utxos
+            .iter()
+            .map(|utxo| utxo.amount_sat)
+            .sum::<u64>()
+            .saturating_sub(fee);
+        let mut tx = Transaction {
+            version: 2,
+            lock_time: PackedLockTime::ZERO,
+            input: utxos
+                .iter()
+                .map(|utxo| utxo.try_into())
+                .collect::<Result<_, _>>()?,
+            output: vec![TxOut {
+                value,
+                script_pubkey: destination_address.script_pubkey(),
+            }],
+        };
+
+        let swap_address: Address = swap_info.bitcoin_address.parse()?;
+        let swap_address_script_pubkey = swap_address.script_pubkey();
+        let refund_privkey = secp256k1::SecretKey::from_slice(&swap_info.private_key)
+            .map_err(|_| ReceiveSwapError::generic("invalid refund private key"))?;
+        let refund_pubkey = refund_privkey.public_key(&self.musig_secp);
+        let cloned_tx = tx.clone();
+        let mut sighasher = SighashCache::new(&cloned_tx);
+        let prevouts: Vec<_> = utxos
+            .iter()
+            .map(|u| TxOut {
+                value: u.amount_sat,
+                script_pubkey: swap_address_script_pubkey.clone(),
+            })
+            .collect();
+        let prevouts = Prevouts::All(&prevouts);
+        let serialized_tx = serialize(&tx);
+        for (input_index, input) in tx.input.iter_mut().enumerate() {
+            let session_id = MusigSecRand::assume_unique_per_nonce_gen(rand::thread_rng().gen());
+            let sighash = sighasher.taproot_key_spend_signature_hash(
+                input_index,
+                &prevouts,
+                SchnorrSighashType::Default,
+            )?;
+            let msg = secp256k1::Message::from_digest(
+                sighash
+                    .to_vec()
+                    .try_into()
+                    .map_err(|_| ReceiveSwapError::generic("invalid signature hash"))?,
+            );
+            let extra_rand = rand::thread_rng().gen();
+            let key_agg_cache =
+                self.key_agg_cache(&swap_info.swapper_public_key, &swap_info.public_key)?;
+            let (our_sec_nonce, our_pub_nonce) = key_agg_cache
+                .nonce_gen(
+                    &self.musig_secp,
+                    session_id,
+                    refund_pubkey,
+                    msg,
+                    Some(extra_rand),
+                )
+                .map_err(|_| ReceiveSwapError::generic("failed to generate nonce"))?;
+
+            let refund_resp = self
+                .swapper_api
+                .refund_swap(
+                    swap_info.bitcoin_address.clone(),
+                    input_index as u32,
+                    our_pub_nonce.serialize().to_vec(),
+                    serialized_tx.clone(),
+                )
+                .await?;
+
+            let their_pub_nonce = MusigPubNonce::from_slice(&refund_resp.pub_nonce)?;
+            let agg_nonce =
+                MusigAggNonce::new(&self.musig_secp, &[&their_pub_nonce, &our_pub_nonce]);
+            let musig_session = MusigSession::new(&self.musig_secp, &key_agg_cache, agg_nonce, msg);
+
+            let their_partial_sig =
+                MusigPartialSignature::from_slice(&refund_resp.partial_signature)?;
+            let partial_sig = musig_session.partial_sign(
+                &self.musig_secp,
+                our_sec_nonce,
+                &refund_privkey.keypair(&self.musig_secp),
+                &key_agg_cache,
+            )?;
+
+            let sig = musig_session.partial_sig_agg(&[&their_partial_sig, &partial_sig]);
+            input.witness.clear();
+            input.witness.push(sig.as_byte_array());
+        }
+
+        Ok(tx)
+    }
+
+    pub fn create_unilateral_refund_tx(
+        &self,
+        swap_info: &SwapInfo,
+        utxos: &[SwapOutput],
+        destination_address: &Address,
+        sat_per_vbyte: u32,
+    ) -> ReceiveSwapResult<Transaction> {
+        let weight = self
+            .create_fake_unilateral_refund_tx(swap_info, utxos, destination_address)?
+            .weight();
+        let fee = compute_tx_fee(weight, sat_per_vbyte);
+        let value: u64 = utxos
+            .iter()
+            .map(|utxo| utxo.amount_sat)
+            .sum::<u64>()
+            .saturating_sub(fee);
+
+        let mut tx = Transaction {
+            version: 2,
+            lock_time: PackedLockTime::ZERO,
+            input: utxos
+                .iter()
+                .map(|utxo| {
+                    Ok(TxIn {
+                        sequence: Sequence::from_consensus(swap_info.lock_height as u32),
+                        ..utxo.try_into()?
+                    })
+                })
+                .collect::<Result<_, ReceiveSwapError>>()?,
+            output: vec![TxOut {
+                value,
+                script_pubkey: destination_address.script_pubkey(),
+            }],
+        };
+        let swap_address: Address = swap_info.bitcoin_address.parse()?;
+        let swap_address_script_pubkey = swap_address.script_pubkey();
+        let claim_pubkey = PublicKey::from_slice(&swap_info.swapper_public_key)
+            .map_err(|_| ReceiveSwapError::generic("invalid claim pubkey"))?;
+        let refund_privkey = SecretKey::from_slice(&swap_info.private_key)
+            .map_err(|_| ReceiveSwapError::generic("invalid refund private key"))?;
+        let refund_pubkey = refund_privkey.public_key(&self.secp);
+        let (x_only_claim_pubkey, _) = claim_pubkey.x_only_public_key();
+        let (x_only_refund_pubkey, _) = refund_pubkey.x_only_public_key();
+        let prevouts: Vec<_> = utxos
+            .iter()
+            .map(|u| TxOut {
+                value: u.amount_sat,
+                script_pubkey: swap_address_script_pubkey.clone(),
+            })
+            .collect();
+        let prevouts = Prevouts::All(&prevouts);
+
+        let claim_script = claim_script(&x_only_claim_pubkey, &swap_info.payment_hash);
+        let refund_script = refund_script(&x_only_refund_pubkey, swap_info.lock_height as u32);
+        let cloned_tx = tx.clone();
+        let mut sighasher = SighashCache::new(&cloned_tx);
+        for (input_index, input) in tx.input.iter_mut().enumerate() {
+            let leaf_hash = TapLeafHash::from_script(&refund_script, LeafVersion::TapScript);
+
+            let sighash = sighasher.taproot_script_spend_signature_hash(
+                input_index,
+                &prevouts,
+                leaf_hash,
+                SchnorrSighashType::Default,
+            )?;
+
+            let rnd = rand::thread_rng().gen();
+            let msg = Message::from(sighash);
+            let signature = self.secp.sign_schnorr_with_aux_rand(
+                &msg,
+                &refund_privkey.keypair(&self.secp),
+                &rnd,
+            );
+
+            let signature: Vec<u8> = signature.as_ref().to_vec();
+            let control_block = self
+                .taproot_spend_info(
+                    &swap_info.swapper_public_key,
+                    &swap_info.public_key,
+                    claim_script.clone(),
+                    refund_script.clone(),
+                )?
+                .control_block(&(refund_script.clone(), LeafVersion::TapScript))
+                .ok_or(ReceiveSwapError::Taproot(
+                    "missing control block".to_string(),
+                ))?;
+            let witness = vec![
+                signature,
+                serialize(&refund_script),
+                control_block.serialize(),
+            ];
+            input.witness.clear();
+            input.witness = Witness::from_vec(witness);
+        }
+
+        Ok(tx)
+    }
+
+    pub async fn get_swap_payment(
+        &self,
+        swap_info: &SwapInfo,
+        payment_request: String,
+    ) -> ReceiveSwapResult<()> {
+        let resp = self.swapper_api.pay_swap(payment_request.clone()).await;
+        let status = match resp {
+            Ok(_) => return Ok(()),
+            Err(status) => status,
+        };
+
+        let error_message = match status.code() {
+            tonic::Code::InvalidArgument => {
+                error!(
+                    "Invalid argument calling pay_swap for address {} with payment request {}: {}",
+                    swap_info.bitcoin_address,
+                    payment_request,
+                    status.message()
+                );
+                format!("Invalid argument: {}", status.message())
+            }
+            tonic::Code::DeadlineExceeded => "Deadline exceeded".to_string(),
+            tonic::Code::NotFound => "Swap not found on remote server".to_string(),
+            tonic::Code::FailedPrecondition => {
+                format!("Failed precondition: {}", status.message())
+            }
+            _ => tonic_wrap::Status(status).to_string(),
+        };
+
+        Err(ReceiveSwapError::PaymentError(error_message))
+    }
+}
+
+impl TaprootReceiveSwap {
+    fn key_agg_cache(
+        &self,
+        claim_pubkey: &[u8],
+        refund_pubkey: &[u8],
+    ) -> ReceiveSwapResult<MusigKeyAggCache> {
+        let cp = secp256k1::PublicKey::from_slice(claim_pubkey)?;
+        let rp = secp256k1::PublicKey::from_slice(refund_pubkey)?;
+        Ok(MusigKeyAggCache::new(&self.musig_secp, &[&cp, &rp]))
+    }
+
+    fn taproot_spend_info(
+        &self,
+        claim_pubkey: &[u8],
+        refund_pubkey: &[u8],
+        claim_script: Script,
+        refund_script: Script,
+    ) -> ReceiveSwapResult<TaprootSpendInfo> {
+        let m = self.key_agg_cache(claim_pubkey, refund_pubkey)?;
+        let internal_key = m.agg_pk();
+
+        // Convert from one secp256k1 crate to the other.
+        let internal_key = XOnlyPublicKey::from_slice(&internal_key.serialize())?;
+
+        // claim and refund scripts go in a taptree.
+        Ok(TaprootBuilder::new()
+            .add_leaf(1, claim_script)?
+            .add_leaf(1, refund_script)?
+            .finalize(&self.secp, internal_key)?)
+    }
+}
+
+fn claim_script(x_only_claim_pubkey: &XOnlyPublicKey, hash: &[u8]) -> Script {
+    script::Builder::new()
+        .push_opcode(OP_HASH160)
+        .push_slice(&ripemd160::Hash::hash(hash))
+        .push_opcode(OP_EQUALVERIFY)
+        .push_x_only_key(x_only_claim_pubkey)
+        .push_opcode(OP_CHECKSIG)
+        .into_script()
+}
+
+fn refund_script(x_only_refund_pubkey: &XOnlyPublicKey, lock_time: u32) -> Script {
+    script::Builder::new()
+        .push_x_only_key(x_only_refund_pubkey)
+        .push_opcode(OP_CHECKSIGVERIFY)
+        .push_int(Sequence::from_height(lock_time as u16).to_consensus_u32() as i64)
+        .push_opcode(OP_CSV)
+        .into_script()
+}

--- a/libs/sdk-core/src/swap_in/taproot.rs
+++ b/libs/sdk-core/src/swap_in/taproot.rs
@@ -399,7 +399,7 @@ impl TaprootReceiveSwap {
         Ok(tx)
     }
 
-    pub async fn get_swap_payment(
+    pub async fn payout_swap(
         &self,
         swap_info: &SwapInfo,
         payment_request: String,

--- a/libs/sdk-core/src/swap_in/taproot.rs
+++ b/libs/sdk-core/src/swap_in/taproot.rs
@@ -34,6 +34,9 @@ use super::{
     taproot_server::TaprootSwapperAPI,
 };
 
+const SCHNORR_SIGNATURE_SIZE: usize = 64;
+const TAPROOT_REFUND_SCRIPT_SIZE: usize = 65;
+const TAPROOT_CONTROL_BLOCK_SIZE: usize = 37;
 const PAYOUT_VALIDITY_BLOCKS: u32 = 360;
 
 pub(super) struct TaprootReceiveSwap {
@@ -154,7 +157,7 @@ impl TaprootReceiveSwap {
                 .iter()
                 .map(|utxo| {
                     Ok(TxIn {
-                        witness: Witness::from_vec(vec![[1; 64].to_vec()]),
+                        witness: Witness::from_vec(vec![[1; SCHNORR_SIGNATURE_SIZE].to_vec()]),
                         ..utxo.try_into()?
                     })
                 })
@@ -180,9 +183,9 @@ impl TaprootReceiveSwap {
                 .map(|utxo| {
                     Ok(TxIn {
                         witness: Witness::from_vec(vec![
-                            [1; 64].to_vec(),
-                            [1; 65].to_vec(),
-                            [1; 37].to_vec(),
+                            [1; SCHNORR_SIGNATURE_SIZE].to_vec(),
+                            [1; TAPROOT_REFUND_SCRIPT_SIZE].to_vec(),
+                            [1; TAPROOT_CONTROL_BLOCK_SIZE].to_vec(),
                         ]),
                         ..utxo.try_into()?
                     })

--- a/libs/sdk-core/src/swap_in/taproot.rs
+++ b/libs/sdk-core/src/swap_in/taproot.rs
@@ -410,7 +410,7 @@ impl TaprootReceiveSwap {
                 ))?;
             let witness = vec![
                 signature,
-                serialize(&refund_script),
+                refund_script.to_bytes(),
                 control_block.serialize(),
             ];
             input.witness.clear();

--- a/libs/sdk-core/src/swap_in/taproot_server.rs
+++ b/libs/sdk-core/src/swap_in/taproot_server.rs
@@ -25,6 +25,8 @@ pub(crate) trait TaprootSwapperAPI: Send + Sync {
         pub_nonce: Vec<u8>,
         transaction: Vec<u8>,
     ) -> SdkResult<RefundSwapResponse>;
+
+    #[allow(unused)]
     async fn swap_parameters(&self) -> SdkResult<Option<SwapParameters>>;
 }
 

--- a/libs/sdk-core/src/swap_in/taproot_server.rs
+++ b/libs/sdk-core/src/swap_in/taproot_server.rs
@@ -1,0 +1,82 @@
+use sdk_common::{
+    grpc::{
+        CreateSwapRequest, CreateSwapResponse, PaySwapRequest, PaySwapResponse, RefundSwapRequest,
+        RefundSwapResponse, SwapParameters, SwapParametersRequest,
+    },
+    prelude::BreezServer,
+    with_connection_retry,
+};
+use tonic::{async_trait, Status};
+
+use crate::error::SdkResult;
+
+#[tonic::async_trait]
+pub(crate) trait TaprootSwapperAPI: Send + Sync {
+    async fn create_swap(
+        &self,
+        hash: Vec<u8>,
+        refund_pubkey: Vec<u8>,
+    ) -> SdkResult<CreateSwapResponse>;
+    async fn pay_swap(&self, payment_request: String) -> Result<PaySwapResponse, Status>;
+    async fn refund_swap(
+        &self,
+        address: String,
+        input_index: u32,
+        pub_nonce: Vec<u8>,
+        transaction: Vec<u8>,
+    ) -> SdkResult<RefundSwapResponse>;
+    async fn swap_parameters(&self) -> SdkResult<Option<SwapParameters>>;
+}
+
+#[async_trait]
+impl TaprootSwapperAPI for BreezServer {
+    async fn create_swap(
+        &self,
+        hash: Vec<u8>,
+        refund_pubkey: Vec<u8>,
+    ) -> SdkResult<CreateSwapResponse> {
+        let mut client = self.get_taproot_swapper_client().await;
+        let req = CreateSwapRequest {
+            hash,
+            refund_pubkey,
+        };
+        Ok(with_connection_retry!(client.create_swap(req.clone()))
+            .await?
+            .into_inner())
+    }
+    async fn pay_swap(&self, payment_request: String) -> Result<PaySwapResponse, Status> {
+        let mut client = self.get_taproot_swapper_client().await;
+        let req = PaySwapRequest { payment_request };
+        Ok(with_connection_retry!(client.pay_swap(req.clone()))
+            .await?
+            .into_inner())
+    }
+    async fn refund_swap(
+        &self,
+        address: String,
+        input_index: u32,
+        pub_nonce: Vec<u8>,
+        transaction: Vec<u8>,
+    ) -> SdkResult<RefundSwapResponse> {
+        let mut client = self.get_taproot_swapper_client().await;
+        let req = RefundSwapRequest {
+            address,
+            input_index,
+            pub_nonce,
+            transaction,
+        };
+        Ok(with_connection_retry!(client.refund_swap(req.clone()))
+            .await?
+            .into_inner())
+    }
+    async fn swap_parameters(&self) -> SdkResult<Option<SwapParameters>> {
+        let mut client = self.get_taproot_swapper_client().await;
+
+        Ok(
+            with_connection_retry!(client.swap_parameters(SwapParametersRequest {}))
+                .await?
+                .into_inner()
+                .parameters,
+        )
+    }
+}

--- a/libs/sdk-core/src/swap_in/taproot_server.rs
+++ b/libs/sdk-core/src/swap_in/taproot_server.rs
@@ -37,7 +37,7 @@ impl TaprootSwapperAPI for BreezServer {
         hash: Vec<u8>,
         refund_pubkey: Vec<u8>,
     ) -> SdkResult<CreateSwapResponse> {
-        let mut client = self.get_taproot_swapper_client().await;
+        let mut client = self.get_taproot_swapper_client().await?;
         let req = CreateSwapRequest {
             hash,
             refund_pubkey,
@@ -47,7 +47,10 @@ impl TaprootSwapperAPI for BreezServer {
             .into_inner())
     }
     async fn pay_swap(&self, payment_request: String) -> Result<PaySwapResponse, Status> {
-        let mut client = self.get_taproot_swapper_client().await;
+        let mut client = match self.get_taproot_swapper_client().await {
+            Ok(client) => client,
+            Err(e) => return Err(Status::unknown(e.to_string())),
+        };
         let req = PaySwapRequest { payment_request };
         Ok(with_connection_retry!(client.pay_swap(req.clone()))
             .await?
@@ -60,7 +63,7 @@ impl TaprootSwapperAPI for BreezServer {
         pub_nonce: Vec<u8>,
         transaction: Vec<u8>,
     ) -> SdkResult<RefundSwapResponse> {
-        let mut client = self.get_taproot_swapper_client().await;
+        let mut client = self.get_taproot_swapper_client().await?;
         let req = RefundSwapRequest {
             address,
             input_index,
@@ -72,7 +75,7 @@ impl TaprootSwapperAPI for BreezServer {
             .into_inner())
     }
     async fn swap_parameters(&self) -> SdkResult<Option<SwapParameters>> {
-        let mut client = self.get_taproot_swapper_client().await;
+        let mut client = self.get_taproot_swapper_client().await?;
 
         Ok(
             with_connection_retry!(client.swap_parameters(SwapParametersRequest {}))

--- a/libs/sdk-core/src/swap_in/taproot_server.rs
+++ b/libs/sdk-core/src/swap_in/taproot_server.rs
@@ -10,6 +10,7 @@ use tonic::{async_trait, Status};
 
 use crate::error::SdkResult;
 
+#[cfg_attr(test, mockall::automock)]
 #[tonic::async_trait]
 pub(crate) trait TaprootSwapperAPI: Send + Sync {
     async fn create_swap(

--- a/libs/sdk-core/src/swap_out/reverseswap.rs
+++ b/libs/sdk-core/src/swap_out/reverseswap.rs
@@ -24,7 +24,7 @@ use crate::chain::{get_utxos, AddressUtxos, ChainService, OnchainTx, Utxo};
 use crate::error::SdkResult;
 use crate::models::{ReverseSwapServiceAPI, ReverseSwapperRoutingAPI};
 use crate::node_api::{NodeAPI, NodeError};
-use crate::swap_in::swap::create_swap_keys;
+use crate::swap_in::create_swap_keys;
 use crate::{
     ensure_sdk, BreezEvent, Config, FullReverseSwapInfo, PayOnchainRequest, PaymentStatus,
     ReverseSwapInfo, ReverseSwapInfoCached, ReverseSwapPairInfo, ReverseSwapStatus,
@@ -778,7 +778,6 @@ fn build_fake_claim_tx() -> Result<Transaction> {
         sk,
         preimage_bytes,
         AddressUtxos {
-            unconfirmed: vec![],
             confirmed: vec![Utxo {
                 out: OutPoint {
                     txid: Txid::all_zeros(),

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -460,11 +460,11 @@ impl NodeAPI for MockNodeAPI {
         Ok(json!({}))
     }
 
-    async fn max_sendable_amount(
+    async fn max_sendable_amount<'a>(
         &self,
         _payee_node_id: Option<Vec<u8>>,
         _max_hops: u32,
-        _last_hop: Option<&RouteHintHop>,
+        _last_hop: Option<&'a RouteHintHop>,
     ) -> NodeResult<Vec<MaxChannelAmount>> {
         Err(NodeError::Generic("Not implemented".to_string()))
     }
@@ -920,7 +920,11 @@ impl TaprootSwapperAPI for MockBreezServer {
             address: address.to_string(),
             claim_pubkey: claim_pubkey_bytes,
             lock_time,
-            parameters: Some(SwapParameters::default()),
+            parameters: Some(SwapParameters {
+                max_swap_amount_sat: 1_000_000,
+                min_swap_amount_sat: 1_000,
+                min_utxo_amount_sat: 1_000,
+            }),
         })
     }
     async fn pay_swap(&self, _payment_request: String) -> Result<PaySwapResponse, Status> {

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -296,6 +296,9 @@ impl Default for MockReceiver {
 
 #[tonic::async_trait]
 impl Receiver for MockReceiver {
+    fn open_channel_needed(&self, _amount_msat: u64) -> Result<bool, ReceivePaymentError> {
+        Ok(true)
+    }
     async fn receive_payment(
         &self,
         _request: ReceivePaymentRequest,

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -5,20 +5,30 @@ use std::{mem, vec};
 
 use anyhow::{Error, Result};
 use chrono::{SecondsFormat, Utc};
+use gl_client::bitcoin::blockdata::opcodes::all::{
+    OP_CHECKSIG, OP_CHECKSIGVERIFY, OP_CSV, OP_EQUALVERIFY, OP_HASH160,
+};
+use gl_client::bitcoin::blockdata::script;
+use gl_client::bitcoin::hashes::ripemd160;
+use gl_client::bitcoin::util::taproot::{TaprootBuilder, TaprootSpendInfo};
+use gl_client::bitcoin::{Address, Script, Sequence, XOnlyPublicKey};
 use gl_client::pb::cln::pay_response::PayStatus;
 use gl_client::pb::cln::Amount;
 use rand::distributions::uniform::{SampleRange, SampleUniform};
 use rand::distributions::{Alphanumeric, DistString, Standard};
 use rand::rngs::OsRng;
 use rand::{random, Rng};
-use sdk_common::grpc;
+use sdk_common::grpc::{
+    self, CreateSwapResponse, PaySwapResponse, RefundSwapResponse, SwapParameters,
+};
 use sdk_common::prelude::{FiatAPI, FiatCurrency, Rate};
+use secp256k1::musig::MusigKeyAggCache;
 use serde_json::{json, Value};
 use tokio::sync::{mpsc, watch, Mutex};
 use tokio::time::sleep;
 use tokio_stream::Stream;
 use tokio_stream::StreamExt;
-use tonic::Streaming;
+use tonic::{Status, Streaming};
 
 use crate::backup::{BackupState, BackupTransport};
 use crate::bitcoin::hashes::hex::ToHex;
@@ -41,6 +51,7 @@ use crate::models::{
 use crate::node_api::{CreateInvoiceRequest, FetchBolt11Result, NodeAPI, NodeError, NodeResult};
 use crate::swap_in::error::SwapResult;
 use crate::swap_in::swap::create_submarine_swap_script;
+use crate::swap_in::TaprootSwapperAPI;
 use crate::swap_out::boltzswap::{BoltzApiCreateReverseSwapResponse, BoltzApiReverseSwapStatus};
 use crate::swap_out::error::{ReverseSwapError, ReverseSwapResult};
 use crate::{
@@ -909,4 +920,103 @@ pub(crate) fn get_test_ofp_generic(
         promise: "".to_string(),
     }
     .into()
+}
+
+#[tonic::async_trait]
+impl TaprootSwapperAPI for MockBreezServer {
+    async fn create_swap(
+        &self,
+        hash: Vec<u8>,
+        refund_pubkey: Vec<u8>,
+    ) -> SdkResult<CreateSwapResponse> {
+        let lock_time = 1008;
+        let claim_pubkey_bytes =
+            hex::decode("0207121ffeda98fb0b28258d06efaa97623d1b4298dce269630432b9c12f4f6c84")
+                .unwrap();
+        let claim_pubkey = PublicKey::from_slice(&claim_pubkey_bytes).unwrap();
+        let refund_pubkey = PublicKey::from_slice(&refund_pubkey).unwrap();
+        let (x_only_claim_pubkey, _) = claim_pubkey.x_only_public_key();
+        let (x_only_refund_pubkey, _) = refund_pubkey.x_only_public_key();
+        let claim_script = claim_script(&x_only_claim_pubkey, &hash);
+        let refund_script = refund_script(&x_only_refund_pubkey, lock_time);
+
+        let taproot_spend_info = taproot_spend_info(
+            &claim_pubkey.serialize(),
+            &refund_pubkey.serialize(),
+            claim_script,
+            refund_script,
+        )?;
+        let address =
+            Address::p2tr_tweaked(taproot_spend_info.output_key(), Network::Bitcoin).to_string();
+
+        Ok(CreateSwapResponse {
+            address: address.to_string(),
+            claim_pubkey: claim_pubkey_bytes,
+            lock_time,
+            parameters: Some(SwapParameters::default()),
+        })
+    }
+    async fn pay_swap(&self, _payment_request: String) -> Result<PaySwapResponse, Status> {
+        Ok(PaySwapResponse::default())
+    }
+    async fn refund_swap(
+        &self,
+        _address: String,
+        _input_index: u32,
+        _pub_nonce: Vec<u8>,
+        _transaction: Vec<u8>,
+    ) -> SdkResult<RefundSwapResponse> {
+        Ok(RefundSwapResponse::default())
+    }
+    async fn swap_parameters(&self) -> SdkResult<Option<SwapParameters>> {
+        Ok(Some(SwapParameters::default()))
+    }
+}
+
+fn claim_script(x_only_claim_pubkey: &XOnlyPublicKey, hash: &[u8]) -> Script {
+    script::Builder::new()
+        .push_opcode(OP_HASH160)
+        .push_slice(&ripemd160::Hash::hash(hash))
+        .push_opcode(OP_EQUALVERIFY)
+        .push_x_only_key(x_only_claim_pubkey)
+        .push_opcode(OP_CHECKSIG)
+        .into_script()
+}
+
+fn refund_script(x_only_refund_pubkey: &XOnlyPublicKey, lock_time: u32) -> Script {
+    script::Builder::new()
+        .push_x_only_key(x_only_refund_pubkey)
+        .push_opcode(OP_CHECKSIGVERIFY)
+        .push_int(Sequence::from_height(lock_time as u16).to_consensus_u32() as i64)
+        .push_opcode(OP_CSV)
+        .into_script()
+}
+
+fn key_agg_cache(claim_pubkey: &[u8], refund_pubkey: &[u8]) -> Result<MusigKeyAggCache> {
+    let cp = secp256k1::PublicKey::from_slice(claim_pubkey)?;
+    let rp = secp256k1::PublicKey::from_slice(refund_pubkey)?;
+    Ok(MusigKeyAggCache::new(
+        &secp256k1::Secp256k1::new(),
+        &[&cp, &rp],
+    ))
+}
+
+fn taproot_spend_info(
+    claim_pubkey: &[u8],
+    refund_pubkey: &[u8],
+    claim_script: Script,
+    refund_script: Script,
+) -> Result<TaprootSpendInfo> {
+    let m = key_agg_cache(claim_pubkey, refund_pubkey)?;
+    let internal_key = m.agg_pk();
+
+    // Convert from one secp256k1 crate to the other.
+    let internal_key = XOnlyPublicKey::from_slice(&internal_key.serialize())?;
+
+    // claim and refund scripts go in a taptree.
+    Ok(TaprootBuilder::new()
+        .add_leaf(1, claim_script)?
+        .add_leaf(1, refund_script)?
+        .finalize(&Secp256k1::new(), internal_key)
+        .map_err(|_| anyhow::anyhow!("taproot builder error"))?)
 }

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -34,7 +34,7 @@ use crate::backup::{BackupState, BackupTransport};
 use crate::bitcoin::hashes::hex::ToHex;
 use crate::bitcoin::hashes::{sha256, Hash};
 use crate::bitcoin::secp256k1::ecdsa::RecoverableSignature;
-use crate::bitcoin::secp256k1::{KeyPair, Message, PublicKey, Secp256k1, SecretKey};
+use crate::bitcoin::secp256k1::{KeyPair, Message, PublicKey, Secp256k1};
 use crate::bitcoin::util::bip32::{ChildNumber, ExtendedPrivKey};
 use crate::bitcoin::Network;
 use crate::breez_services::{OpenChannelParams, Receiver};
@@ -46,11 +46,9 @@ use crate::lightning::ln::PaymentSecret;
 use crate::lightning_invoice::{Currency, InvoiceBuilder, RawBolt11Invoice};
 use crate::lsp::LspInformation;
 use crate::models::{
-    LspAPI, NodeState, Payment, ReverseSwapServiceAPI, Swap, SwapperAPI, SyncResponse, TlvEntry,
+    LspAPI, NodeState, Payment, ReverseSwapServiceAPI, SwapperAPI, SyncResponse, TlvEntry,
 };
 use crate::node_api::{CreateInvoiceRequest, FetchBolt11Result, NodeAPI, NodeError, NodeResult};
-use crate::swap_in::error::SwapResult;
-use crate::swap_in::swap::create_submarine_swap_script;
 use crate::swap_in::TaprootSwapperAPI;
 use crate::swap_out::boltzswap::{BoltzApiCreateReverseSwapResponse, BoltzApiReverseSwapStatus};
 use crate::swap_out::error::{ReverseSwapError, ReverseSwapResult};
@@ -128,37 +126,6 @@ pub struct MockSwapperAPI {}
 
 #[tonic::async_trait]
 impl SwapperAPI for MockSwapperAPI {
-    async fn create_swap(
-        &self,
-        hash: Vec<u8>,
-        payer_pubkey: Vec<u8>,
-        _node_pubkey: String,
-    ) -> SwapResult<Swap> {
-        let mut swapper_priv_key_raw = [2; 32];
-        rand::thread_rng().fill(&mut swapper_priv_key_raw);
-
-        let secp = Secp256k1::new();
-        // swapper keys
-        let swapper_private_key = SecretKey::from_slice(&swapper_priv_key_raw).unwrap();
-        let swapper_pub_key = PublicKey::from_secret_key(&secp, &swapper_private_key)
-            .serialize()
-            .to_vec();
-
-        let script =
-            create_submarine_swap_script(hash, swapper_pub_key.clone(), payer_pubkey, 144).unwrap();
-        let address = crate::bitcoin::Address::p2wsh(&script, crate::bitcoin::Network::Bitcoin);
-
-        Ok(Swap {
-            bitcoin_address: address.to_string(),
-            swapper_pubkey: swapper_pub_key,
-            lock_height: 144,
-            swapper_max_payable: 4_000_000,
-            error_message: "".to_string(),
-            required_reserve: 0,
-            swapper_min_payable: 3_000,
-        })
-    }
-
     async fn complete_swap(&self, _bolt11: String) -> Result<()> {
         Ok(())
     }

--- a/libs/sdk-core/src/test_utils.rs
+++ b/libs/sdk-core/src/test_utils.rs
@@ -351,6 +351,10 @@ impl NodeAPI for MockNodeAPI {
         Ok(invoice.bolt11)
     }
 
+    async fn delete_invoice(&self, _bolt11: String) -> NodeResult<()> {
+        Ok(())
+    }
+
     async fn pull_changed(
         &self,
         _sync_state: Option<Value>,

--- a/libs/sdk-flutter/ios/Classes/bridge_generated.h
+++ b/libs/sdk-flutter/ios/Classes/bridge_generated.h
@@ -254,12 +254,14 @@ typedef struct wire_PrepareRefundRequest {
   struct wire_uint_8_list *swap_address;
   struct wire_uint_8_list *to_address;
   uint32_t sat_per_vbyte;
+  bool *unilateral;
 } wire_PrepareRefundRequest;
 
 typedef struct wire_RefundRequest {
   struct wire_uint_8_list *swap_address;
   struct wire_uint_8_list *to_address;
   uint32_t sat_per_vbyte;
+  bool *unilateral;
 } wire_RefundRequest;
 
 typedef struct wire_list_swap_status {

--- a/libs/sdk-flutter/lib/bridge_generated.dart
+++ b/libs/sdk-flutter/lib/bridge_generated.dart
@@ -1385,11 +1385,13 @@ class PrepareRefundRequest {
   final String swapAddress;
   final String toAddress;
   final int satPerVbyte;
+  final bool? unilateral;
 
   const PrepareRefundRequest({
     required this.swapAddress,
     required this.toAddress,
     required this.satPerVbyte,
+    this.unilateral,
   });
 }
 
@@ -1518,11 +1520,13 @@ class RefundRequest {
   final String swapAddress;
   final String toAddress;
   final int satPerVbyte;
+  final bool? unilateral;
 
   const RefundRequest({
     required this.swapAddress,
     required this.toAddress,
     required this.satPerVbyte,
+    this.unilateral,
   });
 }
 
@@ -4907,6 +4911,7 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
     wireObj.swap_address = api2wire_String(apiObj.swapAddress);
     wireObj.to_address = api2wire_String(apiObj.toAddress);
     wireObj.sat_per_vbyte = api2wire_u32(apiObj.satPerVbyte);
+    wireObj.unilateral = api2wire_opt_box_autoadd_bool(apiObj.unilateral);
   }
 
   void _api_fill_to_wire_receive_onchain_request(
@@ -4935,6 +4940,7 @@ class BreezSdkCorePlatform extends FlutterRustBridgeBase<BreezSdkCoreWire> {
     wireObj.swap_address = api2wire_String(apiObj.swapAddress);
     wireObj.to_address = api2wire_String(apiObj.toAddress);
     wireObj.sat_per_vbyte = api2wire_u32(apiObj.satPerVbyte);
+    wireObj.unilateral = api2wire_opt_box_autoadd_bool(apiObj.unilateral);
   }
 
   void _api_fill_to_wire_report_issue_request(ReportIssueRequest apiObj, wire_ReportIssueRequest wireObj) {
@@ -6751,6 +6757,8 @@ final class wire_PrepareRefundRequest extends ffi.Struct {
 
   @ffi.Uint32()
   external int sat_per_vbyte;
+
+  external ffi.Pointer<ffi.Bool> unilateral;
 }
 
 final class wire_RefundRequest extends ffi.Struct {
@@ -6760,6 +6768,8 @@ final class wire_RefundRequest extends ffi.Struct {
 
   @ffi.Uint32()
   external int sat_per_vbyte;
+
+  external ffi.Pointer<ffi.Bool> unilateral;
 }
 
 final class wire_list_swap_status extends ffi.Struct {

--- a/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
+++ b/libs/sdk-react-native/android/src/main/java/com/breezsdk/BreezSDKMapper.kt
@@ -2393,10 +2393,12 @@ fun asPrepareRefundRequest(prepareRefundRequest: ReadableMap): PrepareRefundRequ
     val swapAddress = prepareRefundRequest.getString("swapAddress")!!
     val toAddress = prepareRefundRequest.getString("toAddress")!!
     val satPerVbyte = prepareRefundRequest.getInt("satPerVbyte").toUInt()
+    val unilateral = if (hasNonNullKey(prepareRefundRequest, "unilateral")) prepareRefundRequest.getBoolean("unilateral") else null
     return PrepareRefundRequest(
         swapAddress,
         toAddress,
         satPerVbyte,
+        unilateral,
     )
 }
 
@@ -2405,6 +2407,7 @@ fun readableMapOf(prepareRefundRequest: PrepareRefundRequest): ReadableMap =
         "swapAddress" to prepareRefundRequest.swapAddress,
         "toAddress" to prepareRefundRequest.toAddress,
         "satPerVbyte" to prepareRefundRequest.satPerVbyte,
+        "unilateral" to prepareRefundRequest.unilateral,
     )
 
 fun asPrepareRefundRequestList(arr: ReadableArray): List<PrepareRefundRequest> {
@@ -2798,10 +2801,12 @@ fun asRefundRequest(refundRequest: ReadableMap): RefundRequest? {
     val swapAddress = refundRequest.getString("swapAddress")!!
     val toAddress = refundRequest.getString("toAddress")!!
     val satPerVbyte = refundRequest.getInt("satPerVbyte").toUInt()
+    val unilateral = if (hasNonNullKey(refundRequest, "unilateral")) refundRequest.getBoolean("unilateral") else null
     return RefundRequest(
         swapAddress,
         toAddress,
         satPerVbyte,
+        unilateral,
     )
 }
 
@@ -2810,6 +2815,7 @@ fun readableMapOf(refundRequest: RefundRequest): ReadableMap =
         "swapAddress" to refundRequest.swapAddress,
         "toAddress" to refundRequest.toAddress,
         "satPerVbyte" to refundRequest.satPerVbyte,
+        "unilateral" to refundRequest.unilateral,
     )
 
 fun asRefundRequestList(arr: ReadableArray): List<RefundRequest> {

--- a/libs/sdk-react-native/ios/BreezSDKMapper.swift
+++ b/libs/sdk-react-native/ios/BreezSDKMapper.swift
@@ -2763,11 +2763,19 @@ enum BreezSDKMapper {
         guard let satPerVbyte = prepareRefundRequest["satPerVbyte"] as? UInt32 else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "satPerVbyte", typeName: "PrepareRefundRequest"))
         }
+        var unilateral: Bool?
+        if hasNonNilKey(data: prepareRefundRequest, key: "unilateral") {
+            guard let unilateralTmp = prepareRefundRequest["unilateral"] as? Bool else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "unilateral"))
+            }
+            unilateral = unilateralTmp
+        }
 
         return PrepareRefundRequest(
             swapAddress: swapAddress,
             toAddress: toAddress,
-            satPerVbyte: satPerVbyte
+            satPerVbyte: satPerVbyte,
+            unilateral: unilateral
         )
     }
 
@@ -2776,6 +2784,7 @@ enum BreezSDKMapper {
             "swapAddress": prepareRefundRequest.swapAddress,
             "toAddress": prepareRefundRequest.toAddress,
             "satPerVbyte": prepareRefundRequest.satPerVbyte,
+            "unilateral": prepareRefundRequest.unilateral == nil ? nil : prepareRefundRequest.unilateral,
         ]
     }
 
@@ -3170,11 +3179,19 @@ enum BreezSDKMapper {
         guard let satPerVbyte = refundRequest["satPerVbyte"] as? UInt32 else {
             throw SdkError.Generic(message: errMissingMandatoryField(fieldName: "satPerVbyte", typeName: "RefundRequest"))
         }
+        var unilateral: Bool?
+        if hasNonNilKey(data: refundRequest, key: "unilateral") {
+            guard let unilateralTmp = refundRequest["unilateral"] as? Bool else {
+                throw SdkError.Generic(message: errUnexpectedValue(fieldName: "unilateral"))
+            }
+            unilateral = unilateralTmp
+        }
 
         return RefundRequest(
             swapAddress: swapAddress,
             toAddress: toAddress,
-            satPerVbyte: satPerVbyte
+            satPerVbyte: satPerVbyte,
+            unilateral: unilateral
         )
     }
 
@@ -3183,6 +3200,7 @@ enum BreezSDKMapper {
             "swapAddress": refundRequest.swapAddress,
             "toAddress": refundRequest.toAddress,
             "satPerVbyte": refundRequest.satPerVbyte,
+            "unilateral": refundRequest.unilateral == nil ? nil : refundRequest.unilateral,
         ]
     }
 

--- a/libs/sdk-react-native/src/index.ts
+++ b/libs/sdk-react-native/src/index.ts
@@ -388,6 +388,7 @@ export interface PrepareRefundRequest {
     swapAddress: string
     toAddress: string
     satPerVbyte: number
+    unilateral?: boolean
 }
 
 export interface PrepareRefundResponse {
@@ -441,6 +442,7 @@ export interface RefundRequest {
     swapAddress: string
     toAddress: string
     satPerVbyte: number
+    unilateral?: boolean
 }
 
 export interface RefundResponse {

--- a/tools/sdk-cli/Cargo.lock
+++ b/tools/sdk-cli/Cargo.lock
@@ -156,6 +156,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "as-any"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,6 +423,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin-io"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
+
+[[package]]
 name = "bitcoin-private"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,6 +461,16 @@ checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
 dependencies = [
  "bitcoin-private",
  "serde",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative",
 ]
 
 [[package]]
@@ -564,6 +586,7 @@ dependencies = [
  "rusqlite_migration",
  "ryu",
  "sdk-common",
+ "secp256k1 0.30.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -1545,6 +1568,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-conservative"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "hex_lit"
@@ -3662,6 +3694,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "secp256k1"
+version = "0.30.0"
+source = "git+https://github.com/rust-bitcoin/rust-secp256k1?rev=1cc7410df436b73d06db3c8ff7cbb29a78916b06#1cc7410df436b73d06db3c8ff7cbb29a78916b06"
+dependencies = [
+ "bitcoin_hashes 0.14.0",
+ "rand",
+ "secp256k1-sys 0.11.0",
+]
+
+[[package]]
 name = "secp256k1-sys"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3675,6 +3717,14 @@ name = "secp256k1-sys"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.11.0"
+source = "git+https://github.com/rust-bitcoin/rust-secp256k1?rev=1cc7410df436b73d06db3c8ff7cbb29a78916b06#1cc7410df436b73d06db3c8ff7cbb29a78916b06"
 dependencies = [
  "cc",
 ]

--- a/tools/sdk-cli/src/command_handlers.rs
+++ b/tools/sdk-cli/src/command_handlers.rs
@@ -406,12 +406,14 @@ pub(crate) async fn handle_command(
             swap_address,
             to_address,
             sat_per_vbyte,
+            unilateral,
         } => {
             let res = sdk()?
                 .prepare_refund(PrepareRefundRequest {
                     swap_address,
                     to_address,
                     sat_per_vbyte,
+                    unilateral,
                 })
                 .await?;
             Ok(format!(
@@ -423,12 +425,14 @@ pub(crate) async fn handle_command(
             swap_address,
             to_address,
             sat_per_vbyte,
+            unilateral,
         } => {
             let res = sdk()?
                 .refund(RefundRequest {
                     swap_address,
                     to_address,
                     sat_per_vbyte,
+                    unilateral,
                 })
                 .await?;
             Ok(format!("Refund tx: {}", res.refund_tx_id))

--- a/tools/sdk-cli/src/commands.rs
+++ b/tools/sdk-cli/src/commands.rs
@@ -130,6 +130,7 @@ pub(crate) enum Commands {
         swap_address: String,
         to_address: String,
         sat_per_vbyte: u32,
+        unilateral: Option<bool>,
     },
 
     /// [swap-in] Broadcast a refund transaction for an incomplete swap
@@ -137,6 +138,7 @@ pub(crate) enum Commands {
         swap_address: String,
         to_address: String,
         sat_per_vbyte: u32,
+        unilateral: Option<bool>,
     },
 
     ListSwaps {


### PR DESCRIPTION
This is an alternative to #1176

There is a single interface to swaps: `BTCReceiveSwap`. The main logic for swap execution is inside this struct, with some divergent paths for either segwit and taproot swaps where applicable. Most of the logic for the segwit and taproot swaps are the same, so they can be bundled together like this.

The data model is the same as before, only additional chain information has been added to the SwapInfo table. This is mainly because the current data model only considered utxos, but it's useful to also consider spent outputs in circumstances where multiple outputs exist for the same swap address.

The invoice creation logic is different from the original version. Invoices are deleted when the amount no longer matches, or when the local liquidity no longer matches. A missing piece of the puzzle there is to allow re-registration of a payment in lspd.