### PR TITLE
sdk-common: expose grpc transport

### DIFF
--- a/libs/sdk-common/src/grpc/mod.rs
+++ b/libs/sdk-common/src/grpc/mod.rs
@@ -4,4 +4,4 @@ tonic::include_proto!("breez");
     all(target_family = "wasm", target_os = "unknown"),
     path = "transport_wasm.rs"
 )]
-pub(crate) mod transport;
+pub mod transport;


### PR DESCRIPTION
This exposes the wasm-compatible grpc client