### PR TITLE
improve error on insufficient balance for trampoline payments

### DIFF
--- a/libs/sdk-bindings/src/breez_sdk.udl
+++ b/libs/sdk-bindings/src/breez_sdk.udl
@@ -42,6 +42,7 @@ enum LnUrlPayError {
     "RouteNotFound",
     "RouteTooExpensive",
     "ServiceConnectivity",
+    "InsufficientBalance",
 };
 
 [Error]
@@ -96,6 +97,7 @@ enum SendPaymentError {
     "RouteNotFound",
     "RouteTooExpensive",
     "ServiceConnectivity",
+    "InsufficientBalance",
 };
 
 [Error]

--- a/libs/sdk-common/src/lnurl/specs/pay.rs
+++ b/libs/sdk-common/src/lnurl/specs/pay.rs
@@ -429,6 +429,10 @@ pub mod model {
         /// This error is raised when a connection to an external service fails.
         #[error("Service connectivity: {err}")]
         ServiceConnectivity { err: String },
+
+        /// This error is raised when the node does not have enough funds to make the payment.
+        #[error("Insufficient balance: {err}")]
+        InsufficientBalance { err: String },
     }
 
     impl From<anyhow::Error> for LnUrlPayError {

--- a/libs/sdk-core/src/breez_services.rs
+++ b/libs/sdk-core/src/breez_services.rs
@@ -325,6 +325,16 @@ impl BreezServices {
             {
                 Ok(res) => Some(res),
                 Err(e) => {
+                    if e.to_string().contains("missing balance") {
+                        debug!(
+                            "trampoline payment failed due to insufficient balance: {:?}",
+                            e
+                        );
+                        return Err(SendPaymentError::InsufficientBalance {
+                            err: "Trampoline payment failed".into(),
+                        });
+                    }
+
                     warn!("trampoline payment failed: {:?}", e);
                     None
                 }

--- a/libs/sdk-core/src/error.rs
+++ b/libs/sdk-core/src/error.rs
@@ -112,6 +112,7 @@ impl From<SendPaymentError> for LnUrlPayError {
             SendPaymentError::RouteNotFound { err } => Self::RouteNotFound { err },
             SendPaymentError::RouteTooExpensive { err } => Self::RouteTooExpensive { err },
             SendPaymentError::ServiceConnectivity { err } => Self::ServiceConnectivity { err },
+            SendPaymentError::InsufficientBalance { err } => Self::InsufficientBalance { err },
         }
     }
 }
@@ -479,7 +480,8 @@ impl From<SendPaymentError> for SdkError {
             | SendPaymentError::PaymentFailed { err }
             | SendPaymentError::PaymentTimeout { err }
             | SendPaymentError::RouteNotFound { err }
-            | SendPaymentError::RouteTooExpensive { err } => Self::Generic { err },
+            | SendPaymentError::RouteTooExpensive { err }
+            | SendPaymentError::InsufficientBalance { err } => Self::Generic { err },
             SendPaymentError::ServiceConnectivity { err } => Self::ServiceConnectivity { err },
         }
     }
@@ -626,6 +628,10 @@ pub enum SendPaymentError {
     /// This error is raised when a connection to an external service fails.
     #[error("Service connectivity: {err}")]
     ServiceConnectivity { err: String },
+
+    /// This error is raised when the node does not have enough funds to make the payment.
+    #[error("Insufficient balance: {err}")]
+    InsufficientBalance { err: String },
 }
 
 impl From<anyhow::Error> for SendPaymentError {


### PR DESCRIPTION
The current flow when you send a trampoline payment and the user's balance is insufficient is:
- we attempt a trampoline payment
- it will return an error like `missing balance 43276289msat<50254000msat`
- we attempt a regular payment
- it will return `Ran out of routes to try after 1 attempt`

This PR improves this flow by introducing an 'InsufficientBalance' error.
If the trampoline payment fails with 'missing balance', return immediately an InsufficientBalance error to the user.