### PR TITLE
Explicitly drop the shutdown sender to notify the receiver

### DIFF
--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -1513,7 +1513,7 @@ impl BreezServices {
                 };
 
                 debug!("shutting down signer");
-                _ = tx.send(());
+                drop(tx); // Dropping the sender explicitly to notify the receiver.
 
                 if is_shutdown {
                     return;


### PR DESCRIPTION
Note: The `Sender::send()` method is asynchronous and returns a future. Creating a future and not awaiting it does nothing. The code actually worked because the sender itself was later dropped. I suggest dropping it explicitly here to express intention.