### PR TITLE
fix clippy

### DIFF
--- a/libs/sdk-bindings/src/uniffi_binding.rs
+++ b/libs/sdk-bindings/src/uniffi_binding.rs
@@ -389,4 +389,10 @@ fn rt() -> &'static tokio::runtime::Runtime {
     &RT
 }
 
-uniffi_macros::include_scaffolding!("breez_sdk");
+#[allow(clippy::all)]
+mod uniffi_binding {
+    use super::*;
+    uniffi_macros::include_scaffolding!("breez_sdk");
+}
+
+pub use uniffi_binding::*;

--- a/libs/sdk-common/src/lnurl/model.rs
+++ b/libs/sdk-common/src/lnurl/model.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 ///  - started to pay the invoice asynchronously in the case of LNURL-withdraw,
 ///  - verified the client signature in the case of LNURL-auth
 /// * `Error` indicates a generic issue the LNURL endpoint encountered, including a freetext
-///    description of the reason.
+///   description of the reason.
 ///
 /// Both cases are described in LUD-03 <https://github.com/lnurl/luds/blob/luds/03.md> & LUD-04: <https://github.com/lnurl/luds/blob/luds/04.md>
 #[derive(Clone, Deserialize, Debug, Serialize)]


### PR DESCRIPTION
Updating rust makes some clippy rules be violated. This PR fixes them.
There were clippy errors in the uniffi generated code. That's why I put the generated code in a module.