### PR TITLE
Update Kotlin Multiplatform bindgen to uniffi 0.28

### DIFF
--- a/.github/workflows/build-bindings-android.yml
+++ b/.github/workflows/build-bindings-android.yml
@@ -21,35 +21,14 @@ on:
         required: false
         type: boolean
         default: false
-      uniffi-25:
-        description: 'If true, builds additional bindings for Uniffi 0.25'
-        required: false
-        type: boolean
-        default: false
 
 jobs:
-  setup:
-    name: Setup
-    runs-on: ubuntu-latest
-    steps:
-      - id: set-matrix
-        run: |
-          if [ ${{ inputs.uniffi-25 }} == true ]; then
-            echo "::set-output name=matrix::['', '-uniffi-25']"
-          else
-            echo "::set-output name=matrix::['']"
-          fi
-    outputs:
-      uniffi-matrix: ${{ steps.set-matrix.outputs.matrix }}
-
   build:
     if: ${{ !inputs.use-dummy-binaries }}
     runs-on: ubuntu-latest
-    name: build ${{ matrix.target }}${{ matrix.uniffi }}
-    needs: setup
+    name: build ${{ matrix.target }}
     strategy:
       matrix:
-        uniffi: ${{ fromJson(needs.setup.outputs.uniffi-matrix) }}
         target: [
           aarch64-linux-android,
           armv7-linux-androideabi,
@@ -87,18 +66,11 @@ jobs:
 
     - uses: Swatinem/rust-cache@v2
       with:
-        key: ${{ matrix.uniffi }}
         workspaces: libs
 
     - name: Build sdk-bindings
-      if: matrix.uniffi != '-uniffi-25'
       working-directory: libs/sdk-bindings
       run: cargo ndk -t ${{ matrix.target }} build --release
-
-    - name: Build sdk-bindings Uniffi 0.25
-      if: matrix.uniffi == '-uniffi-25'
-      working-directory: libs/sdk-bindings
-      run: cargo ndk -t ${{ matrix.target }} build --no-default-features --features=uniffi-25 --release
 
     - name: Copy build output
       run: |
@@ -116,53 +88,46 @@ jobs:
     - name: Archive release
       uses: actions/upload-artifact@v4
       with:
-        name: sdk-bindings-${{ matrix.target }}${{ matrix.uniffi }}
+        name: sdk-bindings-${{ matrix.target }}
         path: dist/*
   
   jnilibs:
-    needs: 
-    - build
-    - setup
+    needs: build
     runs-on: ubuntu-latest
-    name: build jniLibs${{ matrix.uniffi }}
-    strategy:
-      matrix:
-        uniffi: ${{ fromJson(needs.setup.outputs.uniffi-matrix) }}
+    name: build jniLibs
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: sdk-bindings-aarch64-linux-android${{ matrix.uniffi }}
+          name: sdk-bindings-aarch64-linux-android
           path: arm64-v8a
       
       - uses: actions/download-artifact@v4
         with:
-          name: sdk-bindings-armv7-linux-androideabi${{ matrix.uniffi }}
+          name: sdk-bindings-armv7-linux-androideabi
           path: armeabi-v7a
 
       - uses: actions/download-artifact@v4
         with:
-          name: sdk-bindings-i686-linux-android${{ matrix.uniffi }}
+          name: sdk-bindings-i686-linux-android
           path: x86
 
       - uses: actions/download-artifact@v4
         with:
-          name: sdk-bindings-x86_64-linux-android${{ matrix.uniffi }}
+          name: sdk-bindings-x86_64-linux-android
           path: x86_64
       
       - name: Archive jniLibs
         uses: actions/upload-artifact@v4
         with:
-          name: sdk-bindings-android-jniLibs${{ matrix.uniffi }}
+          name: sdk-bindings-android-jniLibs
           path: ./*
 
   build-dummies:
     if: ${{ inputs.use-dummy-binaries }}
     runs-on: ubuntu-latest
-    name: build dummies ${{ matrix.target }}${{ matrix.uniffi }}
-    needs: setup
+    name: build dummies ${{ matrix.target }}
     strategy:
       matrix:
-        uniffi: ${{ fromJson(needs.setup.outputs.uniffi-matrix) }}
         target: [
           aarch64-linux-android,
           armv7-linux-androideabi,
@@ -178,41 +143,36 @@ jobs:
       - name: Upload dummy Android ${{ matrix.target }} artifact
         uses: actions/upload-artifact@v4
         with:
-          name: sdk-bindings-${{ matrix.target }}${{ matrix.uniffi }}
+          name: sdk-bindings-${{ matrix.target }}
           path: ./*
 
   jnilibs-dummy:
-    needs:
-    - setup
-    - build-dummies
+    needs: build-dummies
     runs-on: ubuntu-latest
-    name: build jniLibs dummy ${{ matrix.uniffi }}
-    strategy:
-      matrix:
-        uniffi: ${{ fromJson(needs.setup.outputs.uniffi-matrix) }}
+    name: build jniLibs dummy 
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: sdk-bindings-aarch64-linux-android${{ matrix.uniffi }}
+          name: sdk-bindings-aarch64-linux-android
           path: arm64-v8a
       
       - uses: actions/download-artifact@v4
         with:
-          name: sdk-bindings-armv7-linux-androideabi${{ matrix.uniffi }}
+          name: sdk-bindings-armv7-linux-androideabi
           path: armeabi-v7a
 
       - uses: actions/download-artifact@v4
         with:
-          name: sdk-bindings-i686-linux-android${{ matrix.uniffi }}
+          name: sdk-bindings-i686-linux-android
           path: x86
 
       - uses: actions/download-artifact@v4
         with:
-          name: sdk-bindings-x86_64-linux-android${{ matrix.uniffi }}
+          name: sdk-bindings-x86_64-linux-android
           path: x86_64
       
       - name: Archive jniLibs
         uses: actions/upload-artifact@v4
         with:
-          name: sdk-bindings-android-jniLibs${{ matrix.uniffi }}
+          name: sdk-bindings-android-jniLibs
           path: ./*

--- a/.github/workflows/build-bindings-darwin.yml
+++ b/.github/workflows/build-bindings-darwin.yml
@@ -21,35 +21,14 @@ on:
         required: false
         type: boolean
         default: false
-      uniffi-25:
-        description: 'If true, builds additional bindings for Uniffi 0.25'
-        required: false
-        type: boolean
-        default: false
 
 jobs:
-  setup:
-    name: Setup
-    runs-on: ubuntu-latest
-    steps:
-      - id: set-matrix
-        run: |
-          if [ ${{ inputs.uniffi-25 }} == true ]; then
-            echo "::set-output name=matrix::['', '-uniffi-25']"
-          else
-            echo "::set-output name=matrix::['']"
-          fi
-    outputs:
-      uniffi-matrix: ${{ steps.set-matrix.outputs.matrix }}
-
   build:
     if: ${{ !inputs.use-dummy-binaries }}
     runs-on: macOS-latest
-    name: build ${{ matrix.target }}${{ matrix.uniffi }}
-    needs: setup
+    name: build ${{ matrix.target }}
     strategy:
       matrix:
-        uniffi: ${{ fromJson(needs.setup.outputs.uniffi-matrix) }}
         target: [
           aarch64-apple-darwin,
           x86_64-apple-darwin,
@@ -76,45 +55,33 @@ jobs:
 
     - uses: Swatinem/rust-cache@v2
       with:
-        key: ${{ matrix.uniffi }}
         workspaces: libs
 
     - name: Build sdk-bindings
-      if: matrix.uniffi != '-uniffi-25'
       working-directory: libs/sdk-bindings
       run: cargo lipo --release --targets ${{ matrix.target }}
-
-    - name: Build sdk-bindings Uniffi 0.25
-      if: matrix.uniffi == '-uniffi-25'
-      working-directory: libs/sdk-bindings
-      run: cargo lipo --no-default-features --features=uniffi-25 --release --targets ${{ matrix.target }}
 
     - name: Archive release
       uses: actions/upload-artifact@v4
       with:
-        name: sdk-bindings-${{ matrix.target }}${{ matrix.uniffi }}
+        name: sdk-bindings-${{ matrix.target }}
         path: |
           libs/target/${{ matrix.target }}/release/libbreez_sdk_bindings.dylib
           libs/target/${{ matrix.target }}/release/libbreez_sdk_bindings.a
   
   merge:
     runs-on: macOS-latest
-    needs:
-    - setup
-    - build
-    name: build darwin-universal${{ matrix.uniffi }}
-    strategy:
-      matrix:
-        uniffi: ${{ fromJson(needs.setup.outputs.uniffi-matrix) }}
+    needs: build
+    name: build darwin-universal
     steps:
     - uses: actions/download-artifact@v4
       with:
-        name: sdk-bindings-aarch64-apple-darwin${{ matrix.uniffi }}
+        name: sdk-bindings-aarch64-apple-darwin
         path: aarch64-apple-darwin
 
     - uses: actions/download-artifact@v4
       with:
-        name: sdk-bindings-x86_64-apple-darwin${{ matrix.uniffi }}
+        name: sdk-bindings-x86_64-apple-darwin
         path: x86_64-apple-darwin
 
     - name: Build Darwin universal
@@ -126,7 +93,7 @@ jobs:
     - name: Archive release
       uses: actions/upload-artifact@v4
       with:
-        name: sdk-bindings-darwin-universal${{ matrix.uniffi }}
+        name: sdk-bindings-darwin-universal
         path: |
           darwin-universal/libbreez_sdk_bindings.dylib
           darwin-universal/libbreez_sdk_bindings.a
@@ -134,11 +101,9 @@ jobs:
   build-dummies:
     if: ${{ inputs.use-dummy-binaries }}
     runs-on: ubuntu-latest
-    name: build dummies ${{ matrix.target }}${{ matrix.uniffi }}
-    needs: setup
+    name: build dummies ${{ matrix.target }}
     strategy:
       matrix:
-        uniffi: ${{ fromJson(needs.setup.outputs.uniffi-matrix) }}
         target: [
           aarch64-apple-darwin,
           x86_64-apple-darwin,
@@ -153,5 +118,5 @@ jobs:
       - name: Upload dummy darwin ${{ matrix.target }} artifact
         uses: actions/upload-artifact@v4
         with:
-          name: sdk-bindings-${{ matrix.target }}${{ matrix.uniffi }}
+          name: sdk-bindings-${{ matrix.target }}
           path: ./*

--- a/.github/workflows/build-bindings-ios.yml
+++ b/.github/workflows/build-bindings-ios.yml
@@ -21,35 +21,14 @@ on:
         required: false
         type: boolean
         default: false
-      uniffi-25:
-        description: 'If true, builds additional bindings for Uniffi 0.25'
-        required: false
-        type: boolean
-        default: false
 
 jobs:
-  setup:
-    name: Setup
-    runs-on: ubuntu-latest
-    steps:
-      - id: set-matrix
-        run: |
-          if [ ${{ inputs.uniffi-25 }} == true ]; then
-            echo "::set-output name=matrix::['', '-uniffi-25']"
-          else
-            echo "::set-output name=matrix::['']"
-          fi
-    outputs:
-      uniffi-matrix: ${{ steps.set-matrix.outputs.matrix }}
-
   build:
     if: ${{ !inputs.use-dummy-binaries }}
     runs-on: macOS-latest
-    name: build ${{ matrix.target }}${{ matrix.uniffi }}
-    needs: setup
+    name: build ${{ matrix.target }}
     strategy:
       matrix:
-        uniffi: ${{ fromJson(needs.setup.outputs.uniffi-matrix) }}
         target: [
           aarch64-apple-ios,
           x86_64-apple-ios,
@@ -76,7 +55,6 @@ jobs:
 
     - uses: Swatinem/rust-cache@v2
       with:
-        key: ${{ matrix.uniffi }}
         workspaces: libs
 
     - name: Install xcode
@@ -85,34 +63,21 @@ jobs:
         xcode-version: latest-stable
 
     - name: Build sdk-bindings
-      if: matrix.uniffi != '-uniffi-25'
       working-directory: libs/sdk-bindings
       env:
         IPHONEOS_DEPLOYMENT_TARGET: 12.0
       run: cargo build --release --target ${{ matrix.target }}
 
-    - name: Build sdk-bindings Uniffi 0.25
-      if: matrix.uniffi == '-uniffi-25'
-      working-directory: libs/sdk-bindings
-      env:
-        IPHONEOS_DEPLOYMENT_TARGET: 12.0
-      run: cargo build --no-default-features --features=uniffi-25 --release --target ${{ matrix.target }}
-    
     - name: Archive release
       uses: actions/upload-artifact@v4
       with:
-        name: sdk-bindings-${{ matrix.target }}${{ matrix.uniffi }}
+        name: sdk-bindings-${{ matrix.target }}
         path: libs/target/${{ matrix.target }}/release/libbreez_sdk_bindings.a
 
   merge:
     runs-on: macOS-latest
-    needs:
-    - setup
-    - build
-    name: build ios-universal${{ matrix.uniffi }}
-    strategy:
-      matrix:
-        uniffi: ${{ fromJson(needs.setup.outputs.uniffi-matrix) }}
+    needs: build
+    name: build ios-universal
     steps:
     - uses: actions/download-artifact@v4
       with:
@@ -121,12 +86,12 @@ jobs:
 
     - uses: actions/download-artifact@v4
       with:
-        name: sdk-bindings-x86_64-apple-ios${{ matrix.uniffi }}
+        name: sdk-bindings-x86_64-apple-ios
         path: x86_64-apple-ios
 
     - uses: actions/download-artifact@v4
       with:
-        name: sdk-bindings-aarch64-apple-ios-sim${{ matrix.uniffi }}
+        name: sdk-bindings-aarch64-apple-ios-sim
         path: aarch64-apple-ios-sim
 
     - name: Build iOS universal
@@ -141,25 +106,23 @@ jobs:
     - name: Archive release
       uses: actions/upload-artifact@v4
       with:
-        name: sdk-bindings-ios-universal${{ matrix.uniffi }}
+        name: sdk-bindings-ios-universal
         path: |
           ios-universal/libbreez_sdk_bindings.a
 
     - name: Archive release
       uses: actions/upload-artifact@v4
       with:
-        name: sdk-bindings-ios-universal-sim${{ matrix.uniffi }}
+        name: sdk-bindings-ios-universal-sim
         path: |
           ios-universal-sim/libbreez_sdk_bindings.a
 
   build-dummies:
     if: ${{ inputs.use-dummy-binaries }}
     runs-on: ubuntu-latest
-    name: build dummies ${{ matrix.target }}${{ matrix.uniffi }}
-    needs: setup
+    name: build dummies ${{ matrix.target }}
     strategy:
       matrix:
-        uniffi: ${{ fromJson(needs.setup.outputs.uniffi-matrix) }}
         target: [
           aarch64-apple-ios,
           x86_64-apple-ios,
@@ -175,5 +138,5 @@ jobs:
       - name: Upload dummy ios ${{ matrix.target }} artifact
         uses: actions/upload-artifact@v4
         with:
-          name: sdk-bindings-${{ matrix.target }}${{ matrix.uniffi }}
+          name: sdk-bindings-${{ matrix.target }}
           path: ./*

--- a/.github/workflows/build-bindings-linux.yml
+++ b/.github/workflows/build-bindings-linux.yml
@@ -21,35 +21,14 @@ on:
         required: false
         type: boolean
         default: false
-      uniffi-25:
-        description: 'If true, builds additional bindings for Uniffi 0.25'
-        required: false
-        type: boolean
-        default: false
 
 jobs:
-  setup:
-    name: Setup
-    runs-on: ubuntu-latest
-    steps:
-      - id: set-matrix
-        run: |
-          if [ ${{ inputs.uniffi-25 }} == true ]; then
-            echo "::set-output name=matrix::['', '-uniffi-25']"
-          else
-            echo "::set-output name=matrix::['']"
-          fi
-    outputs:
-      uniffi-matrix: ${{ steps.set-matrix.outputs.matrix }}
-
   build:
     if: ${{ !inputs.use-dummy-binaries }}
     runs-on: ubuntu-22.04
-    name: build ${{ matrix.target }}${{ matrix.uniffi }}
-    needs: setup
+    name: build ${{ matrix.target }}
     strategy:
       matrix:
-        uniffi: ${{ fromJson(needs.setup.outputs.uniffi-matrix) }}
         target: [
           aarch64-unknown-linux-gnu,
           x86_64-unknown-linux-gnu,
@@ -87,39 +66,27 @@ jobs:
 
     - uses: Swatinem/rust-cache@v2
       with:
-        key: ${{ matrix.uniffi }}
         workspaces: libs
 
     - name: Build sdk-bindings
-      if: matrix.uniffi != '-uniffi-25'
       working-directory: libs/sdk-bindings
       env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: /usr/bin/aarch64-linux-gnu-gcc
           CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: /usr/bin/x86_64-linux-gnu-gcc
       run: cargo build --release --target ${{ matrix.target }}
-
-    - name: Build sdk-bindings Uniffi 0.25
-      if: matrix.uniffi == '-uniffi-25'
-      working-directory: libs/sdk-bindings
-      env:
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: /usr/bin/aarch64-linux-gnu-gcc
-          CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER: /usr/bin/x86_64-linux-gnu-gcc
-      run: cargo build --no-default-features --features=uniffi-25 --release --target ${{ matrix.target }}
     
     - name: Archive release
       uses: actions/upload-artifact@v4
       with:
-        name: sdk-bindings-${{ matrix.target }}${{ matrix.uniffi }}
+        name: sdk-bindings-${{ matrix.target }}
         path: libs/target/${{ matrix.target }}/release/libbreez_sdk_bindings.so
 
   build-dummies:
     if: ${{ inputs.use-dummy-binaries }}
     runs-on: ubuntu-latest
-    name: build dummies ${{ matrix.target }}${{ matrix.uniffi }}
-    needs: setup
+    name: build dummies ${{ matrix.target }}
     strategy:
       matrix:
-        uniffi: ${{ fromJson(needs.setup.outputs.uniffi-matrix) }}
         target: [
           aarch64-unknown-linux-gnu,
           x86_64-unknown-linux-gnu,
@@ -132,5 +99,5 @@ jobs:
       - name: Upload dummy linux ${{ matrix.target }} artifact
         uses: actions/upload-artifact@v4
         with:
-          name: sdk-bindings-${{ matrix.target }}${{ matrix.uniffi }}
+          name: sdk-bindings-${{ matrix.target }}
           path: ./*

--- a/.github/workflows/build-bindings-windows.yml
+++ b/.github/workflows/build-bindings-windows.yml
@@ -21,35 +21,14 @@ on:
         required: false
         type: boolean
         default: false
-      uniffi-25:
-        description: 'If true, builds additional bindings for Uniffi 0.25'
-        required: false
-        type: boolean
-        default: false
 
 jobs:
-  setup:
-    name: Setup
-    runs-on: ubuntu-latest
-    steps:
-      - id: set-matrix
-        run: |
-          if [ ${{ inputs.uniffi-25 }} == true ]; then
-            echo "::set-output name=matrix::['', '-uniffi-25']"
-          else
-            echo "::set-output name=matrix::['']"
-          fi
-    outputs:
-      uniffi-matrix: ${{ steps.set-matrix.outputs.matrix }}
-
   build:
     if: ${{ !inputs.use-dummy-binaries }}
     runs-on: windows-latest
-    name: build ${{ matrix.target }}${{ matrix.uniffi }}
-    needs: setup
+    name: build ${{ matrix.target }}
     strategy:
       matrix:
-        uniffi: ${{ fromJson(needs.setup.outputs.uniffi-matrix) }}
         target: [
           x86_64-pc-windows-msvc,
           i686-pc-windows-msvc,
@@ -75,33 +54,24 @@ jobs:
 
     - uses: Swatinem/rust-cache@v2
       with:
-        key: ${{ matrix.uniffi }}
         workspaces: libs
 
     - name: Build sdk-bindings
-      if: matrix.uniffi != '-uniffi-25'
       working-directory: libs/sdk-bindings
       run: cargo build --release --target ${{ matrix.target }}
-
-    - name: Build sdk-bindings Uniffi 0.25
-      if: matrix.uniffi == '-uniffi-25'
-      working-directory: libs/sdk-bindings
-      run: cargo build --no-default-features --features=uniffi-25 --release --target ${{ matrix.target }}
 
     - name: Archive release
       uses: actions/upload-artifact@v4
       with:
-        name: sdk-bindings-${{ matrix.target }}${{ matrix.uniffi }}
+        name: sdk-bindings-${{ matrix.target }}
         path: libs/target/${{ matrix.target }}/release/breez_sdk_bindings.dll
 
   build-dummies:
     if: ${{ inputs.use-dummy-binaries }}
     runs-on: ubuntu-latest
-    name: build dummies ${{ matrix.target }}${{ matrix.uniffi }}
-    needs: setup
+    name: build dummies ${{ matrix.target }}
     strategy:
       matrix:
-        uniffi: ${{ fromJson(needs.setup.outputs.uniffi-matrix) }}
         target: [
           x86_64-pc-windows-msvc,
           i686-pc-windows-msvc,
@@ -114,5 +84,5 @@ jobs:
       - name: Upload dummy windows ${{ matrix.target }} artifact
         uses: actions/upload-artifact@v4
         with:
-          name: sdk-bindings-${{ matrix.target }}${{ matrix.uniffi }}
+          name: sdk-bindings-${{ matrix.target }}
           path: ./*

--- a/.github/workflows/build-language-bindings.yml
+++ b/.github/workflows/build-language-bindings.yml
@@ -60,7 +60,7 @@ on:
 jobs:
   build-language-bindings:
     runs-on: ubuntu-latest
-    if: ${{ inputs.csharp || inputs.golang || inputs.python || inputs.swift }}
+    if: ${{ inputs.csharp || inputs.golang || inputs.kotlin || inputs.python || inputs.swift }}
     steps:
       - name: Checkout breez-sdk repo
         uses: actions/checkout@v4
@@ -78,6 +78,11 @@ jobs:
         with:
           version: "27.2"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Install Gobley
+        if: ${{ inputs.kotlin }}
+        run: |
+          cargo install gobley-uniffi-bindgen --git https://github.com/breez/gobley --rev f920c275e4f60e22080a6cd280d9562d64eb6ac9
       
       - name: Build Swift binding
         if: ${{ inputs.swift }}
@@ -120,6 +125,32 @@ jobs:
           name: bindings-csharp
           path: libs/sdk-bindings/ffi/csharp/breez_sdk.cs
     
+      - name: Build Kotlin binding
+        if: ${{ inputs.kotlin }}
+        working-directory: libs/sdk-bindings
+        run: |
+          gobley-uniffi-bindgen -c ./uniffi.toml -o ffi/kotlin src/breez_sdk.udl
+  
+      - name: Archive Kotlin binding
+        if: ${{ inputs.kotlin }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: bindings-kotlin
+          path: libs/sdk-bindings/ffi/kotlin/main/kotlin/breez_sdk/breez_sdk.*.kt
+    
+      - name: Build Kotlin multiplatform binding
+        if: ${{ inputs.kotlin }}
+        working-directory: libs/sdk-bindings
+        run: |
+          gobley-uniffi-bindgen -c ./uniffi.kotlin-multiplatform.toml -o ffi/kmp src/breez_sdk.udl
+
+      - name: Archive Kotlin multiplatform binding
+        if: ${{ inputs.kotlin }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: bindings-kotlin-multiplatform
+          path: libs/sdk-bindings/ffi/kmp/*
+   
       - name: Build golang binding
         if: ${{ inputs.golang }}
         working-directory: libs/sdk-bindings
@@ -133,49 +164,3 @@ jobs:
         with:
           name: bindings-golang
           path: libs/sdk-bindings/ffi/golang/breez_sdk/breez_sdk.*
-
-  build-language-bindings-uniffi-25:
-    runs-on: ubuntu-latest
-    if: ${{ inputs.kotlin }}
-    steps:
-      - name: Checkout breez-sdk repo
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ inputs.repository || github.repository }}
-          ref: ${{ inputs.ref || github.sha }}
-
-      - name: Install rust
-        run: |
-          rustup set auto-self-update disable
-          rustup toolchain install stable --profile minimal
-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          version: "27.2"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          key: uniffi-25
-          workspaces: lib
-
-      - name: Build Kotlin binding
-        if: ${{ inputs.kotlin }}
-        working-directory: libs/sdk-bindings
-        run: |
-          cargo run --no-default-features --features=uniffi-25 --bin uniffi-bindgen generate src/breez_sdk.udl --language kotlin -o ffi/kotlin
-  
-      - name: Archive Kotlin binding
-        if: ${{ inputs.kotlin }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: bindings-kotlin
-          path: libs/sdk-bindings/ffi/kotlin/breez_sdk/breez_sdk.kt
-
-      - name: Archive Kotlin multiplatform binding
-        if: ${{ inputs.kotlin }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: bindings-kotlin-multiplatform
-          path: libs/sdk-bindings/ffi/kmp/*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -270,6 +270,62 @@ jobs:
       - name: Clippy WASM
         working-directory: libs/sdk-common 
         run: cargo clippy --target=wasm32-unknown-unknown -- -D warnings
+
+  notification-plugin:
+    name: Check notification plugin
+    runs-on: macOS-14
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            lib -> target
+            cli -> target
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "27.2"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v2
+        with:
+          distribution: "temurin"
+          java-version: 17
+
+      - name: Build bindings
+        working-directory: libs/sdk-bindings
+        run: cargo build
+
+      - name: Build Android bindings
+        working-directory: libs/sdk-bindings       
+        run: |
+          cargo install gobley-uniffi-bindgen --git https://github.com/breez/gobley --rev f920c275e4f60e22080a6cd280d9562d64eb6ac9
+          gobley-uniffi-bindgen -c ./uniffi.toml -o bindings-android/lib/src src/breez_sdk.udl
+
+      - name: Run Android build
+        working-directory: libs/sdk-bindings/bindings-android  
+        run: |
+          ./gradlew build
+
+      - name: Build Swift bindings
+        working-directory: libs/sdk-bindings       
+        run: |
+          cargo run --bin uniffi-bindgen generate src/breez_sdk.udl --no-format --language swift -o bindings-swift/Sources/BreezSDK
+          mv bindings-swift/Sources/BreezSDK/breez_sdk.swift bindings-swift/Sources/BreezSDK/BreezSDK.swift
+          cp bindings-swift/Sources/BreezSDK/breez_sdkFFI.h bindings-swift/breez_sdkFFI.xcframework/ios-arm64/breez_sdkFFI.framework/Headers
+          cp bindings-swift/Sources/BreezSDK/breez_sdkFFI.h bindings-swift/breez_sdkFFI.xcframework/ios-arm64_x86_64-simulator/breez_sdkFFI.framework/Headers
+          cp bindings-swift/Sources/BreezSDK/breez_sdkFFI.h bindings-swift/breez_sdkFFI.xcframework/macos-arm64_x86_64/breez_sdkFFI.framework/Headers
+          rm bindings-swift/Sources/BreezSDK/breez_sdkFFI.h
+          rm bindings-swift/Sources/BreezSDK/breez_sdkFFI.modulemap
+
+      - name: Run Swift build
+        working-directory: libs/sdk-bindings/bindings-swift  
+        run: |
+          swift build
   
   react-native:
     name: Check react native

--- a/.github/workflows/publish-all-platforms.yml
+++ b/.github/workflows/publish-all-platforms.yml
@@ -122,7 +122,6 @@ jobs:
       swift-package-version: ${{ needs.pre-setup.outputs.swift-package-version || '0.0.2' }}
       publish: ${{ needs.pre-setup.outputs.publish }}
       use-dummy-binaries: ${{ needs.pre-setup.outputs.use-dummy-binaries }}
-      uniffi-25: ${{ !!needs.pre-setup.outputs.kotlin-multiplatform-package-version || !!needs.pre-setup.outputs.maven-package-version }}
     steps:
       - run: echo "set setup output variables"
 
@@ -134,7 +133,6 @@ jobs:
       repository: ${{ needs.setup.outputs.repository }}
       ref: ${{ needs.setup.outputs.ref }}
       use-dummy-binaries: ${{ needs.setup.outputs.use-dummy-binaries == 'true' }}
-      uniffi-25: ${{ needs.setup.outputs.uniffi-25 == 'true' }}
 
   build-bindings-darwin:
     needs: setup
@@ -144,7 +142,6 @@ jobs:
       repository: ${{ needs.setup.outputs.repository }}
       ref: ${{ needs.setup.outputs.ref }}
       use-dummy-binaries: ${{ needs.setup.outputs.use-dummy-binaries == 'true' }}
-      uniffi-25: ${{ needs.setup.outputs.uniffi-25 == 'true' }}
 
   build-bindings-linux:
     needs: setup
@@ -154,7 +151,6 @@ jobs:
       repository: ${{ needs.setup.outputs.repository }}
       ref: ${{ needs.setup.outputs.ref }}
       use-dummy-binaries: ${{ needs.setup.outputs.use-dummy-binaries == 'true' }}
-      uniffi-25: ${{ needs.setup.outputs.uniffi-25 == 'true' }}
 
   build-bindings-android:
     needs: setup
@@ -164,7 +160,6 @@ jobs:
       repository: ${{ needs.setup.outputs.repository }}
       ref: ${{ needs.setup.outputs.ref }}
       use-dummy-binaries: ${{ needs.setup.outputs.use-dummy-binaries == 'true' }}
-      uniffi-25: ${{ needs.setup.outputs.uniffi-25 == 'true' }}
 
   build-bindings-ios:
     needs: setup
@@ -174,7 +169,6 @@ jobs:
       repository: ${{ needs.setup.outputs.repository }}
       ref: ${{ needs.setup.outputs.ref }}
       use-dummy-binaries: ${{ needs.setup.outputs.use-dummy-binaries == 'true' }}
-      uniffi-25: ${{ needs.setup.outputs.uniffi-25 == 'true' }}
 
   build-language-bindings:
     needs: setup

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: sdk-bindings-android-jniLibs-uniffi-25
+          name: sdk-bindings-android-jniLibs
           path: libs/sdk-bindings/bindings-android/lib/src/main/jniLibs
 
       - uses: actions/download-artifact@v4

--- a/.github/workflows/publish-kotlin-multiplatform.yml
+++ b/.github/workflows/publish-kotlin-multiplatform.yml
@@ -44,7 +44,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: sdk-bindings-android-jniLibs-uniffi-25
+          name: sdk-bindings-android-jniLibs
           path: libs/sdk-bindings/bindings-kotlin-multiplatform/breez-sdk-kmp/src/androidMain/jniLibs
 
       - uses: actions/download-artifact@v4
@@ -52,24 +52,32 @@ jobs:
           name: bindings-kotlin-multiplatform
           path: libs/sdk-bindings/bindings-kotlin-multiplatform/breez-sdk-kmp/src
 
-      - name: Copy jvmMain
-        working-directory: libs/sdk-bindings
+      - name: Move files
+        working-directory: libs/sdk-bindings/bindings-kotlin-multiplatform/breez-sdk-kmp/src
         run: |
-          cp -r bindings-kotlin-multiplatform/breez-sdk-kmp/src/jvmMain/kotlin bindings-kotlin-multiplatform/breez-sdk-kmp/src/androidMain/
+          mkdir -p androidMain/kotlin/breez_sdk
+          mkdir -p commonMain/kotlin/breez_sdk
+          mkdir -p jvmMain/kotlin/breez_sdk
+          mkdir -p nativeMain/kotlin/breez_sdk
+          mv main/kotlin/breez_sdk/breez_sdk.android.kt androidMain/kotlin/breez_sdk/
+          mv main/kotlin/breez_sdk/breez_sdk.common.kt commonMain/kotlin/breez_sdk/
+          mv main/kotlin/breez_sdk/breez_sdk.jvm.kt jvmMain/kotlin/breez_sdk/
+          mv main/kotlin/breez_sdk/breez_sdk.native.kt nativeMain/kotlin/breez_sdk/
+          rm -r main/kotlin/breez_sdk
 
       - uses: actions/download-artifact@v4
         with:
-          name: sdk-bindings-aarch64-apple-ios-uniffi-25
+          name: sdk-bindings-aarch64-apple-ios
           path: libs/sdk-bindings/bindings-kotlin-multiplatform/breez-sdk-kmp/src/lib/ios-arm64
 
       - uses: actions/download-artifact@v4
         with:
-          name: sdk-bindings-aarch64-apple-ios-sim-uniffi-25
+          name: sdk-bindings-aarch64-apple-ios-sim
           path: libs/sdk-bindings/bindings-kotlin-multiplatform/breez-sdk-kmp/src/lib/ios-simulator-arm64
 
       - uses: actions/download-artifact@v4
         with:
-          name: sdk-bindings-x86_64-apple-ios-uniffi-25
+          name: sdk-bindings-x86_64-apple-ios
           path: libs/sdk-bindings/bindings-kotlin-multiplatform/breez-sdk-kmp/src/lib/ios-simulator-x64
 
       - name: Build Kotlin Multiplatform project

--- a/libs/Cargo.lock
+++ b/libs/Cargo.lock
@@ -787,11 +787,8 @@ dependencies = [
  "tiny-bip39",
  "tokio",
  "tonic 0.8.3",
- "uniffi 0.25.3",
- "uniffi 0.28.3",
- "uniffi_bindgen 0.25.3",
- "uniffi_bindgen 0.28.3",
- "uniffi_bindgen_kotlin_multiplatform",
+ "uniffi",
+ "uniffi_bindgen",
 ]
 
 [[package]]
@@ -1709,24 +1706,13 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "goblin"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6b4de4a8eb6c46a8c77e1d3be942cb9a8bf073c22374578e5ba4b08ed0ff68"
-dependencies = [
- "log",
- "plain",
- "scroll 0.11.0",
-]
-
-[[package]]
-name = "goblin"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
 dependencies = [
  "log",
  "plain",
- "scroll 0.12.0",
+ "scroll",
 ]
 
 [[package]]
@@ -2321,25 +2307,6 @@ checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
-]
-
-[[package]]
-name = "include_dir"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
-dependencies = [
- "include_dir_macros",
-]
-
-[[package]]
-name = "include_dir_macros"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
-dependencies = [
- "proc-macro2",
- "quote",
 ]
 
 [[package]]
@@ -2939,12 +2906,6 @@ name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
-
-[[package]]
-name = "oneshot-uniffi"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c548d5c78976f6955d72d0ced18c48ca07030f7a1d4024529fedd7c1c01b29c"
 
 [[package]]
 name = "opaque-debug"
@@ -3966,31 +3927,11 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scroll"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
-dependencies = [
- "scroll_derive 0.11.1",
-]
-
-[[package]]
-name = "scroll"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
 dependencies = [
- "scroll_derive 0.12.1",
-]
-
-[[package]]
-name = "scroll_derive"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
+ "scroll_derive",
 ]
 
 [[package]]
@@ -5109,21 +5050,6 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "uniffi"
-version = "0.25.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21345172d31092fd48c47fd56c53d4ae9e41c4b1f559fb8c38c1ab1685fd919f"
-dependencies = [
- "anyhow",
- "camino",
- "clap",
- "uniffi_bindgen 0.25.3",
- "uniffi_build 0.25.3",
- "uniffi_core 0.25.3",
- "uniffi_macros 0.25.3",
-]
-
-[[package]]
-name = "uniffi"
 version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cb08c58c7ed7033150132febe696bef553f891b1ede57424b40d87a89e3c170"
@@ -5132,34 +5058,10 @@ dependencies = [
  "camino",
  "cargo_metadata",
  "clap",
- "uniffi_bindgen 0.28.3",
- "uniffi_build 0.28.3",
- "uniffi_core 0.28.3",
- "uniffi_macros 0.28.3",
-]
-
-[[package]]
-name = "uniffi_bindgen"
-version = "0.25.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd992f2929a053829d5875af1eff2ee3d7a7001cb3b9a46cc7895f2caede6940"
-dependencies = [
- "anyhow",
- "askama",
- "camino",
- "cargo_metadata",
- "clap",
- "fs-err",
- "glob",
- "goblin 0.6.1",
- "heck 0.4.1",
- "once_cell",
- "paste",
- "serde",
- "toml",
- "uniffi_meta 0.25.3",
- "uniffi_testing 0.25.3",
- "uniffi_udl 0.25.3",
+ "uniffi_bindgen",
+ "uniffi_build",
+ "uniffi_core",
+ "uniffi_macros",
 ]
 
 [[package]]
@@ -5174,44 +5076,16 @@ dependencies = [
  "cargo_metadata",
  "fs-err",
  "glob",
- "goblin 0.8.2",
+ "goblin",
  "heck 0.5.0",
  "once_cell",
  "paste",
  "serde",
  "textwrap",
  "toml",
- "uniffi_meta 0.28.3",
- "uniffi_testing 0.28.3",
- "uniffi_udl 0.28.3",
-]
-
-[[package]]
-name = "uniffi_bindgen_kotlin_multiplatform"
-version = "0.1.0"
-source = "git+https://gitlab.com/trixnity/uniffi-kotlin-multiplatform-bindings?rev=e8e3a88df5b657787c1198425c16008232b26548#e8e3a88df5b657787c1198425c16008232b26548"
-dependencies = [
- "anyhow",
- "askama",
- "camino",
- "clap",
- "heck 0.4.1",
- "include_dir",
- "paste",
- "serde",
- "toml",
- "uniffi_bindgen 0.25.3",
-]
-
-[[package]]
-name = "uniffi_build"
-version = "0.25.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "001964dd3682d600084b3aaf75acf9c3426699bc27b65e96bb32d175a31c74e9"
-dependencies = [
- "anyhow",
- "camino",
- "uniffi_bindgen 0.25.3",
+ "uniffi_meta",
+ "uniffi_testing",
+ "uniffi_udl",
 ]
 
 [[package]]
@@ -5222,17 +5096,7 @@ checksum = "4c7cf32576e08104b7dc2a6a5d815f37616e66c6866c2a639fe16e6d2286b75b"
 dependencies = [
  "anyhow",
  "camino",
- "uniffi_bindgen 0.28.3",
-]
-
-[[package]]
-name = "uniffi_checksum_derive"
-version = "0.25.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55137c122f712d9330fd985d66fa61bdc381752e89c35708c13ce63049a3002c"
-dependencies = [
- "quote",
- "syn 2.0.98",
+ "uniffi_bindgen",
 ]
 
 [[package]]
@@ -5243,22 +5107,6 @@ checksum = "802d2051a700e3ec894c79f80d2705b69d85844dafbbe5d1a92776f8f48b563a"
 dependencies = [
  "quote",
  "syn 2.0.98",
-]
-
-[[package]]
-name = "uniffi_core"
-version = "0.25.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6121a127a3af1665cd90d12dd2b3683c2643c5103281d0fed5838324ca1fad5b"
-dependencies = [
- "anyhow",
- "bytes",
- "camino",
- "log",
- "once_cell",
- "oneshot-uniffi",
- "paste",
- "static_assertions",
 ]
 
 [[package]]
@@ -5277,25 +5125,6 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.25.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11cf7a58f101fcedafa5b77ea037999b88748607f0ef3a33eaa0efc5392e92e4"
-dependencies = [
- "bincode",
- "camino",
- "fs-err",
- "once_cell",
- "proc-macro2",
- "quote",
- "serde",
- "syn 2.0.98",
- "toml",
- "uniffi_build 0.25.3",
- "uniffi_meta 0.25.3",
-]
-
-[[package]]
-name = "uniffi_macros"
 version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12c65a5b12ec544ef136693af8759fb9d11aefce740fb76916721e876639033b"
@@ -5309,19 +5138,7 @@ dependencies = [
  "serde",
  "syn 2.0.98",
  "toml",
- "uniffi_meta 0.28.3",
-]
-
-[[package]]
-name = "uniffi_meta"
-version = "0.25.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71dc8573a7b1ac4b71643d6da34888273ebfc03440c525121f1b3634ad3417a2"
-dependencies = [
- "anyhow",
- "bytes",
- "siphasher",
- "uniffi_checksum_derive 0.25.3",
+ "uniffi_meta",
 ]
 
 [[package]]
@@ -5333,20 +5150,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "siphasher",
- "uniffi_checksum_derive 0.28.3",
-]
-
-[[package]]
-name = "uniffi_testing"
-version = "0.25.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "118448debffcb676ddbe8c5305fb933ab7e0123753e659a71dc4a693f8d9f23c"
-dependencies = [
- "anyhow",
- "camino",
- "cargo_metadata",
- "fs-err",
- "once_cell",
+ "uniffi_checksum_derive",
 ]
 
 [[package]]
@@ -5364,27 +5168,15 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.25.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "889edb7109c6078abe0e53e9b4070cf74a6b3468d141bdf5ef1bd4d1dc24a1c3"
-dependencies = [
- "anyhow",
- "uniffi_meta 0.25.3",
- "uniffi_testing 0.25.3",
- "weedle2 4.0.0",
-]
-
-[[package]]
-name = "uniffi_udl"
 version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037820a4cfc4422db1eaa82f291a3863c92c7d1789dc513489c36223f9b4cdfc"
 dependencies = [
  "anyhow",
  "textwrap",
- "uniffi_meta 0.28.3",
- "uniffi_testing 0.28.3",
- "weedle2 5.0.0",
+ "uniffi_meta",
+ "uniffi_testing",
+ "weedle2",
 ]
 
 [[package]]
@@ -5707,15 +5499,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
-]
-
-[[package]]
-name = "weedle2"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e79c5206e1f43a2306fd64bdb95025ee4228960f2e6c5a8b173f3caaf807741"
-dependencies = [
- "nom",
 ]
 
 [[package]]

--- a/libs/sdk-bindings/Cargo.toml
+++ b/libs/sdk-bindings/Cargo.toml
@@ -11,11 +11,6 @@ path = "uniffi-bindgen.rs"
 name = "breez_sdk_bindings"
 crate-type = ["staticlib", "cdylib", "lib"]
 
-[features]
-default = ["uniffi-28"]
-uniffi-25 = ["uniffi_25", "uniffi_bindgen_25", "uniffi_bindgen_kotlin_multiplatform"]
-uniffi-28 = ["uniffi_28", "uniffi_bindgen_28"]
-
 [lints]
 workspace = true
 
@@ -25,11 +20,8 @@ breez-sdk-core = { path = "../sdk-core" }
 sdk-common = { path = "../sdk-common" }
 thiserror = { workspace = true }
 tokio = { workspace = true }
-uniffi_25 = { package = "uniffi", version = "0.25.2", features = [ "bindgen-tests", "cli" ], optional = true }
-uniffi_28 = { package = "uniffi", version = "0.28.0", features = [ "bindgen-tests", "cli" ], optional = true }
-uniffi_bindgen_25 = { package = "uniffi_bindgen", version = "0.25.2", optional = true }
-uniffi_bindgen_28 = { package = "uniffi_bindgen", version = "0.28.0", optional = true }
-uniffi_bindgen_kotlin_multiplatform = { git = "https://gitlab.com/trixnity/uniffi-kotlin-multiplatform-bindings", rev = "e8e3a88df5b657787c1198425c16008232b26548", optional = true }
+uniffi = { package = "uniffi", version = "0.28.0", features = [ "bindgen-tests", "cli" ] }
+uniffi_bindgen = { package = "uniffi_bindgen", version = "0.28.0" }
 camino = "1.1.1"
 log = { workspace = true }
 once_cell = { workspace = true }
@@ -41,6 +33,5 @@ tonic = { workspace = true, features = [
 ] }
 
 [build-dependencies]
-uniffi_25 = { package = "uniffi", version = "0.25.2", features = [ "build" ], optional = true }
-uniffi_28 = { package = "uniffi", version = "0.28.0", features = [ "build" ], optional = true }
+uniffi = { package = "uniffi", version = "0.28.0", features = [ "build" ] }
 glob = "0.3.1"

--- a/libs/sdk-bindings/bindings-android/.gitignore
+++ b/libs/sdk-bindings/bindings-android/.gitignore
@@ -45,4 +45,4 @@ gen-external-apklibs
 # End of https://www.toptal.com/developers/gitignore/api/android
 
 lib/src/main/jniLibs/
-lib/src/main/kotlin/breez_sdk
+lib/src/main/kotlin/breez_sdk/breez_sdk.*.kt

--- a/libs/sdk-bindings/bindings-android/build.gradle.kts
+++ b/libs/sdk-bindings/bindings-android/build.gradle.kts
@@ -4,6 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.4.2")
+        classpath("com.android.tools.build:gradle:8.2.0")
+        classpath("org.jetbrains.kotlinx:atomicfu-gradle-plugin:0.23.1")
     }
 }

--- a/libs/sdk-bindings/bindings-android/gradle/wrapper/gradle-wrapper.properties
+++ b/libs/sdk-bindings/bindings-android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Feb 29 12:00:20 TRT 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/libs/sdk-bindings/bindings-android/lib/build.gradle.kts
+++ b/libs/sdk-bindings/bindings-android/lib/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
     id("com.android.library")
-    id("org.jetbrains.kotlin.android") version "1.8.20"
+    id("org.jetbrains.kotlin.android") version "1.9.21"
     id("maven-publish")
-    kotlin("plugin.serialization") version "1.8.20"
+    kotlin("plugin.serialization") version "1.9.21"
 }
 
 repositories {
@@ -11,7 +11,8 @@ repositories {
 }
 
 android {
-    compileSdk = 33
+    namespace = "technology.breez"
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 24
@@ -38,10 +39,12 @@ android {
 }
 
 dependencies {
+    implementation("com.squareup.okio:okio:3.6.0")
     implementation("net.java.dev.jna:jna:5.14.0@aar")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7")
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
+    implementation("org.jetbrains.kotlinx:atomicfu:0.23.1")
 }
 
 val libraryVersion: String by project

--- a/libs/sdk-bindings/bindings-android/lib/src/main/AndroidManifest.xml
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="technology.breez">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <uses-permission android:name="android.permission.INTERNET" />
 

--- a/libs/sdk-bindings/build.rs
+++ b/libs/sdk-bindings/build.rs
@@ -1,8 +1,3 @@
-#[cfg(feature = "uniffi-25")]
-extern crate uniffi_25 as uniffi;
-#[cfg(feature = "uniffi-28")]
-extern crate uniffi_28 as uniffi;
-
 use glob::glob;
 use std::env;
 

--- a/libs/sdk-bindings/makefile
+++ b/libs/sdk-bindings/makefile
@@ -29,28 +29,10 @@ ios-universal: $(SOURCES)
 	# build universal lib for arm sim and x86 sim
 	lipo -create -output ../target/ios-universal-sim/release/libbreez_sdk_bindings.a ../target/aarch64-apple-ios-sim/release/libbreez_sdk_bindings.a ../target/x86_64-apple-ios/release/libbreez_sdk_bindings.a
 
-ios-universal-uniffi-25: $(SOURCES)		
-	mkdir -p ../target/ios-universal/release
-	mkdir -p ../target/ios-universal-sim/release
-	cargo build --no-default-features --features uniffi-25 --release --target aarch64-apple-ios ;\
-	cargo build --no-default-features --features uniffi-25 --release --target x86_64-apple-ios ;\
-	cargo build --no-default-features --features uniffi-25 --release --target aarch64-apple-ios-sim ;\
-	# build universal lib for arm device and x86 sim
-	lipo -create -output ../target/ios-universal/release/libbreez_sdk_bindings.a ../target/aarch64-apple-ios/release/libbreez_sdk_bindings.a ../target/x86_64-apple-ios/release/libbreez_sdk_bindings.a
-	# build universal lib for arm sim and x86 sim
-	lipo -create -output ../target/ios-universal-sim/release/libbreez_sdk_bindings.a ../target/aarch64-apple-ios-sim/release/libbreez_sdk_bindings.a ../target/x86_64-apple-ios/release/libbreez_sdk_bindings.a
-
 darwin-universal: $(SOURCES)
 	mkdir -p ../target/darwin-universal/release
 	cargo lipo --release --targets aarch64-apple-darwin
 	cargo lipo --release --targets x86_64-apple-darwin
-	lipo -create -output ../target/darwin-universal/release/libbreez_sdk_bindings.dylib ../target/aarch64-apple-darwin/release/libbreez_sdk_bindings.dylib ../target/x86_64-apple-darwin/release/libbreez_sdk_bindings.dylib
-	lipo -create -output ../target/darwin-universal/release/libbreez_sdk_bindings.a ../target/aarch64-apple-darwin/release/libbreez_sdk_bindings.a ../target/x86_64-apple-darwin/release/libbreez_sdk_bindings.a
-
-darwin-universal-uniffi-25: $(SOURCES)
-	mkdir -p ../target/darwin-universal/release
-	cargo lipo --no-default-features --features uniffi-25 --release --targets aarch64-apple-darwin
-	cargo lipo --no-default-features --features uniffi-25 --release --targets x86_64-apple-darwin
 	lipo -create -output ../target/darwin-universal/release/libbreez_sdk_bindings.dylib ../target/aarch64-apple-darwin/release/libbreez_sdk_bindings.dylib ../target/x86_64-apple-darwin/release/libbreez_sdk_bindings.dylib
 	lipo -create -output ../target/darwin-universal/release/libbreez_sdk_bindings.a ../target/aarch64-apple-darwin/release/libbreez_sdk_bindings.a ../target/x86_64-apple-darwin/release/libbreez_sdk_bindings.a
 
@@ -113,7 +95,8 @@ build-ios-framework:
 	rm bindings-swift/Sources/BreezSDK/breez_sdkFFI.modulemap
 
 android: aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
-	cargo run --bin uniffi-bindgen generate src/breez_sdk.udl --no-format --language kotlin -o ffi/kotlin
+	cargo install gobley-uniffi-bindgen --git https://github.com/breez/gobley --rev f920c275e4f60e22080a6cd280d9562d64eb6ac9
+	gobley-uniffi-bindgen -c ./uniffi.toml -o ffi/kotlin src/breez_sdk.udl
 
 aarch64-linux-android: $(SOURCES) ndk-home
 	cargo ndk -t aarch64-linux-android -o ffi/kotlin/jniLibs build --release	
@@ -131,28 +114,9 @@ x86_64-linux-android: $(SOURCES) ndk-home
 	cargo ndk -t x86_64-linux-android -o ffi/kotlin/jniLibs build --release
 	cp -a $(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/$(OS_NAME)-x86_64/sysroot/usr/lib/x86_64-linux-android/libc++_shared.so ffi/kotlin/jniLibs/x86_64/
 
-android-uniffi-25: aarch64-linux-android-uniffi-25 armv7-linux-androideabi-uniffi-25 i686-linux-android-uniffi-25 x86_64-linux-android-uniffi-25
-	cargo run --no-default-features --features=uniffi-25 --bin uniffi-bindgen generate src/breez_sdk.udl --no-format --language kotlin -o ffi/kotlin
-
-aarch64-linux-android-uniffi-25: $(SOURCES) ndk-home
-	cargo ndk -t aarch64-linux-android -o ffi/kotlin/jniLibs build --no-default-features --features=uniffi-25 --release	
-	cp -a $(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/$(OS_NAME)-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so ffi/kotlin/jniLibs/arm64-v8a/
-
-armv7-linux-androideabi-uniffi-25: $(SOURCES) ndk-home
-	cargo ndk -t armv7-linux-androideabi -o ffi/kotlin/jniLibs build --no-default-features --features=uniffi-25 --release
-	cp -a $(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/$(OS_NAME)-x86_64/sysroot/usr/lib/arm-linux-androideabi/libc++_shared.so ffi/kotlin/jniLibs/armeabi-v7a/
-
-i686-linux-android-uniffi-25: $(SOURCES) ndk-home
-	cargo ndk -t i686-linux-android -o ffi/kotlin/jniLibs build --no-default-features --features=uniffi-25 --release
-	cp -a $(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/$(OS_NAME)-x86_64/sysroot/usr/lib/i686-linux-android/libc++_shared.so ffi/kotlin/jniLibs/x86/
-
-x86_64-linux-android-uniffi-25: $(SOURCES) ndk-home
-	cargo ndk -t x86_64-linux-android -o ffi/kotlin/jniLibs build --no-default-features --features=uniffi-25 --release
-	cp -a $(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/$(OS_NAME)-x86_64/sysroot/usr/lib/x86_64-linux-android/libc++_shared.so ffi/kotlin/jniLibs/x86_64/
-
-bindings-android: android-uniffi-25
+bindings-android: android
 	cp -r ffi/kotlin/jniLibs bindings-android/lib/src/main
-	cp -r ffi/kotlin/breez_sdk bindings-android/lib/src/main/kotlin/
+	cp -r ffi/kotlin/main/kotlin/breez_sdk bindings-android/lib/src/main/kotlin/
 	cd bindings-android && ./gradlew assemble
 	mkdir -p ffi/android
 	cp bindings-android/lib/build/outputs/aar/lib-release.aar ffi/android
@@ -161,14 +125,25 @@ bindings-android: android-uniffi-25
 .PHONY: kotlin
 kotlin: $(SOURCES)
 	cargo build --release --target $(TARGET)
-	cargo run --bin uniffi-bindgen generate src/breez_sdk.udl --no-format --language kotlin -o ffi/kotlin
+	cargo install gobley-uniffi-bindgen --git https://github.com/breez/gobley --rev f920c275e4f60e22080a6cd280d9562d64eb6ac9
+	gobley-uniffi-bindgen -c ./uniffi.toml -o ffi/kotlin src/breez_sdk.udl
 
-bindings-kotlin-multiplatform: ios-universal-uniffi-25 android-uniffi-25
-	mkdir -p bindings-kotlin-multiplatform/breez-sdk-kmp/src/androidMain
+bindings-kotlin-multiplatform: ios-universal android
+	cargo install gobley-uniffi-bindgen --git https://github.com/breez/gobley --rev f920c275e4f60e22080a6cd280d9562d64eb6ac9
+	gobley-uniffi-bindgen -c ./uniffi.kotlin-multiplatform.toml -o ffi/kmp src/breez_sdk.udl
+
+	mkdir -p bindings-kotlin-multiplatform/breez-sdk-kmp/src/androidMain/kotlin/breez_sdk
+	mkdir -p bindings-kotlin-multiplatform/breez-sdk-kmp/src/commonMain/kotlin/breez_sdk
+	mkdir -p bindings-kotlin-multiplatform/breez-sdk-kmp/src/jvmMain/kotlin/breez_sdk
+	mkdir -p bindings-kotlin-multiplatform/breez-sdk-kmp/src/nativeMain/kotlin/breez_sdk
+	
 	cp -r ffi/kotlin/jniLibs/ bindings-kotlin-multiplatform/breez-sdk-kmp/src/androidMain/jniLibs/
-	cp -r ffi/kmp/* bindings-kotlin-multiplatform/breez-sdk-kmp/src/
+	cp -r ffi/kmp/nativeInterop bindings-kotlin-multiplatform/breez-sdk-kmp/src/
 
-	cp -r bindings-kotlin-multiplatform/breez-sdk-kmp/src/jvmMain/kotlin bindings-kotlin-multiplatform/breez-sdk-kmp/src/androidMain/
+	cp ffi/kmp/main/kotlin/breez_sdk/breez_sdk.android.kt bindings-kotlin-multiplatform/breez-sdk-kmp/src/androidMain/kotlin/breez_sdk/
+	cp ffi/kmp/main/kotlin/breez_sdk/breez_sdk.common.kt bindings-kotlin-multiplatform/breez-sdk-kmp/src/commonMain/kotlin/breez_sdk/
+	cp ffi/kmp/main/kotlin/breez_sdk/breez_sdk.jvm.kt bindings-kotlin-multiplatform/breez-sdk-kmp/src/jvmMain/kotlin/breez_sdk/
+	cp ffi/kmp/main/kotlin/breez_sdk/breez_sdk.native.kt bindings-kotlin-multiplatform/breez-sdk-kmp/src/nativeMain/kotlin/breez_sdk/
 
 	mkdir -p bindings-kotlin-multiplatform/breez-sdk-kmp/src/lib/ios-arm64/
 	mkdir -p bindings-kotlin-multiplatform/breez-sdk-kmp/src/lib/ios-simulator-arm64/
@@ -178,7 +153,7 @@ bindings-kotlin-multiplatform: ios-universal-uniffi-25 android-uniffi-25
 	cp ../target/aarch64-apple-ios-sim/release/libbreez_sdk_bindings.a bindings-kotlin-multiplatform/breez-sdk-kmp/src/lib/ios-simulator-arm64/
 	cp ../target/x86_64-apple-ios/release/libbreez_sdk_bindings.a bindings-kotlin-multiplatform/breez-sdk-kmp/src/lib/ios-simulator-x64/
 	cd bindings-kotlin-multiplatform && ./gradlew :breez-sdk-kmp:assemble
-	
+
 react-native:
 	make -C bindings-react-native codegen
 

--- a/libs/sdk-bindings/src/lib.rs
+++ b/libs/sdk-bindings/src/lib.rs
@@ -1,9 +1,3 @@
-//! Uniffi bindings
-#[cfg(feature = "uniffi-25")]
-extern crate uniffi_25 as uniffi;
-#[cfg(feature = "uniffi-28")]
-extern crate uniffi_28 as uniffi;
-
 use std::sync::Arc;
 
 use anyhow::Result;

--- a/libs/sdk-bindings/tests/test_generated_bindings.rs
+++ b/libs/sdk-bindings/tests/test_generated_bindings.rs
@@ -1,9 +1,7 @@
-extern crate uniffi_28 as uniffi;
 use std::process::Command;
 
 uniffi::build_foreign_language_testcases!(
     "tests/bindings/test_breez_sdk.swift",
-    "tests/bindings/test_breez_sdk.kts",
     "tests/bindings/test_breez_sdk.py"
 );
 

--- a/libs/sdk-bindings/uniffi-bindgen.rs
+++ b/libs/sdk-bindings/uniffi-bindgen.rs
@@ -1,31 +1,3 @@
-#[cfg(feature = "uniffi-25")]
-extern crate uniffi_25 as uniffi;
-#[cfg(feature = "uniffi-28")]
-extern crate uniffi_28 as uniffi;
-#[cfg(feature = "uniffi-25")]
-extern crate uniffi_bindgen_25 as uniffi_bindgen;
-
-#[cfg(feature = "uniffi-25")]
-use camino::Utf8Path;
-
 fn main() {
     uniffi::uniffi_bindgen_main();
-    #[cfg(feature = "uniffi-25")]
-    build_kmp()
-}
-
-#[cfg(feature = "uniffi-25")]
-fn build_kmp() {
-    let udl_file = "./src/breez_sdk.udl";
-    let out_dir = Utf8Path::new("ffi/kmp");
-    let config = Utf8Path::new("uniffi.toml");
-    uniffi_bindgen::generate_external_bindings(
-        uniffi_bindgen_kotlin_multiplatform::KotlinBindingGenerator {},
-        udl_file,
-        Some(config),
-        Some(out_dir),
-        None::<&Utf8Path>,
-        None,
-    )
-    .unwrap();
 }

--- a/libs/sdk-bindings/uniffi.kotlin-multiplatform.toml
+++ b/libs/sdk-bindings/uniffi.kotlin-multiplatform.toml
@@ -1,0 +1,5 @@
+# Kotlin Multi Platform https://gobley.dev/docs/bindgen#bindgen-configuration
+package_name = "breez_sdk"
+kotlin_targets = ["jvm", "android", "native"]
+kotlin_target_version = "1.8.20"
+disable_java_cleaner = true

--- a/libs/sdk-bindings/uniffi.toml
+++ b/libs/sdk-bindings/uniffi.toml
@@ -1,10 +1,13 @@
+# Kotlin https://gobley.dev/docs/bindgen#bindgen-configuration
+package_name = "breez_sdk"
+cdylib_name = "breez_sdk_bindings"
+kotlin_multiplatform = false
+kotlin_targets = ["jvm"]
+kotlin_target_version = "1.8.20"
+disable_java_cleaner = true
+
 # https://mozilla.github.io/uniffi-rs/swift/configuration.html
 [bindings.swift]
-cdylib_name = "breez_sdk_bindings"
-
-# https://mozilla.github.io/uniffi-rs/kotlin/configuration.html
-[bindings.kotlin]
-package_name = "breez_sdk"
 cdylib_name = "breez_sdk_bindings"
 
 # https://mozilla.github.io/uniffi-rs/python/configuration.html

--- a/libs/sdk-core/Cargo.toml
+++ b/libs/sdk-core/Cargo.toml
@@ -9,9 +9,6 @@ crate-type = ["staticlib", "cdylib", "lib"]
 
 [features]
 default = []
-# Uniffi features required to build using cargo-lipo
-uniffi-25 = []
-uniffi-28 = []
 
 [dependencies]
 flutter_rust_bridge = "=2.9.0"

--- a/libs/sdk-flutter/android/build.gradle
+++ b/libs/sdk-flutter/android/build.gradle
@@ -63,4 +63,7 @@ dependencies {
     }
     /* JSON serialization */
     implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3'
+    /* Kotlin bindgen dependencies */
+    implementation "org.jetbrains.kotlinx:atomicfu:0.23.1" 
+    implementation("com.squareup.okio:okio:3.6.0")
 }

