### PR TITLE
Only attempt to parse BIP353 in Nodeless

### DIFF
--- a/libs/sdk-common/src/input_parser.rs
+++ b/libs/sdk-common/src/input_parser.rs
@@ -245,7 +245,13 @@ fn parse_bip353_record(bip353_record: String) -> Option<String> {
 
     let query_params = querystring::querify(query_part);
 
-    get_by_key(&query_params, BOLT12_PREFIX).or_else(|| get_by_key(&query_params, LNURL_PAY_PREFIX))
+    // If the feature is enabled, we also look for the BOLT12 Offer prefix
+    if cfg!(feature = "liquid") {
+        get_by_key(&query_params, BOLT12_PREFIX)
+            .or_else(|| get_by_key(&query_params, LNURL_PAY_PREFIX))
+    } else {
+        get_by_key(&query_params, LNURL_PAY_PREFIX)
+    }
 }
 
 fn is_valid_bip353_record(decoded: &str) -> bool {


### PR DESCRIPTION
This PR solves the issue in the Native/Greenlight SDK where if a LN address is registered with an offer (on Nodeless), then parsing the same address will first be parsed using BIP353, and as it's also a valid BIP353 address the returned BOLT12 Offer will not be recognized as a valid input.

Fixes https://github.com/breez/misty-breez/issues/562