### PR TITLE
ci(ios): unify iOS 12.0 deployment target across CI and podspecs

### DIFF
--- a/.github/workflows/build-bindings-ios.yml
+++ b/.github/workflows/build-bindings-ios.yml
@@ -47,9 +47,6 @@ jobs:
         rustup toolchain install stable --profile minimal
         rustup target add ${{ matrix.target }}
 
-    - name: Set IPHONEOS_DEPLOYMENT_TARGET 
-      run: echo "IPHONEOS_DEPLOYMENT_TARGET=12.0" >> $GITHUB_ENV
-
     - name: Install Protoc
       uses: arduino/setup-protoc@v3
       with:
@@ -67,6 +64,8 @@ jobs:
 
     - name: Build sdk-bindings
       working-directory: libs/sdk-bindings
+      env:
+        IPHONEOS_DEPLOYMENT_TARGET: 12.0
       run: cargo build --release --target ${{ matrix.target }}
     
     - name: Archive release

--- a/.github/workflows/publish-swift.yml
+++ b/.github/workflows/publish-swift.yml
@@ -105,6 +105,9 @@ jobs:
         run: |
           sed -i '' 's#^.\{2\}spec.version.*$#  spec.version                = "${{ inputs.package-version }}"#' breez_sdkFFI.podspec
           sed -i '' 's#^.\{2\}spec.version.*$#  spec.version                = "${{ inputs.package-version }}"#' BreezSDK.podspec
+          # Set iOS Deployment Target to 12.0
+          sed -i '' 's#^.\{2\}spec.ios.deployment_target.*$#  spec.ios.deployment_target = "12.0"#' breez_sdkFFI.podspec
+          sed -i '' 's#^.\{2\}spec.ios.deployment_target.*$#  spec.ios.deployment_target = "12.0"#' BreezSDK.podspec
 
       - name: Tag swift package
         working-directory: breez-sdk-swift

--- a/libs/sdk-flutter/ios/breez_sdk.podspec
+++ b/libs/sdk-flutter/ios/breez_sdk.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
     ]
   }
   s.dependency 'Flutter'
-  s.platform = :ios, '11.0'
+  s.platform = :ios, '12.0'
   s.static_framework = true
 
   # Flutter.framework does not contain a i386 slice.

--- a/libs/sdk-flutter/ios/breez_sdk.podspec.production
+++ b/libs/sdk-flutter/ios/breez_sdk.podspec.production
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
     ]
   }
   s.dependency 'Flutter'
-  s.platform = :ios, '11.0'
+  s.platform = :ios, '12.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = {'STRIP_STYLE' => 'non-global', 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/libs/sdk-react-native/BreezSDK.podspec.dev
+++ b/libs/sdk-react-native/BreezSDK.podspec.dev
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => "11.0" }
+  s.platforms    = { :ios => "12.0" }
   s.source       = { :git => "https://github.com/breez/breez-sdk.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"  

--- a/libs/sdk-react-native/breez_sdk.podspec
+++ b/libs/sdk-react-native/breez_sdk.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => "11.0" }
+  s.platforms    = { :ios => "12.0" }
   s.source       = { :git => "https://github.com/breez/breez-sdk.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"


### PR DESCRIPTION
This PR is a continuation of 
- #1154 &
- #1206

to address missing architecture artifacts on iOS due target version being too low, as Rust require [Xcode 12 or higher to build the ARM64 targets](https://doc.rust-lang.org/rustc/platform-support/apple-ios.html#requirements).

This resolves online build & publishing Swift package issues, which consequently fix Flutter & React Native package issue as they depend on Swift package.