--- a/libs/sdk-flutter/makefile
+++ b/libs/sdk-flutter/makefile
@@ -31,7 +31,7 @@ android: $(SOURCES) flutter_rust_bridge
 	rm -rf android/src/main/kotlin/breez_sdk
 	rm -rf android/src/main/kotlin/breez_sdk_notification
 	cp -r ../sdk-bindings/ffi/kotlin/jniLibs android/src/main/
-	cp -r ../sdk-bindings/ffi/kotlin/breez_sdk android/src/main/kotlin/
+	cp -r ../sdk-bindings/ffi/kotlin/main/kotlin/breez_sdk android/src/main/kotlin/
 	cp -r ../sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification android/src/main/kotlin/
 
 ## desktop: compiles for x86_64-unknown-linux-gnu by default, other targets can be specified

--- a/libs/sdk-react-native/.gitignore
+++ b/libs/sdk-react-native/.gitignore
@@ -68,7 +68,7 @@ android/keystores/debug.keystore
 lib/
 
 # bindings (used for local development only)
-android/src/main/java/com/breezsdk/breez_sdk.kt
+android/src/main/java/com/breezsdk/breez_sdk.*.kt
 android/src/main/jniLibs
 ios/include/*
 ios/libs/*

--- a/libs/sdk-react-native/DEVELOPING.md
+++ b/libs/sdk-react-native/DEVELOPING.md
@@ -81,8 +81,10 @@ To use the locally built bindings instead of integrating them remotely, make the
 		- Rename `breez_sdk.podspec` to `breez_sdk.podspec.prod`
 		- Rename `BreezSDK.podspec.dev` to `BreezSDK.podspec`
 - For Android:
-	- Comment out the following line from the dependencies section in `libs/sdk-react-native/android/build.gradle`:
+	- Comment the following line from the dependencies section in `libs/sdk-react-native/android/build.gradle`:
 		- `implementation("com.github.breez:breez-sdk:${getVersionFromNpmPackage()}") { exclude group:"net.java.dev.jna" }`
+	- Uncomment the following line from the dependencies section in `libs/sdk-react-native/android/build.gradle`:
+		- `implementation "org.jetbrains.kotlinx:atomicfu:0.23.1"`
 
 Reinstall the dependencies in the example project and run it.
 It will now use the locally built bindings.

--- a/libs/sdk-react-native/android/build.gradle
+++ b/libs/sdk-react-native/android/build.gradle
@@ -24,10 +24,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 31
+    namespace "com.breezsdk"
+    compileSdkVersion 34
+
     defaultConfig {
-        minSdkVersion 21
-        targetSdkVersion 31
+        minSdkVersion 24
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
     }
@@ -77,6 +79,9 @@ dependencies {
     // the Android platform versions of JNA (specifically libjnadispatch.so) are missing when downloading the Breez SDK from Jitpack.
     // Thereforew we ignore the version of JNA that comes with the Breez SDK from Jitpack
     // and manually add one that does include the necessary Android platoform binaries.
-    implementation("com.github.breez:breez-sdk:${getVersionFromNpmPackage()}") { exclude group:"net.java.dev.jna" } // remove for using locally built bindings during development
-    implementation("net.java.dev.jna:jna:5.8.0@aar")
+    implementation("net.java.dev.jna:jna:5.14.0@aar")
+    // Comment this line for using locally built bindings during development
+    implementation("com.github.breez:breez-sdk:${getVersionFromNpmPackage()}") { exclude group:"net.java.dev.jna" }
+    // Uncomment this line for using locally built bindings during development
+    // implementation "org.jetbrains.kotlinx:atomicfu:0.23.1"
 }

--- a/libs/sdk-react-native/android/src/main/AndroidManifest.xml
+++ b/libs/sdk-react-native/android/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.breezsdk">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 

--- a/libs/sdk-react-native/example/android/app/build.gradle
+++ b/libs/sdk-react-native/example/android/app/build.gradle
@@ -284,7 +284,6 @@ dependencies {
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.0.0"
 
     implementation "androidx.core:core-ktx:1.3.2"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.kotlinVersion}"
 
     debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {
         exclude group:'com.facebook.fbjni'

--- a/libs/sdk-react-native/example/android/build.gradle
+++ b/libs/sdk-react-native/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         minSdkVersion = 24
         compileSdkVersion = 33
         targetSdkVersion = 33
-        kotlinVersion = "1.8.0"
+        kotlinVersion = "1.8.20"
 
         if (System.properties['os.arch'] == "aarch64") {
             // For M1 Users we need to use the NDK 24 which added support for aarch64

--- a/libs/sdk-react-native/example/android/gradle.properties
+++ b/libs/sdk-react-native/example/android/gradle.properties
@@ -22,7 +22,7 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
-android.enableJetifier=true
+android.enableJetifier=false
 
 # Version of flipper SDK to use with React Native
 FLIPPER_VERSION=0.125.0

--- a/libs/sdk-react-native/example/babel.config.js
+++ b/libs/sdk-react-native/example/babel.config.js
@@ -5,7 +5,6 @@ module.exports = {
             "module-resolver",
             {
                 alias: {
-                    crypto: "react-native-quick-crypto",
                     stream: "stream-browserify",
                     buffer: "@craftzdog/react-native-buffer"
                 }

--- a/libs/sdk-react-native/example/package.json
+++ b/libs/sdk-react-native/example/package.json
@@ -22,7 +22,6 @@
     "react-native-build-config": "^0.3.2",
     "react-native-file-logger": "0.4.1",
     "react-native-quick-base64": "^2.0.5",
-    "react-native-quick-crypto": "^0.5.0",
     "react-native-safe-area-context": "3.3.2",
     "react-native-screens": "3.7.2",
     "react-native-secure-storage": "https://github.com/satimoto/react-native-secure-storage"

--- a/libs/sdk-react-native/example/src/screens/HomeScreen.js
+++ b/libs/sdk-react-native/example/src/screens/HomeScreen.js
@@ -24,7 +24,6 @@ import {
 } from "@breeztech/react-native-breez-sdk"
 import BuildConfig from "react-native-build-config"
 import { FileLogger } from "react-native-file-logger"
-import { generateMnemonic } from "@dreson4/react-native-quick-bip39"
 import DebugLine from "../components/DebugLine"
 import { Log } from "../utils/logging"
 import { obfuscateString } from "../utils/security"
@@ -110,7 +109,7 @@ const HomeScreen = ({ navigation }) => {
                 let mnemonic = await getSecureItem(MNEMONIC_STORE)
 
                 if (mnemonic == null) {
-                    mnemonic = generateMnemonic(256)
+                    mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
                     setSecureItem(MNEMONIC_STORE, mnemonic)
                 }
 

--- a/libs/sdk-react-native/example/yarn.lock
+++ b/libs/sdk-react-native/example/yarn.lock
@@ -6145,7 +6145,7 @@ react-native-screens@3.7.2:
 
 "react-native-secure-storage@https://github.com/satimoto/react-native-secure-storage":
   version "0.1.2"
-  resolved "https://github.com/satimoto/react-native-secure-storage#e5d100a5e8f681f4a657fa613a349456954f96b7"
+  resolved "https://github.com/satimoto/react-native-secure-storage#fc6a4da0974641d9eaadc845c64f90b9f676ebca"
 
 react-native@0.70.15:
   version "0.70.15"

--- a/libs/sdk-react-native/makefile
+++ b/libs/sdk-react-native/makefile
@@ -30,7 +30,7 @@ android-copy:
 	mkdir -p android/src/main/jniLibs/x86_64
 	mkdir -p android/src/main/jniLibs/arm64-v8a
 	mkdir -p android/src/main/jniLibs/armeabi-v7a
-	cp ../sdk-bindings/ffi/kotlin/breez_sdk/breez_sdk.kt  android/src/main/java/com/breezsdk/breez_sdk.kt
+	cp ../sdk-bindings/ffi/kotlin/main/kotlin/breez_sdk/breez_sdk.*.kt  android/src/main/java/com/breezsdk/
 	cp ../sdk-bindings/ffi/kotlin/jniLibs/x86/libbreez_sdk_bindings.so android/src/main/jniLibs/x86/libbreez_sdk_bindings.so
 	cp ../sdk-bindings/ffi/kotlin/jniLibs/x86_64/libbreez_sdk_bindings.so android/src/main/jniLibs/x86_64/libbreez_sdk_bindings.so
 	cp ../sdk-bindings/ffi/kotlin/jniLibs/arm64-v8a/libbreez_sdk_bindings.so android/src/main/jniLibs/arm64-v8a/libbreez_sdk_bindings.so


### PR DESCRIPTION
Builds Kotlin and Kotlin Multiplatform bindings using https://github.com/gobley/gobley (forked UniFFI Kotlin Multiplatform bindings)

Tested locally building the React Native example app with the Android/Kotlin bindings

CI publish run: https://github.com/breez/breez-sdk-greenlight/actions/runs/15212454148
C-Breez Android run: https://github.com/breez/c-breez/actions/runs/15212903668