### PR TITLE
A fix to parse another varirant of cln error

### DIFF
--- a/libs/sdk-core/src/greenlight/error.rs
+++ b/libs/sdk-core/src/greenlight/error.rs
@@ -235,7 +235,7 @@ pub(crate) fn parse_cln_error(status: tonic::Status) -> Result<JsonRpcErrCode> {
 /// The [tonic::Status] is nested into an [tonic::Code::Internal] one here:
 /// <https://github.com/Blockstream/greenlight/blob/e87f60e473edf9395631086c48ba6234c0c052ff/libs/gl-plugin/src/node/wrapper.rs#L90-L93>
 pub(crate) fn parse_cln_error_wrapped(status: tonic::Status) -> Result<JsonRpcErrCode> {
-    let re: Regex = Regex::new(r"code: (?<code>-?\d+)")?;
+    let re: Regex = Regex::new(r"code:? (?<code>-?\d+)")?;
     re.captures(status.message())
         .and_then(|caps| {
             caps["code"]
@@ -254,6 +254,14 @@ mod tests {
 
     #[test]
     fn test_parse_cln_error() -> Result<()> {
+        assert!(matches!(
+            parse_cln_error(tonic::Status::new(
+                Code::Internal,
+                "converting invoice response to grpc: Error code 901: preimage already used"
+            )),
+            Ok(JsonRpcErrCode::InvoicePreimageAlreadyExists)
+        ));
+
         assert!(parse_cln_error(tonic::Status::new(Code::Internal, "...")).is_err());
 
         assert!(matches!(


### PR DESCRIPTION
Seems that there is another variant of cln error that we should parse.
Before this change since we didn't detect this type of error we didn't fail back to using the node invoice.

Fixed #1209 
