### PR TITLE
build(android): update Gradle config for Flutter plugin compatibility

### DIFF
--- a/libs/sdk-flutter/android/build.gradle
+++ b/libs/sdk-flutter/android/build.gradle
@@ -52,6 +52,7 @@ android {
     }
 
     defaultConfig {
+        ndkVersion = flutter.ndkVersion
         minSdk = 24
     }
 }

--- a/libs/sdk-flutter/android/build.gradle
+++ b/libs/sdk-flutter/android/build.gradle
@@ -11,6 +11,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
     }
 }
 

--- a/libs/sdk-flutter/android/build.gradle
+++ b/libs/sdk-flutter/android/build.gradle
@@ -35,12 +35,12 @@ android {
     compileSdk 35
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '11'
     }
 
     sourceSets {

--- a/libs/sdk-flutter/android/build.gradle
+++ b/libs/sdk-flutter/android/build.gradle
@@ -57,7 +57,9 @@ android {
 }
 
 dependencies {
-    implementation "net.java.dev.jna:jna:5.14.0@aar"
+    implementation("net.java.dev.jna:jna:5.14.0@aar") {
+        exclude group: 'net.java.dev.jna', module: 'jna'
+    }
     /* JSON serialization */
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3'
 }

--- a/libs/sdk-flutter/android/build.gradle
+++ b/libs/sdk-flutter/android/build.gradle
@@ -52,7 +52,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 24
+        minSdk = 24
     }
 }
 

--- a/libs/sdk-flutter/android/build.gradle
+++ b/libs/sdk-flutter/android/build.gradle
@@ -27,6 +27,11 @@ apply plugin: 'kotlinx-serialization'
 
 android {
     compileSdkVersion 33
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+      namespace "$group"
+    }
+    
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/libs/sdk-flutter/android/build.gradle
+++ b/libs/sdk-flutter/android/build.gradle
@@ -26,12 +26,12 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlinx-serialization'
 
 android {
-    compileSdkVersion 33
     // Conditional for compatibility with AGP <4.2.
     if (project.android.hasProperty("namespace")) {
       namespace "$group"
     }
-    
+
+    compileSdk 35
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/libs/sdk-flutter/android/build.gradle
+++ b/libs/sdk-flutter/android/build.gradle
@@ -44,7 +44,11 @@ android {
     }
 
     sourceSets {
-        main.java.srcDirs += 'src/main/kotlin'
+        main {
+            java.srcDirs += 'src/main/kotlin'
+            // Troubleshooting: Run 'make android' first to generate library files
+            jniLibs.srcDirs = ['src/main/jniLibs']
+        }
     }
 
     defaultConfig {

--- a/libs/sdk-flutter/android/build.gradle.production
+++ b/libs/sdk-flutter/android/build.gradle.production
@@ -55,8 +55,9 @@ android {
 
 dependencies {
     api "breez_sdk:bindings-android:$version"
-    implementation "net.java.dev.jna:jna:5.14.0@aar"
+    implementation("net.java.dev.jna:jna:5.14.0@aar") {
+        exclude group: 'net.java.dev.jna', module: 'jna'
+    }
     /* JSON serialization */
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3'
-
 }

--- a/libs/sdk-flutter/android/build.gradle.production
+++ b/libs/sdk-flutter/android/build.gradle.production
@@ -49,6 +49,7 @@ android {
     }
 
     defaultConfig {
+        ndkVersion = flutter.ndkVersion
         minSdk = 24
     }
 }

--- a/libs/sdk-flutter/android/build.gradle.production
+++ b/libs/sdk-flutter/android/build.gradle.production
@@ -11,6 +11,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
     }
 }
 

--- a/libs/sdk-flutter/android/build.gradle.production
+++ b/libs/sdk-flutter/android/build.gradle.production
@@ -27,12 +27,12 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlinx-serialization'
 
 android {
-    compileSdkVersion 33
     // Conditional for compatibility with AGP <4.2.
     if (project.android.hasProperty("namespace")) {
       namespace "$group"
     }
-    
+
+    compileSdk 35
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/libs/sdk-flutter/android/build.gradle.production
+++ b/libs/sdk-flutter/android/build.gradle.production
@@ -28,6 +28,11 @@ apply plugin: 'kotlinx-serialization'
 
 android {
     compileSdkVersion 33
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+      namespace "$group"
+    }
+    
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/libs/sdk-flutter/android/build.gradle.production
+++ b/libs/sdk-flutter/android/build.gradle.production
@@ -36,12 +36,12 @@ android {
     compileSdk 35
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '11'
     }
 
     sourceSets {

--- a/libs/sdk-flutter/android/build.gradle.production
+++ b/libs/sdk-flutter/android/build.gradle.production
@@ -49,7 +49,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 24
+        minSdk = 24
     }
 }
 

--- a/libs/sdk-flutter/android/src/main/AndroidManifest.xml
+++ b/libs/sdk-flutter/android/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"></manifest>

--- a/libs/sdk-flutter/android/src/main/AndroidManifest.xml
+++ b/libs/sdk-flutter/android/src/main/AndroidManifest.xml
@@ -1,3 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.breez.breez_sdk">
-</manifest>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"></manifest>


### PR DESCRIPTION
Fixes https://github.com/breez/breez-sdk-greenlight/issues/1128

---

Supersedes 
- https://github.com/breez/breez-sdk-greenlight/pull/1129

---

This PR updates the Android Gradle configuration to align with AGP 8 and recent tooling requirements:
- Add `namespace` to module-level `build.gradle` to comply with AGP requirements.
  - Remove obsolete `AndroidManifest.xml` no longer needed after namespace migration.
- Update `compileSdk` and `targetSdk` versions to 35.
-  Add missing `kotlinx-serialization` plugin dependency to fix: 
   - #1128 
   - `Plugin with id 'kotlinx-serialization' not found.`
- Add local `.so` artifacts to `jniLibs` via `sourceSets` to avoid build cache conflicts.
- Fix duplicate JNA class issue by excluding one of the clashing JARs:
   ```
    Duplicate class com.sun.jna.**** found in modules jna-5.14.0.aar -> jetified-jna-5.14.0-runtime (net.java.dev.jna:jna:5.14.0) and jna-5.14.0.jar -> jetified-jna-5.14.0 (net.java.dev.jna:jna:5.14.0)
    ```

These changes resolve build issues and ensure compatibility with the latest Flutter plugin, Android toolchain, and both local and remote dependencies.

---

There will be a continuation PR for addressing issues Flutter plugin issues on iOS.