### PR TITLE
Lock flutter_rust_bridge_codegen install

### DIFF
--- a/libs/sdk-flutter/makefile
+++ b/libs/sdk-flutter/makefile
@@ -12,7 +12,7 @@ init:
 all: ios android
 
 flutter_rust_bridge:
-	cargo install flutter_rust_bridge_codegen --version 2.9.0
+	cargo install flutter_rust_bridge_codegen --version 2.9.0 --locked
 	mkdir -p ./lib/generated
 	flutter_rust_bridge_codegen generate
 


### PR DESCRIPTION
Locks the installation of flutter_rust_bridge_codegen to use only the dependency versions stated without attempting to upgrade. This is a stop-gap between now and [upgrading to 2.11.0](https://github.com/breez/breez-sdk-greenlight/pull/1240) which needs coordination with other libraries (e.g BDK)