### PR TITLE
Update CS and Go bindgen to uniffi 0.28

### DIFF
--- a/.github/workflows/build-language-bindings.yml
+++ b/.github/workflows/build-language-bindings.yml
@@ -60,7 +60,7 @@ on:
 jobs:
   build-language-bindings:
     runs-on: ubuntu-latest
-    if: ${{ inputs.swift || inputs.python }}
+    if: ${{ inputs.csharp || inputs.golang || inputs.python || inputs.swift }}
     steps:
       - name: Checkout breez-sdk repo
         uses: actions/checkout@v4
@@ -106,9 +106,37 @@ jobs:
           name: bindings-python
           path: libs/sdk-bindings/ffi/python/breez_sdk.py
 
+      - name: Build C# binding
+        if: ${{ inputs.csharp }}
+        working-directory: libs/sdk-bindings
+        run: |
+          cargo install uniffi-bindgen-cs --git https://github.com/NordSecurity/uniffi-bindgen-cs --tag v0.9.1+v0.28.3
+          uniffi-bindgen-cs src/breez_sdk.udl -o ffi/csharp -c ./uniffi.toml
+      
+      - name: Archive C# binding
+        if: ${{ inputs.csharp }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: bindings-csharp
+          path: libs/sdk-bindings/ffi/csharp/breez_sdk.cs
+    
+      - name: Build golang binding
+        if: ${{ inputs.golang }}
+        working-directory: libs/sdk-bindings
+        run: |
+          cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go --tag v0.3.0+v0.28.3
+          uniffi-bindgen-go src/breez_sdk.udl -o ffi/golang -c ./uniffi.toml
+  
+      - name: Archive golang binding
+        if: ${{ inputs.golang }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: bindings-golang
+          path: libs/sdk-bindings/ffi/golang/breez_sdk/breez_sdk.*
+
   build-language-bindings-uniffi-25:
     runs-on: ubuntu-latest
-    if: ${{ inputs.kotlin || inputs.csharp || inputs.golang }}
+    if: ${{ inputs.kotlin }}
     steps:
       - name: Checkout breez-sdk repo
         uses: actions/checkout@v4
@@ -151,31 +179,3 @@ jobs:
         with:
           name: bindings-kotlin-multiplatform
           path: libs/sdk-bindings/ffi/kmp/*
-
-      - name: Build C# binding
-        if: ${{ inputs.csharp }}
-        working-directory: libs/sdk-bindings
-        run: |
-          cargo install uniffi-bindgen-cs --git https://github.com/NordSecurity/uniffi-bindgen-cs --tag v0.8.0+v0.25.0
-          uniffi-bindgen-cs src/breez_sdk.udl -o ffi/csharp -c ./uniffi.toml
-      
-      - name: Archive C# binding
-        if: ${{ inputs.csharp }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: bindings-csharp
-          path: libs/sdk-bindings/ffi/csharp/breez_sdk.cs
-    
-      - name: Build golang binding
-        if: ${{ inputs.golang }}
-        working-directory: libs/sdk-bindings
-        run: |
-          cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go --tag v0.2.1+v0.25.0
-          uniffi-bindgen-go src/breez_sdk.udl -o ffi/golang -c ./uniffi.toml
-  
-      - name: Archive golang binding
-        if: ${{ inputs.golang }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: bindings-golang
-          path: libs/sdk-bindings/ffi/golang/breez_sdk/breez_sdk.*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
   
   build-bindings:
     name: Test sdk-bindings
-    runs-on: macOS-latest
+    runs-on: ubuntu-latest
     env:
       DOTNET_INSTALL_DIR: "${{ github.workspace }}/dotnet"
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,42 +92,6 @@ jobs:
           version: "27.2"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup python
-        uses: actions/setup-python@v5 
-        with:
-          python-version: '3.11'
-
-      - name: Build sdk-bindings
-        working-directory: libs/sdk-bindings
-        run: cargo build
-
-      - name: Run sdk-bindings tests
-        run: |
-          curl -o jna-5.12.1.jar https://repo1.maven.org/maven2/net/java/dev/jna/jna/5.12.1/jna-5.12.1.jar
-          export CLASSPATH=$(pwd)/jna-5.12.1.jar;
-          cd libs/sdk-bindings
-          cargo test
-
-  build-bindings-uniffi-25:
-    name: Test bindings Uniffi 0.25
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: -uniffi-25
-          workspaces: |
-            lib -> target
-            cli -> target
-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          version: "27.2"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Setup dotnet
         uses: actions/setup-dotnet@v3
         with:
@@ -138,29 +102,37 @@ jobs:
         with:
           go-version: '1.19.9'
 
+      - name: Setup python
+        uses: actions/setup-python@v5 
+        with:
+          python-version: '3.11'
+
       - name: Build sdk-bindings
         working-directory: libs/sdk-bindings
-        run: cargo build --no-default-features --features uniffi-25
+        run: cargo build
 
       - name: Build C# bindings
         working-directory: libs/sdk-bindings       
         run: |
-          cargo install uniffi-bindgen-cs --git https://github.com/NordSecurity/uniffi-bindgen-cs --tag v0.8.0+v0.25.0
+          cargo install uniffi-bindgen-cs --git https://github.com/NordSecurity/uniffi-bindgen-cs --tag v0.9.1+v0.28.3
           uniffi-bindgen-cs src/breez_sdk.udl -o ffi/csharp -c ./uniffi.toml
           cp ../target/debug/libbreez_sdk_bindings.so ffi/csharp
 
       - name: Build golang bindings
         working-directory: libs/sdk-bindings       
         run: |
-          cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go --tag v0.2.1+v0.25.0
+          cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go --tag v0.3.0+v0.28.3
           uniffi-bindgen-go src/breez_sdk.udl -o ffi/golang -c ./uniffi.toml
           cp ../target/debug/libbreez_sdk_bindings.so ffi/golang
           cp -r ffi/golang/breez_sdk tests/bindings/golang/
 
-      - name: Run bindings tests
-        working-directory: libs/sdk-bindings       
-        run: cargo test --no-default-features --features uniffi-25
-          
+      - name: Run sdk-bindings tests
+        run: |
+          curl -o jna-5.12.1.jar https://repo1.maven.org/maven2/net/java/dev/jna/jna/5.12.1/jna-5.12.1.jar
+          export CLASSPATH=$(pwd)/jna-5.12.1.jar;
+          cd libs/sdk-bindings
+          cargo test
+
   build-cli:
     name: Test sdk-cli
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-all-platforms.yml
+++ b/.github/workflows/publish-all-platforms.yml
@@ -122,7 +122,7 @@ jobs:
       swift-package-version: ${{ needs.pre-setup.outputs.swift-package-version || '0.0.2' }}
       publish: ${{ needs.pre-setup.outputs.publish }}
       use-dummy-binaries: ${{ needs.pre-setup.outputs.use-dummy-binaries }}
-      uniffi-25: ${{ !!needs.pre-setup.outputs.csharp-package-version || !!needs.pre-setup.outputs.golang-package-version || !!needs.pre-setup.outputs.kotlin-multiplatform-package-version || !!needs.pre-setup.outputs.maven-package-version }}
+      uniffi-25: ${{ !!needs.pre-setup.outputs.kotlin-multiplatform-package-version || !!needs.pre-setup.outputs.maven-package-version }}
     steps:
       - run: echo "set setup output variables"
 

--- a/.github/workflows/publish-csharp.yml
+++ b/.github/workflows/publish-csharp.yml
@@ -46,32 +46,32 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: sdk-bindings-aarch64-apple-darwin-uniffi-25
+          name: sdk-bindings-aarch64-apple-darwin
           path: libs/sdk-bindings/bindings-csharp/src/runtimes/osx-arm64/native
 
       - uses: actions/download-artifact@v4
         with:
-          name: sdk-bindings-x86_64-apple-darwin-uniffi-25
+          name: sdk-bindings-x86_64-apple-darwin
           path: libs/sdk-bindings/bindings-csharp/src/runtimes/osx-x64/native
 
       - uses: actions/download-artifact@v4
         with:
-          name: sdk-bindings-aarch64-unknown-linux-gnu-uniffi-25
+          name: sdk-bindings-aarch64-unknown-linux-gnu
           path: libs/sdk-bindings/bindings-csharp/src/runtimes/linux-arm64/native
 
       - uses: actions/download-artifact@v4
         with:
-          name: sdk-bindings-x86_64-unknown-linux-gnu-uniffi-25
+          name: sdk-bindings-x86_64-unknown-linux-gnu
           path: libs/sdk-bindings/bindings-csharp/src/runtimes/linux-x64/native
 
       - uses: actions/download-artifact@v4
         with:
-          name: sdk-bindings-x86_64-pc-windows-msvc-uniffi-25
+          name: sdk-bindings-x86_64-pc-windows-msvc
           path: libs/sdk-bindings/bindings-csharp/src/runtimes/win-x64/native
 
       - uses: actions/download-artifact@v4
         with:
-          name: sdk-bindings-i686-pc-windows-msvc-uniffi-25
+          name: sdk-bindings-i686-pc-windows-msvc
           path: libs/sdk-bindings/bindings-csharp/src/runtimes/win-x86/native
 
       - name: Update package version

--- a/.github/workflows/publish-golang.yml
+++ b/.github/workflows/publish-golang.yml
@@ -38,47 +38,47 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: sdk-bindings-i686-linux-android-uniffi-25
+          name: sdk-bindings-i686-linux-android
           path: breez_sdk/lib/android-386
 
       - uses: actions/download-artifact@v4
         with:
-          name: sdk-bindings-armv7-linux-androideabi-uniffi-25
+          name: sdk-bindings-armv7-linux-androideabi
           path: breez_sdk/lib/android-aarch
 
       - uses: actions/download-artifact@v4
         with:
-          name: sdk-bindings-aarch64-linux-android-uniffi-25
+          name: sdk-bindings-aarch64-linux-android
           path: breez_sdk/lib/android-aarch64
 
       - uses: actions/download-artifact@v4
         with:
-          name: sdk-bindings-x86_64-linux-android-uniffi-25
+          name: sdk-bindings-x86_64-linux-android
           path: breez_sdk/lib/android-amd64
 
       - uses: actions/download-artifact@v4
         with:
-          name: sdk-bindings-aarch64-apple-darwin-uniffi-25
+          name: sdk-bindings-aarch64-apple-darwin
           path: breez_sdk/lib/darwin-aarch64
 
       - uses: actions/download-artifact@v4
         with:
-          name: sdk-bindings-x86_64-apple-darwin-uniffi-25
+          name: sdk-bindings-x86_64-apple-darwin
           path: breez_sdk/lib/darwin-amd64
 
       - uses: actions/download-artifact@v4
         with:
-          name: sdk-bindings-aarch64-unknown-linux-gnu-uniffi-25
+          name: sdk-bindings-aarch64-unknown-linux-gnu
           path: breez_sdk/lib/linux-aarch64
 
       - uses: actions/download-artifact@v4
         with:
-          name: sdk-bindings-x86_64-unknown-linux-gnu-uniffi-25
+          name: sdk-bindings-x86_64-unknown-linux-gnu
           path: breez_sdk/lib/linux-amd64
 
       - uses: actions/download-artifact@v4
         with:
-          name: sdk-bindings-x86_64-pc-windows-msvc-uniffi-25
+          name: sdk-bindings-x86_64-pc-windows-msvc
           path: breez_sdk/lib/windows-amd64
 
       - name: Archive Go release
@@ -95,7 +95,6 @@ jobs:
           git config --global user.email github-actions@github.com
           git config --global user.name github-actions
           git add breez_sdk/breez_sdk.h
-          git add breez_sdk/breez_sdk.c
           git add breez_sdk/breez_sdk.go
           git add breez_sdk/lib/android-386/libbreez_sdk_bindings.so
           git add breez_sdk/lib/android-386/libc++_shared.so

--- a/.github/workflows/publish-swift.yml
+++ b/.github/workflows/publish-swift.yml
@@ -80,6 +80,14 @@ jobs:
           rm bindings-swift/Sources/BreezSDK/breez_sdkFFI.h
           rm bindings-swift/Sources/BreezSDK/breez_sdkFFI.modulemap
 
+      - name: Set plist versions
+        working-directory: breez-sdk/libs/sdk-bindings/bindings-swift/breez_sdkFFI.xcframework
+        run: |
+          SHORT_VERSION=$(echo "${{ inputs.package-version }}" | grep -Eo '^(\d+\.\d+\.\d+)')
+          /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $SHORT_VERSION" ios-arm64/breez_sdkFFI.framework/Info.plist
+          /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $SHORT_VERSION" ios-arm64_x86_64-simulator/breez_sdkFFI.framework/Info.plist
+          /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $SHORT_VERSION" macos-arm64_x86_64/breez_sdkFFI.framework/Info.plist
+
       - name: Compress xcframework
         working-directory: breez-sdk/libs/sdk-bindings/bindings-swift
         run: |

--- a/libs/sdk-bindings/bindings-swift/breez_sdkFFI.xcframework/ios-arm64/breez_sdkFFI.framework/Info.plist
+++ b/libs/sdk-bindings/bindings-swift/breez_sdkFFI.xcframework/ios-arm64/breez_sdkFFI.framework/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>breez_sdkFFI</string>
+    <key>CFBundleIdentifier</key>
+    <string>technology.breez.breez-sdkFFI</string>
+    <key>CFBundleName</key>
+    <string>breez_sdkFFI</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundlePackageType</key>
+    <string>FMWK</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneOS</string>
+	</array>
+    <key>CFBundleSignature</key>
+    <string>????</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>MinimumOSVersion</key>
+    <string>13.0</string>
+</dict>
+</plist>

--- a/libs/sdk-bindings/bindings-swift/breez_sdkFFI.xcframework/ios-arm64_x86_64-simulator/breez_sdkFFI.framework/Info.plist
+++ b/libs/sdk-bindings/bindings-swift/breez_sdkFFI.xcframework/ios-arm64_x86_64-simulator/breez_sdkFFI.framework/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>breez_sdkFFI</string>
+    <key>CFBundleIdentifier</key>
+    <string>technology.breez.breez-sdkFFI</string>
+    <key>CFBundleName</key>
+    <string>breez_sdkFFI</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundlePackageType</key>
+    <string>FMWK</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>iPhoneSimulator</string>
+	</array>
+    <key>CFBundleSignature</key>
+    <string>????</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>MinimumOSVersion</key>
+    <string>13.0</string>
+</dict>
+</plist>

--- a/libs/sdk-bindings/bindings-swift/breez_sdkFFI.xcframework/macos-arm64_x86_64/breez_sdkFFI.framework/Info.plist
+++ b/libs/sdk-bindings/bindings-swift/breez_sdkFFI.xcframework/macos-arm64_x86_64/breez_sdkFFI.framework/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>breez_sdkFFI</string>
+    <key>CFBundleIdentifier</key>
+    <string>technology.breez.breez-sdkFFI</string>
+    <key>CFBundleName</key>
+    <string>breez_sdkFFI</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundlePackageType</key>
+    <string>FMWK</string>
+    <key>CFBundleSupportedPlatforms</key>
+    <array>
+        <string>MacOSX</string>
+    </array>
+    <key>CFBundleSignature</key>
+    <string>????</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>MinimumOSVersion</key>
+    <string>15.0</string>
+</dict>
+</plist>

--- a/libs/sdk-bindings/makefile
+++ b/libs/sdk-bindings/makefile
@@ -54,26 +54,26 @@ darwin-universal-uniffi-25: $(SOURCES)
 	lipo -create -output ../target/darwin-universal/release/libbreez_sdk_bindings.dylib ../target/aarch64-apple-darwin/release/libbreez_sdk_bindings.dylib ../target/x86_64-apple-darwin/release/libbreez_sdk_bindings.dylib
 	lipo -create -output ../target/darwin-universal/release/libbreez_sdk_bindings.a ../target/aarch64-apple-darwin/release/libbreez_sdk_bindings.a ../target/x86_64-apple-darwin/release/libbreez_sdk_bindings.a
 
-csharp-darwin: darwin-universal-uniffi-25
-	cargo install uniffi-bindgen-cs --git https://github.com/NordSecurity/uniffi-bindgen-cs --tag v0.8.0+v0.25.0
+csharp-darwin: darwin-universal
+	cargo install uniffi-bindgen-cs --git https://github.com/NordSecurity/uniffi-bindgen-cs --tag v0.9.1+v0.28.3
 	uniffi-bindgen-cs src/breez_sdk.udl -o ffi/csharp -c ./uniffi.toml
 	cp ../target/darwin-universal/release/libbreez_sdk_bindings.dylib ffi/csharp
 
 csharp-linux: $(SOURCES)
-	cargo install uniffi-bindgen-cs --git https://github.com/NordSecurity/uniffi-bindgen-cs --tag v0.8.0+v0.25.0
-	cargo build --no-default-features --features uniffi-25 --release --target $(TARGET)
+	cargo install uniffi-bindgen-cs --git https://github.com/NordSecurity/uniffi-bindgen-cs --tag v0.9.1+v0.28.3
+	cargo build --release --target $(TARGET)
 	uniffi-bindgen-cs src/breez_sdk.udl -o ffi/csharp -c ./uniffi.toml
 	cp ../target/$(TARGET)/release/libbreez_sdk_bindings.so ffi/csharp
 
-golang-darwin: darwin-universal-uniffi-25
-	cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go --tag v0.2.1+v0.25.0
+golang-darwin: darwin-universal
+	cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go --tag v0.3.0+v0.28.3
 	uniffi-bindgen-go src/breez_sdk.udl -o ffi/golang -c ./uniffi.toml
 	cp ../target/darwin-universal/release/libbreez_sdk_bindings.dylib ffi/golang
 	cp -r ffi/golang/breez_sdk tests/bindings/golang/
 
 golang-linux: $(SOURCES)
-	cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go --tag v0.2.1+v0.25.0
-	cargo build --no-default-features --features uniffi-25 --release --target $(TARGET)
+	cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go --tag v0.3.0+v0.28.3
+	cargo build --release --target $(TARGET)
 	uniffi-bindgen-go src/breez_sdk.udl -o ffi/golang -c ./uniffi.toml
 	cp ../target/$(TARGET)/release/libbreez_sdk_bindings.so ffi/golang
 	cp -r ffi/golang/breez_sdk tests/bindings/golang/

--- a/libs/sdk-bindings/tests/bindings/golang/test_breez_sdk.go
+++ b/libs/sdk-bindings/tests/bindings/golang/test_breez_sdk.go
@@ -24,10 +24,10 @@ func main() {
 
 	breez_sdk.SetLogStream(breezListener)
 
-	seed, err := breez_sdk.MnemonicToSeed("repeat hawk combine screen network rhythm ritual social neither casual volcano powder")
+	seed, sdkErr := breez_sdk.MnemonicToSeed("repeat hawk combine screen network rhythm ritual social neither casual volcano powder")
 
-	if err != nil {
-		log.Fatalf("MnemonicToSeed failed: %#v", err)
+	if sdkErr != nil {
+		log.Fatalf("MnemonicToSeed failed: %#v", sdkErr)
 	}
 
 	config := breez_sdk.DefaultConfig(breez_sdk.EnvironmentTypeProduction, "code", breez_sdk.NodeConfigGreenlight{
@@ -37,16 +37,16 @@ func main() {
 		},
 	})
 	connectRequest := breez_sdk.ConnectRequest{Config: config, Seed: seed}
-	sdkServices, err := breez_sdk.Connect(connectRequest, breezListener)
+	sdkServices, connectErr := breez_sdk.Connect(connectRequest, breezListener)
 
-	if err != nil {
-		log.Fatalf("Connect failed: %#v", err)
+	if connectErr != nil {
+		log.Fatalf("Connect failed: %#v", connectErr)
 	}
 
-	nodeInfo, err := sdkServices.NodeInfo()
+	nodeInfo, sdkErr := sdkServices.NodeInfo()
 
-	if err != nil {
-		log.Fatalf("NodeInfo failed: %#v", err)
+	if sdkErr != nil {
+		log.Fatalf("NodeInfo failed: %#v", sdkErr)
 	}
 
 	log.Print(nodeInfo.Id)

--- a/libs/sdk-bindings/tests/test_generated_bindings.rs
+++ b/libs/sdk-bindings/tests/test_generated_bindings.rs
@@ -1,10 +1,6 @@
-#[cfg(feature = "uniffi-28")]
 extern crate uniffi_28 as uniffi;
-
-#[cfg(feature = "uniffi-25")]
 use std::process::Command;
 
-#[cfg(feature = "uniffi-28")]
 uniffi::build_foreign_language_testcases!(
     "tests/bindings/test_breez_sdk.swift",
     "tests/bindings/test_breez_sdk.kts",
@@ -12,7 +8,6 @@ uniffi::build_foreign_language_testcases!(
 );
 
 #[test]
-#[cfg(feature = "uniffi-25")]
 fn test_csharp() {
     let output = Command::new("dotnet")
         .arg("run")
@@ -27,7 +22,6 @@ fn test_csharp() {
 }
 
 #[test]
-#[cfg(feature = "uniffi-25")]
 fn test_golang() {
     let output = Command::new("go")
         .env(


### PR DESCRIPTION
This PR:
- Updates Go and C# to Uniffi 0.28
- Sets the xcframework Info.plist short version string

Depends on https://github.com/breez/breez-sdk-go/pull/15

CI publish run: https://github.com/breez/breez-sdk-greenlight/actions/runs/15189612502