### PR TITLE
CI: update minimal ubuntu versions

### DIFF
--- a/.github/workflows/build-bindings-linux.yml
+++ b/.github/workflows/build-bindings-linux.yml
@@ -25,7 +25,7 @@ on:
 jobs:
   build:
     if: ${{ !inputs.use-dummy-binaries }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: build ${{ matrix.target }}
     strategy:
       matrix:

--- a/.github/workflows/publish-csharp.yml
+++ b/.github/workflows/publish-csharp.yml
@@ -106,7 +106,7 @@ jobs:
         target: [
           windows-latest,
           ubuntu-latest,
-          ubuntu-20.04,
+          ubuntu-22.04,
           macOS-latest,
         ]
     steps:

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -81,7 +81,7 @@ jobs:
           path: libs/sdk-bindings/bindings-python/dist/*.whl
 
   build-linux-wheels:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         arch: [x86_64, aarch64]


### PR DESCRIPTION
ubuntu 20.04 is deprecated

This will affect the glibc versions used in our distributions, meaning we support less linux machines.