### PR TITLE
Expose swap proxy url

### DIFF
--- a/libs/sdk-common/src/model.rs
+++ b/libs/sdk-common/src/model.rs
@@ -32,3 +32,9 @@ impl From<Network> for bitcoin::network::constants::Network {
         }
     }
 }
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BoltzSwapperUrls {
+    pub boltz_url: String,
+    pub proxy_url: String,
+}


### PR DESCRIPTION
Exposes the separate `GENERAL_SWAPPER` swapper url which contains the swap proxy instance url. Exposing the 2 urls allows clients with no API key to keep using the boltz url without the proxy.