### PR TITLE
Update bolt12 lightning dependency

### DIFF
--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -1164,6 +1164,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dnssec-prover"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96487aad690d45a83f2b9876828ba856c5430bbb143cb5730d8a5d04a4805179"
+
+[[package]]
 name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1639,6 +1645,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 
 [[package]]
 name = "hashbrown"
@@ -2371,14 +2383,18 @@ dependencies = [
 
 [[package]]
 name = "lightning"
-version = "0.0.125"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "767f388e50251da71f95a3737d6db32c9729f9de6427a54fa92bb994d04d793f"
+version = "0.1.1"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=f80d82e835987e045928955d2c83baba86c445e9#f80d82e835987e045928955d2c83baba86c445e9"
 dependencies = [
- "bech32 0.9.1",
+ "bech32 0.11.0",
  "bitcoin 0.32.5",
- "lightning-invoice 0.32.0",
+ "dnssec-prover",
+ "hashbrown 0.13.2",
+ "libm",
+ "lightning-invoice 0.33.1",
  "lightning-types",
+ "musig2",
+ "possiblyrandom",
 ]
 
 [[package]]
@@ -2397,24 +2413,20 @@ dependencies = [
 
 [[package]]
 name = "lightning-invoice"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ab9f6ea77e20e3129235e62a2e6bd64ed932363df104e864ee65ccffb54a8f"
+version = "0.33.1"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=f80d82e835987e045928955d2c83baba86c445e9#f80d82e835987e045928955d2c83baba86c445e9"
 dependencies = [
- "bech32 0.9.1",
+ "bech32 0.11.0",
  "bitcoin 0.32.5",
  "lightning-types",
 ]
 
 [[package]]
 name = "lightning-types"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1083b8d9137000edf3bfcb1ff011c0d25e0cdd2feb98cc21d6765e64a494148f"
+version = "0.2.0"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=f80d82e835987e045928955d2c83baba86c445e9#f80d82e835987e045928955d2c83baba86c445e9"
 dependencies = [
- "bech32 0.9.1",
  "bitcoin 0.32.5",
- "hex-conservative",
 ]
 
 [[package]]
@@ -2571,6 +2583,14 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "musig2"
+version = "0.1.0"
+source = "git+https://github.com/arik-so/rust-musig2?rev=6f95a05718cbb44d8fe3fa6021aea8117aa38d50#6f95a05718cbb44d8fe3fa6021aea8117aa38d50"
+dependencies = [
+ "bitcoin 0.32.5",
+]
 
 [[package]]
 name = "native-tls"
@@ -3051,6 +3071,14 @@ dependencies = [
  "cpufeatures",
  "opaque-debug",
  "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "possiblyrandom"
+version = "0.2.0"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=f80d82e835987e045928955d2c83baba86c445e9#f80d82e835987e045928955d2c83baba86c445e9"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -3764,7 +3792,7 @@ dependencies = [
  "hickory-resolver",
  "lazy_static",
  "lightning 0.0.118",
- "lightning 0.0.125",
+ "lightning 0.1.1",
  "lightning-invoice 0.26.0",
  "log",
  "percent-encoding",

--- a/libs/sdk-common/Cargo.toml
+++ b/libs/sdk-common/Cargo.toml
@@ -15,7 +15,10 @@ elements = { version = "0.25.0", optional = true }
 hex = { workspace = true }
 lazy_static = "1.5.0"
 lightning = { workspace = true }
-lightning-125 = { package = "lightning", version = "0.0.125", default-features = false, features = ["std"], optional = true }
+# Update to 0.1.2 when it is released
+lightning-with-bolt12 = { package = "lightning", git = "https://github.com/lightningdevkit/rust-lightning", rev = "f80d82e835987e045928955d2c83baba86c445e9", default-features = false, features = [
+    "std",
+], optional = true }
 lightning-invoice = { workspace = true }
 log = { workspace = true }
 percent-encoding = "2.3.1"
@@ -45,7 +48,10 @@ tonic = { workspace = true, features = [
 dns-parser = "0.8.0"
 getrandom = { version = "0.2.14", features = ["js"] }
 prost = "^0.13"
-tonic = { version = "0.12", default-features = false, features = ["codegen", "prost"] }
+tonic = { version = "0.12", default-features = false, features = [
+    "codegen",
+    "prost",
+] }
 tonic-web-wasm-client = "0.6"
 wasm-bindgen = "0.2.100"
 
@@ -65,5 +71,5 @@ tonic-build = { workspace = true }
 tonic-build = "0.12"
 
 [features]
-liquid = ["dep:elements", "dep:lightning-125"]
+liquid = ["dep:elements", "dep:lightning-with-bolt12"]
 test-utils = []

--- a/libs/sdk-common/src/invoice.rs
+++ b/libs/sdk-common/src/invoice.rs
@@ -12,8 +12,9 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "liquid")]
 use {
-    bitcoin::hashes::hex::ToHex as BitcoinHashToHex, lightning_125::ln::msgs::DecodeError,
-    lightning_125::offers::offer::Offer, lightning_125::offers::parse::Bolt12ParseError,
+    bitcoin::hashes::hex::ToHex as BitcoinHashToHex, lightning_with_bolt12::ln::msgs::DecodeError,
+    lightning_with_bolt12::offers::offer::Offer,
+    lightning_with_bolt12::offers::parse::Bolt12ParseError,
 };
 
 use crate::prelude::*;
@@ -401,10 +402,12 @@ pub fn parse_bolt12_offer(input: &str) -> Result<LNOffer, Bolt12ParseError> {
     let min_amount = offer
         .amount()
         .map(|amount| match amount {
-            lightning_125::offers::offer::Amount::Bitcoin { amount_msats } => Ok(Amount::Bitcoin {
-                amount_msat: amount_msats,
-            }),
-            lightning_125::offers::offer::Amount::Currency {
+            lightning_with_bolt12::offers::offer::Amount::Bitcoin { amount_msats } => {
+                Ok(Amount::Bitcoin {
+                    amount_msat: amount_msats,
+                })
+            }
+            lightning_with_bolt12::offers::offer::Amount::Currency {
                 iso4217_code,
                 amount,
             } => Ok(Amount::Currency {
@@ -427,7 +430,7 @@ pub fn parse_bolt12_offer(input: &str) -> Result<LNOffer, Bolt12ParseError> {
         description: offer.description().map(|d| d.to_string()),
         absolute_expiry: offer.absolute_expiry().map(|expiry| expiry.as_secs()),
         issuer: offer.issuer().map(|s| s.to_string()),
-        signing_pubkey: offer.signing_pubkey().map(|pk| pk.to_string()),
+        signing_pubkey: offer.issuer_signing_pubkey().map(|pk| pk.to_string()),
         paths: offer
             .paths()
             .iter()

--- a/libs/sdk-common/src/lib.rs
+++ b/libs/sdk-common/src/lib.rs
@@ -21,9 +21,9 @@ mod utils;
 // (e.g. impl From<bip32::Error> for LnUrlError)
 pub use bitcoin;
 pub use lightning;
-#[cfg(feature = "liquid")]
-pub use lightning_125;
 pub use lightning_invoice;
+#[cfg(feature = "liquid")]
+pub use lightning_with_bolt12;
 
 // We don't include grpc::* in the prelude exports, to force callers to use the grpc path prefix.
 #[rustfmt::skip]


### PR DESCRIPTION
Updates the `rust-lightning` dependency for Nodeless to reintroduce building the SDK for 32bit targets