### PR TITLE
🔧 Formatted byte arrays as hexadecimal in diagnostic outputs

### DIFF
--- a/libs/sdk-core/src/greenlight/node_api.rs
+++ b/libs/sdk-core/src/greenlight/node_api.rs
@@ -615,7 +615,15 @@ impl Greenlight {
         let route_response = route_result?.into_inner();
         info!(
             "max_sendable_amount: route response = {:?}",
-            route_response.route
+            route_response
+                .route
+                .iter()
+                .map(|r| format!(
+                    "{{node_id: {}, channel: {}}}",
+                    hex::encode(&r.id),
+                    r.channel
+                ))
+                .collect::<Vec<_>>()
         );
 
         // We fetch the opened channels so can calculate max amount to send for each channel
@@ -657,7 +665,18 @@ impl Greenlight {
                 }])
             }
 
-            info!("max_sendable_amount: route_hops = {:?}", payment_path.edges);
+            info!(
+                "max_sendable_amount: route_hops = {:?}",
+                payment_path
+                    .edges
+                    .iter()
+                    .map(|e| format!(
+                        "{{node_id: {}, channel: {}}}",
+                        hex::encode(&e.node_id),
+                        e.short_channel_id
+                    ))
+                    .collect::<Vec<_>>()
+            );
 
             // go over each hop and calculate the amount to forward.
             let max_payment_amount =

--- a/libs/sdk-core/src/lsps0/transport.rs
+++ b/libs/sdk-core/src/lsps0/transport.rs
@@ -129,7 +129,12 @@ impl Transport {
 
     async fn handle_message(&self, msg: CustomMessage) {
         if msg.message_type != LSPS0_MESSAGE_TYPE {
-            debug!("received custom message that was not lsps0: {:?}", msg);
+            debug!(
+                "received custom message that was not lsps0: node_id={}, type={}, payload={}",
+                hex::encode(&msg.peer_id),
+                msg.message_type,
+                hex::encode(&msg.payload)
+            );
             return;
         }
 

--- a/libs/sdk-core/src/swap_in/swap.rs
+++ b/libs/sdk-core/src/swap_in/swap.rs
@@ -569,7 +569,7 @@ impl BTCReceiveSwap {
             &script,
             req.sat_per_vbyte,
         )?;
-        info!("broadcasting refund tx {:?}", hex::encode(&refund_tx));
+        info!("broadcasting refund tx {}", hex::encode(&refund_tx));
         let tx_id = self.chain_service.broadcast_transaction(refund_tx).await?;
 
         self.persister


### PR DESCRIPTION
This PR ensures all byte arrays (Vec<u8>) in diagnostic and dev command outputs are consistently printed in hex format, improving readability and debugging.
Key Changes:
--> Node IDs & Public Keys: Hex encoding in node_api.rs.
-->Channel & Tx IDs: Updated swap.rs to print in hex.
-->Payment Data: Improved debug formatting in models.rs.
-->Custom Messages: Hex encoding for payloads in transport.rs.
-->Diagnostics: generate_diagnostic_data() now converts byte arrays to hex.

These changes enhance output clarity without altering functionality. 🚀
It solves issue (#1072 )