### PR TITLE
Remove std feature from lightning for Wasm

### DIFF
--- a/libs/sdk-common/Cargo.toml
+++ b/libs/sdk-common/Cargo.toml
@@ -15,9 +15,6 @@ elements = { version = "0.25.0", optional = true }
 hex = { workspace = true }
 lazy_static = "1.5.0"
 lightning = { workspace = true }
-lightning-with-bolt12 = { package = "lightning", version = "0.1.2", default-features = false, features = [
-    "std",
-], optional = true }
 lightning-invoice = { workspace = true }
 log = { workspace = true }
 percent-encoding = "2.3.1"
@@ -35,6 +32,9 @@ urlencoding = { version = "2.1.3" }
 
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dependencies]
 hickory-resolver = { version = "0.24.2", features = ["dnssec-ring"] }
+lightning-with-bolt12 = { package = "lightning", version = "0.1.2", default-features = false, features = [
+    "std",
+], optional = true }
 prost = { workspace = true }
 tonic = { workspace = true, features = [
     "tls",
@@ -47,6 +47,7 @@ maybe-sync = { version = "0.1.1", features = ["sync"] }
 [target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
 dns-parser = "0.8.0"
 getrandom = { version = "0.2.14", features = ["js"] }
+lightning-with-bolt12 = { package = "lightning", version = "0.1.2", default-features = false, features = [], optional = true }
 prost = "^0.13"
 tonic = { version = "0.12", default-features = false, features = [
     "codegen",


### PR DESCRIPTION
When validating the BOLT12 invoice request the lightning crate checks if the BOLT12 offer has expired which causes a panic in Wasm. Removing the `std` feature avoids this. It is our offer so we know it's valid.