### PR TITLE
Relax Kotlin JSON request decoding

### DIFF
--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/ConfirmTransaction.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/ConfirmTransaction.kt
@@ -36,7 +36,8 @@ class ConfirmTransactionJob(
 
     override fun start(breezSDK: BlockingBreezServices) {
         try {
-            val request = Json.decodeFromString(AddressTxsConfirmedRequest.serializer(), payload)
+            val decoder = Json { ignoreUnknownKeys = true }
+            val request = decoder.decodeFromString(AddressTxsConfirmedRequest.serializer(), payload)
             this.bitcoinAddress = request.address
         } catch (e: Exception) {
             logger.log(TAG, "Failed to decode payload: ${e.message}", "WARN")

--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/LnurlPayInfo.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/LnurlPayInfo.kt
@@ -53,7 +53,8 @@ class LnurlPayInfoJob(
     override fun start(breezSDK: BlockingBreezServices) {
         var request: LnurlInfoRequest? = null
         try {
-            request = Json.decodeFromString(LnurlInfoRequest.serializer(), payload)
+            val decoder = Json { ignoreUnknownKeys = true }
+            request = decoder.decodeFromString(LnurlInfoRequest.serializer(), payload)
             // Get the fee parameters offered by the LSP for opening a new channel
             val ofp = breezSDK.openChannelFee(OpenChannelFeeRequest(amountMsat = null)).feeParams
             // Calculate the maximum receivable amount within the fee limit (in millisatoshis)

--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/LnurlPayInvoice.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/LnurlPayInvoice.kt
@@ -49,7 +49,8 @@ class LnurlPayInvoiceJob(
     override fun start(breezSDK: BlockingBreezServices) {
         var request: LnurlInvoiceRequest? = null
         try {
-            request = Json.decodeFromString(LnurlInvoiceRequest.serializer(), payload)
+            val decoder = Json { ignoreUnknownKeys = true }
+            request = decoder.decodeFromString(LnurlInvoiceRequest.serializer(), payload)
             // Get channel setup fee for invoice amount
             val ofpResp =
                 breezSDK.openChannelFee(OpenChannelFeeRequest(amountMsat = request.amount))

--- a/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/ReceivePayment.kt
+++ b/libs/sdk-bindings/bindings-android/lib/src/main/kotlin/breez_sdk_notification/job/ReceivePayment.kt
@@ -36,7 +36,8 @@ class ReceivePaymentJob(
 
     override fun start(breezSDK: BlockingBreezServices) {
         try {
-            val request = Json.decodeFromString(ReceivePaymentRequest.serializer(), payload)
+            val decoder = Json { ignoreUnknownKeys = true }
+            val request = decoder.decodeFromString(ReceivePaymentRequest.serializer(), payload)
             val payment = breezSDK.paymentByHash(request.paymentHash)
             if (payment != null) {
                 this.receivedPayment = payment


### PR DESCRIPTION
This PR relaxes the decoding of JSON requests in the Notification Plugin so that it can handle additions to the requests without throwing an error